### PR TITLE
Making samplers/tpe/parzen_estimator.py Adaptive (bug fix)

### DIFF
--- a/optuna/samplers/tpe/parzen_estimator.py
+++ b/optuna/samplers/tpe/parzen_estimator.py
@@ -110,7 +110,7 @@ class ParzenEstimator(object):
             minsigma = 1.0 * (high - low) / min(100.0, (1.0 + len(sorted_mus)))
         else:
             minsigma = 0.0
-        sigma = numpy.clip(sigma, maxsigma, minsigma)
+        sigma = numpy.clip(sigma, minsigma, maxsigma)
 
         sorted_weights = list(sorted_weights)
         sorted_mus = list(sorted_mus)


### PR DESCRIPTION
Existing Optuna implementation of an adaptive parzen estimator is not "adaptive", because all covariance (=bandwidths) of kernels are equivalent to "maxsigma = high - low".
Thanks to this bug fix, we can consider "adaptive" parzen estimator. and then, strong anytime performance will be ensured.
Some benchmark tests (blackbox optimization bench and pruning bench) prove that. 