### PR TITLE
Dashboard can not access from remote host.

### DIFF
--- a/optuna/cli.py
+++ b/optuna/cli.py
@@ -126,6 +126,8 @@ class Dashboard(BaseCommand):
         parser.add_argument('--out', '-o',
                             help='Output HTML file path. If it is not given, a HTTP server starts '
                                  'and the dashboard is served.')
+        parser.add_argument('--allow-websocket-origin', dest='bokeh_allow_websocket_origin',
+                            help='bokeh --allow_websocket_origin parameter for access from remote access')
         return parser
 
     def take_action(self, parsed_args):
@@ -136,7 +138,7 @@ class Dashboard(BaseCommand):
         study = optuna.Study(storage=storage_url, study_name=parsed_args.study)
 
         if parsed_args.out is None:
-            optuna.dashboard.serve(study)
+            optuna.dashboard.serve(study, parsed_args.bokeh_allow_websocket_origin)
         else:
             optuna.dashboard.write(study, parsed_args.out)
             self.logger.info('Report successfully written to: {}'.format(parsed_args.out))

--- a/optuna/dashboard.py
+++ b/optuna/dashboard.py
@@ -255,7 +255,7 @@ def _get_this_source_path():
     return path
 
 
-def serve(study):
+def serve(study, bokeh_allow_websocket_origin=None):
     # type: (optuna.study.Study) -> None
 
     global _mode, _study
@@ -278,7 +278,10 @@ def serve(study):
     # for some reason, we found that the CDS update is not reflected to browsers, at least on Bokeh
     # version 0.12.15. In addition, we will need to do many configuration to servers, which can be
     # done automatically with the following one line. So, for now, we decided to use this way.
-    bokeh.command.bootstrap.main(['bokeh', 'serve', '--show', _get_this_source_path()])
+    command = ['bokeh', 'serve', '--show', _get_this_source_path()]
+    if bokeh_allow_websocket_origin is not None:
+        command.extend(['--allow-websocket-origin', bokeh_allow_websocket_origin])
+    bokeh.command.bootstrap.main(command)
 
 
 def write(study, out_path):


### PR DESCRIPTION
I tried that command and access from remote.
e.g. dashboard server IP is `192.168.1.1` and my local PC IP is `192.168.1.2`

```bash
optuna dashboard --storage "sqlite:///example.db" --study "example-study"
```

It can not be access to `http://192.168.1.1:5006` from "192.168.1.2"

I got that error log .

```
[E 2018-12-06 15:10:05,468] Refusing websocket connection from Origin 'http://192.168.1.5:5006';                       use --allow-websocket-origin=192.168.1.5:5006 to permit this; currently we allow origins {'localhost:5006'}
```

However, we can not set that option, this PR fixed the problem.