### PR TITLE
Add FixedTrial.

### DIFF
--- a/docs/source/reference/trial.rst
+++ b/docs/source/reference/trial.rst
@@ -8,4 +8,4 @@ Trial
     :members:
     :exclude-members: system_attrs, set_system_attr
 
-
+.. autoclass:: FixedTrial

--- a/optuna/trial.py
+++ b/optuna/trial.py
@@ -465,7 +465,7 @@ class FixedTrial(BaseTrial):
 
             >>> def objective(trial):
             >>>     x = trial.suggest_uniform('x', -100, 100)
-            >>>     y = trial.suggest_categorical('y', (-1, 0, 1))
+            >>>     y = trial.suggest_categorical('y', [-1, 0, 1])
             >>>     return x ** 2 + y
             >>>
             >>> objective(FixedTrial({'x': 1, 'y': 0}))

--- a/optuna/trial.py
+++ b/optuna/trial.py
@@ -455,7 +455,7 @@ class FixedTrial(BaseTrial):
     parameter values. The parameter values can be determined at the construction of the
     :class:`~optuna.trial.FixedTrial` object. In contrast to :class:`~optuna.trial.Trial`,
     :class:`~optuna.trial.FixedTrial` does not depend on :class:`~optuna.study.Study`, and it is
-    useful to deploy optimization results.
+    useful for deploying optimization results.
 
     Example:
 

--- a/tests/test_trial.py
+++ b/tests/test_trial.py
@@ -7,6 +7,7 @@ from optuna import distributions
 from optuna import samplers
 from optuna import storages
 from optuna.study import create_study
+from optuna.trial import FixedTrial
 from optuna.trial import Trial
 
 parametrize_storage = pytest.mark.parametrize(
@@ -73,3 +74,93 @@ def test_suggest_int(storage_init_func):
         assert trial._suggest('y', distribution) == 3  # Test suggesting a different param.
         assert trial.params == {'x': 1, 'y': 3}
         assert mock_object.call_count == 3
+
+
+def test_fixed_trial_suggest_uniform():
+    # type: () -> None
+
+    trial = FixedTrial({'x': 1.})
+    assert trial.suggest_uniform('x', -100., 100.) == 1.
+
+    with pytest.raises(ValueError):
+        trial.suggest_uniform('y', -100., 100.)
+
+
+def test_fixed_trial_suggest_loguniform():
+    # type: () -> None
+
+    trial = FixedTrial({'x': 1.})
+    assert trial.suggest_loguniform('x', 0., 1.) == 1.
+
+    with pytest.raises(ValueError):
+        trial.suggest_loguniform('y', 0., 1.)
+
+
+def test_fixed_trial_suggest_discrete_uniform():
+    # type: () -> None
+
+    trial = FixedTrial({'x': 1.})
+    assert trial.suggest_discrete_uniform('x', 0., 1., 0.1) == 1.
+
+    with pytest.raises(ValueError):
+        trial.suggest_discrete_uniform('y', 0., 1., 0.1)
+
+
+def test_fixed_trial_suggest_int():
+    # type: () -> None
+
+    trial = FixedTrial({'x': 1})
+    assert trial.suggest_int('x', 0, 10) == 1
+
+    with pytest.raises(ValueError):
+        trial.suggest_int('y', 0, 10)
+
+
+def test_fixed_trial_suggest_categorical():
+    # type: () -> None
+
+    trial = FixedTrial({'x': 1})
+    assert trial.suggest_categorical('x', [0, 1, 2, 3]) == 1
+
+    with pytest.raises(ValueError):
+        trial.suggest_categorical('y', [0, 1, 2, 3])
+
+
+def test_fixed_trial_user_attrs():
+    # type: () -> None
+
+    trial = FixedTrial({'x': 1})
+    trial.set_user_attr('data', 'MNIST')
+    assert trial.user_attrs['data'] == 'MNIST'
+
+
+def test_fixed_trial_system_attrs():
+    # type: () -> None
+
+    trial = FixedTrial({'x': 1})
+    trial.set_system_attr('system_message', 'test')
+    assert trial.system_attrs['system_message'] == 'test'
+
+
+def test_fixed_trial_params():
+    # type: () -> None
+
+    params = {'x': 1}
+    trial = FixedTrial(params)
+    assert trial.params == params
+
+
+def test_fixed_trial_report():
+    # type: () -> None
+
+    # FixedTrial ignores reported values.
+    trial = FixedTrial({})
+    trial.report(1.0, 1)
+    trial.report(2.0)
+
+
+def test_fixed_trial_should_prune():
+    # type: () -> None
+
+    # FixedTrial never prunes trials.
+    assert FixedTrial({}).should_prune(1) is False


### PR DESCRIPTION
This PR adds `FixedTrial` class to evaluate an objective function with certain parameter values. It will be useful to deploy the best trial to other environments like production.
- Adds `BaseTrial` class as a common parent class of `Trial` and `FixedTrial`
- `FixedTrial` receives a dictionary of parameters
- `FixedTrial` suggests parameter values in the dictionary
- `FixedTrial` raises `ValueError` when the given parameter name is not found.