### PR TITLE
Add `load_if_exists` option

### DIFF
--- a/docs/source/reference/structs.rst
+++ b/docs/source/reference/structs.rst
@@ -26,3 +26,6 @@ Structs
 
 .. autoclass:: StorageInternalError
     :members:
+
+.. autoclass:: DuplicatedStudyError
+    :members:

--- a/optuna/cli.py
+++ b/optuna/cli.py
@@ -53,6 +53,10 @@ class CreateStudy(BaseCommand):
                             default='minimize',
                             help='Set direction of optimization to a new study. Set \'minimize\' '
                                  'for minimization and \'maximize\' for maximization.')
+        parser.add_argument('--exist-ok', default=False, action='store_true',
+                            help='If specified, the creation of the study is skipped '
+                                 'without any error even if the same name study already '
+                                 'exists in the storage.')
         return parser
 
     def take_action(self, parsed_args):
@@ -62,7 +66,8 @@ class CreateStudy(BaseCommand):
         storage_url = get_storage_url(self.app_args.storage, config)
         storage = optuna.storages.RDBStorage(storage_url)
         study_name = optuna.create_study(storage, study_name=parsed_args.study_name,
-                                         direction=parsed_args.direction).study_name
+                                         direction=parsed_args.direction,
+                                         exist_ok=parsed_args.exist_ok).study_name
         print(study_name)
 
 

--- a/optuna/cli.py
+++ b/optuna/cli.py
@@ -55,8 +55,7 @@ class CreateStudy(BaseCommand):
                                  'for minimization and \'maximize\' for maximization.')
         parser.add_argument('--exist-ok', default=False, action='store_true',
                             help='If specified, the creation of the study is skipped '
-                                 'without any error even if the same name study already '
-                                 'exists in the storage.')
+                                 'without any error when the study name is duplicated.')
         return parser
 
     def take_action(self, parsed_args):

--- a/optuna/cli.py
+++ b/optuna/cli.py
@@ -53,7 +53,7 @@ class CreateStudy(BaseCommand):
                             default='minimize',
                             help='Set direction of optimization to a new study. Set \'minimize\' '
                                  'for minimization and \'maximize\' for maximization.')
-        parser.add_argument('--exist-ok', default=False, action='store_true',
+        parser.add_argument('--skip-if-exists', default=False, action='store_true',
                             help='If specified, the creation of the study is skipped '
                                  'without any error when the study name is duplicated.')
         return parser
@@ -66,7 +66,7 @@ class CreateStudy(BaseCommand):
         storage = optuna.storages.RDBStorage(storage_url)
         study_name = optuna.create_study(storage, study_name=parsed_args.study_name,
                                          direction=parsed_args.direction,
-                                         exist_ok=parsed_args.exist_ok).study_name
+                                         load_if_exists=parsed_args.skip_if_exists).study_name
         print(study_name)
 
 

--- a/optuna/storages/rdb/storage.py
+++ b/optuna/storages/rdb/storage.py
@@ -64,8 +64,9 @@ class RDBStorage(BaseStorage):
         session.add(study)
         if not self._commit_with_integrity_check(session):
             raise structs.DuplicatedStudyError(
-                "study_name {} already exists. Please use a different name or "
-                "set `exist_ok` flag.".format(study_name))
+                "Another study with name '{}' already exists. "
+                "Please specify a different name, or reuse the existing one "
+                "by setting `load_if_exists` or `--skip-if-exists` flag.".format(study_name))
 
         self.logger.info('A new study created with name: {}'.format(study.study_name))
 

--- a/optuna/storages/rdb/storage.py
+++ b/optuna/storages/rdb/storage.py
@@ -66,7 +66,8 @@ class RDBStorage(BaseStorage):
             raise structs.DuplicatedStudyError(
                 "Another study with name '{}' already exists. "
                 "Please specify a different name, or reuse the existing one "
-                "by setting `load_if_exists` or `--skip-if-exists` flag.".format(study_name))
+                "by setting `load_if_exists` (for Python API) or "
+                "`--skip-if-exists` flag (for CLI).".format(study_name))
 
         self.logger.info('A new study created with name: {}'.format(study.study_name))
 

--- a/optuna/storages/rdb/storage.py
+++ b/optuna/storages/rdb/storage.py
@@ -63,8 +63,9 @@ class RDBStorage(BaseStorage):
                                   direction=structs.StudyDirection.NOT_SET)
         session.add(study)
         if not self._commit_with_integrity_check(session):
