### PR TITLE
Make `ChainerPruningExtension` report NaN to pruner.

### DIFF
--- a/optuna/integration/chainer.py
+++ b/optuna/integration/chainer.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import
 
-import math
 from typing import TYPE_CHECKING
 
 import optuna
@@ -108,9 +107,6 @@ class ChainerPruningExtension(Extension):
             return
 
         current_score = self._get_float_value(trainer.observation[self.observation_key])
-        if math.isnan(current_score):
-            return
-
         current_step = getattr(trainer.updater, self.pruner_trigger.unit)
         self.trial.report(current_score, step=current_step)
         if self.trial.should_prune(current_step):


### PR DESCRIPTION
For historical reasons, `ChainerPruningExtension` has not reported NaN values to pruner. Currently, pruners can handle NaN values well. So I removed the code for handling NaN as a special value from `ChainerPruningExtension`.