-            raise ValueError(
-                "study_name {} already exists. Please use a different name.".format(study_name))
+            raise structs.DuplicatedStudyError(
+                "study_name {} already exists. Please use a different name or "
+                "set `exist_ok` flag.".format(study_name))
 
         self.logger.info('A new study created with name: {}'.format(study.study_name))
 

--- a/optuna/structs.py
+++ b/optuna/structs.py
@@ -181,3 +181,13 @@ class StorageInternalError(OptunaError):
     """
 
     pass
+
+
+class DuplicatedStudyError(OptunaError):
+
+    """Exception for a duplicated study name.
+
+    This error is raised when a specified study name already exists in the storage.
+    """
+
+    pass

--- a/optuna/study.py
+++ b/optuna/study.py
@@ -474,8 +474,8 @@ def create_study(
             Direction of optimization. Set ``minimize`` for minimization and ``maximize`` for
             maximization. Note that ``maximize`` is currently unsupported.
         exist_ok:
-            Flag for controlling the behavior when study names conflict.
-            If a study named ``study_name`` already exists in the ``storage``,
+            Flag to control the behavior to handle a conflict of study names.
+            In the case where a study named ``study_name`` already exists in the ``storage``,
             a :class:`~optuna.structs.DuplicatedStudyError` is raised if ``exist_ok`` is
             set to :obj:`False`.
             Otherwise the creation of the study is skipped and no exception is raised.
@@ -493,8 +493,8 @@ def create_study(
             assert study_name is not None
 
             logger = logging.get_logger(__name__)
-            logger.info('The same name study exists in the storage. '
-                        'It is reused instead of creating a new one.')
+            logger.info('The study name {} is duplicated with the existing study.'
+                        'It is reused instead of creating a new one.'.format(study_name))
             study_id = storage.get_study_id_from_name(study_name)
         else:
             raise

--- a/optuna/study.py
+++ b/optuna/study.py
@@ -494,7 +494,7 @@ def create_study(
 
             logger = logging.get_logger(__name__)
             logger.info("Using an existing study with name '{}' instead of "
-                        "creating a new one".format(study_name))
+                        "creating a new one.".format(study_name))
             study_id = storage.get_study_id_from_name(study_name)
         else:
             raise

--- a/optuna/study.py
+++ b/optuna/study.py
@@ -452,7 +452,7 @@ def create_study(
         pruner=None,  # type: pruners.BasePruner
         study_name=None,  # type: Optional[str]
         direction='minimize',  # type: str
-        exist_ok=False,  # type: bool
+        load_if_exists=False,  # type: bool
 ):
     # type: (...) -> Study
     """Create a new :class:`~optuna.study.Study`.
@@ -473,12 +473,12 @@ def create_study(
         direction:
             Direction of optimization. Set ``minimize`` for minimization and ``maximize`` for
             maximization. Note that ``maximize`` is currently unsupported.
-        exist_ok:
+        load_if_exists:
             Flag to control the behavior to handle a conflict of study names.
             In the case where a study named ``study_name`` already exists in the ``storage``,
-            a :class:`~optuna.structs.DuplicatedStudyError` is raised if ``exist_ok`` is
+            a :class:`~optuna.structs.DuplicatedStudyError` is raised if ``load_if_exists`` is
             set to :obj:`False`.
-            Otherwise the creation of the study is skipped and no exception is raised.
+            Otherwise, the creation of the study is skipped, and the existing one is returned.
 
     Returns:
         A :class:`~optuna.study.Study` object.
@@ -489,12 +489,12 @@ def create_study(
     try:
         study_id = storage.create_new_study_id(study_name)
     except structs.DuplicatedStudyError:
-        if exist_ok:
+        if load_if_exists:
             assert study_name is not None
 
             logger = logging.get_logger(__name__)
-            logger.info('The study name {} is duplicated with the existing study.'
-                        'It is reused instead of creating a new one.'.format(study_name))
+            logger.info("Using an existing study with name '{}' instead of "
+                        "creating a new one".format(study_name))
             study_id = storage.get_study_id_from_name(study_name)
         else:
             raise

--- a/tests/storages_tests/rdb_tests/test_storage.py
+++ b/tests/storages_tests/rdb_tests/test_storage.py
@@ -13,6 +13,7 @@ from optuna.storages.rdb.models import StudyModel
 from optuna.storages.rdb.models import TrialParamModel
 from optuna.storages.rdb.models import VersionInfoModel
 from optuna.storages import RDBStorage
+from optuna.structs import DuplicatedStudyError
 from optuna.structs import StorageInternalError
 from optuna.structs import StudyDirection
 from optuna.structs import StudySummary
@@ -72,7 +73,7 @@ def test_create_new_study_id_duplicated_name():
     storage = create_test_storage()
     study_name = 'sample_study_name'
     storage.create_new_study_id(study_name)
-    with pytest.raises(ValueError):
+    with pytest.raises(DuplicatedStudyError):
         storage.create_new_study_id(study_name)
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -206,6 +206,34 @@ def test_studies_command(options):
         assert elms[2] == '10'
 
 
+def test_create_study_command_with_exist_ok():
+    # type: () -> None
+
+    with StorageConfigSupplier(TEST_CONFIG_TEMPLATE) as (storage_url, config_path):
+        storage = RDBStorage(storage_url)
+        study_name = 'test_study'
+
+        # Create study with name.
+        command = ['optuna', 'create-study', '--storage', storage_url, '--study-name', study_name]
+        study_name = str(subprocess.check_output(command).decode().strip())
+
+        # Check if study_name is stored in the storage.
+        study_id = storage.get_study_id_from_name(study_name)
+        assert storage.get_study_name_from_id(study_id) == study_name
+
+        # Try to create the same name study without `--exist-ok` flag (error).
+        command = ['optuna', 'create-study', '--storage', storage_url, '--study-name', study_name]
+        with pytest.raises(subprocess.CalledProcessError):
+            subprocess.check_output(command)
+
+        # Try to create the same name study with `--exist-ok` flag (OK).
+        command = ['optuna', 'create-study', '--storage',
+                   storage_url, '--study-name', study_name, '--exist-ok']
+        study_name = str(subprocess.check_output(command).decode().strip())
+        new_study_id = storage.get_study_id_from_name(study_name)
+        assert study_id == new_study_id  # The existing study instance is reused.
+
+
 @pytest.mark.parametrize('options', [['storage'], ['config'], ['storage', 'config']])
 def test_dashboard_command(options):
     # type: (List[str]) -> None

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -206,7 +206,7 @@ def test_studies_command(options):
         assert elms[2] == '10'
 
 
-def test_create_study_command_with_exist_ok():
+def test_create_study_command_with_skip_if_exists():
     # type: () -> None
 
     with StorageConfigSupplier(TEST_CONFIG_TEMPLATE) as (storage_url, config_path):
@@ -221,14 +221,14 @@ def test_create_study_command_with_exist_ok():
         study_id = storage.get_study_id_from_name(study_name)
         assert storage.get_study_name_from_id(study_id) == study_name
 
-        # Try to create the same name study without `--exist-ok` flag (error).
+        # Try to create the same name study without `--skip-if-exists` flag (error).
         command = ['optuna', 'create-study', '--storage', storage_url, '--study-name', study_name]
         with pytest.raises(subprocess.CalledProcessError):
             subprocess.check_output(command)
 
-        # Try to create the same name study with `--exist-ok` flag (OK).
+        # Try to create the same name study with `--skip-if-exists` flag (OK).
         command = ['optuna', 'create-study', '--storage',
-                   storage_url, '--study-name', study_name, '--exist-ok']
+                   storage_url, '--study-name', study_name, '--skip-if-exists']
         study_name = str(subprocess.check_output(command).decode().strip())
         new_study_id = storage.get_study_id_from_name(study_name)
         assert study_id == new_study_id  # The existing study instance is reused.

--- a/tests/test_study.py
+++ b/tests/test_study.py
@@ -10,7 +10,6 @@ from typing import Dict  # NOQA
 from typing import Optional  # NOQA
 
 import optuna
-from optuna import structs
 from optuna.testing.storage import StorageSupplier
 
 STORAGE_MODES = [

--- a/tests/test_study.py
+++ b/tests/test_study.py
@@ -445,15 +445,16 @@ def test_create_study(storage_mode):
 
     with StorageSupplier(storage_mode) as storage:
         # Test creating a new study.
-        study = optuna.create_study(storage=storage, exist_ok=False)
+        study = optuna.create_study(storage=storage, load_if_exists=False)
 
-        # Test exist_ok=True with existing study.
-        optuna.create_study(study_name=study.study_name, storage=storage, exist_ok=True)
+        # Test `load_if_exists=True` with existing study.
+        optuna.create_study(study_name=study.study_name, storage=storage, load_if_exists=True)
 
         if isinstance(study.storage, optuna.storages.InMemoryStorage):
             # `InMemoryStorage` does not share study's namespace (i.e., no name conflicts occur).
-            optuna.create_study(study_name=study.study_name, storage=storage, exist_ok=False)
+            optuna.create_study(study_name=study.study_name, storage=storage, load_if_exists=False)
         else:
-            # Test exist_ok=False with existing study.
+            # Test `load_if_exists=False` with existing study.
             with pytest.raises(optuna.structs.DuplicatedStudyError):
-                optuna.create_study(study_name=study.study_name, storage=storage, exist_ok=False)
+                optuna.create_study(study_name=study.study_name, storage=storage,
+                                    load_if_exists=False)

--- a/tests/test_study.py
+++ b/tests/test_study.py
@@ -10,6 +10,7 @@ from typing import Dict  # NOQA
 from typing import Optional  # NOQA
 
 import optuna
+from optuna import structs
 from optuna.testing.storage import StorageSupplier
 
 STORAGE_MODES = [
@@ -437,3 +438,77 @@ def test_trials_dataframe_with_failure(storage_mode):
             assert df.params.y[i] == 2.5
             assert df.user_attrs.train_loss[i] == 3
             assert ('system_attrs', 'fail_reason') in df.columns
+
+
+@pytest.mark.parametrize('storage_mode', STORAGE_MODES)
+def test_create_study(storage_mode):
+    # type: (str) -> None
+
+    with StorageSupplier(storage_mode) as storage:
+        # Test creating a new study.
+        study = optuna.create_study(storage=storage, exist_ok=False)
+
+        if not isinstance(study.storage, optuna.storages.InMemoryStorage):
+            # Test exist_ok=True with existing study.
+            optuna.create_study(study_name=study.study_name, storage=storage, exist_ok=True)
+
+            # Test exist_ok=False with existing study.
+            with pytest.raises(optuna.structs.DuplicatedStudyError):
+                optuna.create_study(study_name=study.study_name, storage=storage, exist_ok=False)
+
+
+def test_create_study_parallel():
+    # type: () -> None
+
+    def create_study(results, i, storage, exist_ok):
+        try:
+            study = optuna.create_study(study_name='foo', storage=storage, exist_ok=exist_ok)
+            results[i] = study.study_id
+        except structs.DuplicatedStudyError:
+            results[i] = False
+
+    n_threads = 100
+
+    # exist_ok=True
+    with StorageSupplier('new') as storage:
+        exist_ok = True
+        results = [None] * n_threads
+        threads = []
+        for i in range(n_threads):
+            thread = threading.Thread(target=create_study, args=(results, i, storage, exist_ok))
+            threads.append(thread)
+
+        for thread in threads:
+            thread.start()
+
+        for thread in threads:
+            thread.join()
+
+        # All threads should succeeded to retrieve the same `study_id`.
+        study_id = results[0]
+        assert study_id is not None and study_id is not False
+        for result in results:
+            assert result == study_id
+
+    # exist_ok=False
+    with StorageSupplier('new') as storage:
+        exist_ok = False
+        results = [None] * n_threads
+        threads = []
+        for i in range(n_threads):
+            thread = threading.Thread(target=create_study, args=(results, i, storage, exist_ok))
+            threads.append(thread)
+
+        for thread in threads:
+            thread.start()
+
+        for thread in threads:
+            thread.join()
+
+        # Only one of the threads should succeeded to create the study.
+        n_created = 0
+        for result in results:
+            assert result is not None
+            if result is not False:
+                n_created += 1
+        assert n_created == 1

--- a/tests/test_study.py
+++ b/tests/test_study.py
@@ -451,8 +451,9 @@ def test_create_study(storage_mode):
         optuna.create_study(study_name=study.study_name, storage=storage, exist_ok=True)
 
         if isinstance(study.storage, optuna.storages.InMemoryStorage):
-            return
-
-        # Test exist_ok=False with existing study.
-        with pytest.raises(optuna.structs.DuplicatedStudyError):
+            # `InMemoryStorage` does not share study's namespace (i.e., no name conflicts occur).
             optuna.create_study(study_name=study.study_name, storage=storage, exist_ok=False)
+        else:
+            # Test exist_ok=False with existing study.
+            with pytest.raises(optuna.structs.DuplicatedStudyError):
+                optuna.create_study(study_name=study.study_name, storage=storage, exist_ok=False)


### PR DESCRIPTION
I added `exist_ok` option to` optuna.study.create_study() `function and `$ optuna create-study` CLI command. It allows users to create studies without warrying about "whether the study already exists in the storage or not".