### PR TITLE
Make TYPE_CHECKING work before Python 3.5.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,7 @@ workflows:
       - tests-python37
       - tests-python36
       - tests-python35
+      - tests-python35_1
       - tests-python34
       - tests-python27
       - examples-python37
@@ -127,6 +128,13 @@ jobs:
   tests-python35:
     docker:
       - image: circleci/python:3.5
+    steps:
+      [checkout, run: *install, run: *tests, run: *tests-mn]
+
+  # for testing usage of typing module
+  tests-python35_1:
+    docker:
+      - image: circleci/python:3.5.1
     steps:
       [checkout, run: *install, run: *tests, run: *tests-mn]
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,7 @@ workflows:
       - document
       - tests-python37
       - tests-python36
+      - tests-python35_1
       - tests-python35
       - tests-python34
       - tests-python27

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,6 @@ workflows:
       - document
       - tests-python37
       - tests-python36
-      - tests-python35_1
       - tests-python35
       - tests-python34
       - tests-python27

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,6 @@ workflows:
       - tests-python37
       - tests-python36
       - tests-python35
-      - tests-python35_1
       - tests-python34
       - tests-python27
       - examples-python37
@@ -128,13 +127,6 @@ jobs:
   tests-python35:
     docker:
       - image: circleci/python:3.5
-    steps:
-      [checkout, run: *install, run: *tests, run: *tests-mn]
-
-  # for testing usage of typing module
-  tests-python35_1:
-    docker:
-      - image: circleci/python:3.5.1
     steps:
       [checkout, run: *install, run: *tests, run: *tests-mn]
 

--- a/optuna/integration/chainer.py
+++ b/optuna/integration/chainer.py
@@ -1,9 +1,9 @@
 from __future__ import absolute_import
 
 import math
-from typing import TYPE_CHECKING
 
 import optuna
+from optuna import types
 
 try:
     import chainer
@@ -18,7 +18,7 @@ except ImportError as e:
     Extension = object
 
 
-if TYPE_CHECKING:
+if types.TYPE_CHECKING:
     from typing import Tuple
     from typing import Union
 

--- a/optuna/integration/chainer.py
+++ b/optuna/integration/chainer.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import
 
-import math
-
 import optuna
 from optuna import types
 

--- a/optuna/trial.py
+++ b/optuna/trial.py
@@ -1,10 +1,10 @@
 import abc
 import six
-from typing import TYPE_CHECKING  # NOQA
 
 from optuna import distributions
+from optuna import types
 
-if TYPE_CHECKING:
+if types.TYPE_CHECKING:
     from optuna.study import Study  # NOQA
     from typing import Any  # NOQA
     from typing import Dict  # NOQA

--- a/optuna/types.py
+++ b/optuna/types.py
@@ -1,0 +1,5 @@
+try:
+    from typing import TYPE_CHECKING  # NOQA
+except ImportError:
+    # typing.TYPE_CHECKING doesn't exist before Python 3.5.2
+    TYPE_CHECKING = False


### PR DESCRIPTION
`typing.TYPE_CHECKING` is introduced in Python 3.5.2 and it doesn't work before. You can check like the following:

```python
$ pyenv install 3.5.1
$ pyenv local 3.5.1
$ python
Python 3.5.1 (default, Nov 15 2018, 17:50:51) 
[GCC 5.5.0 20171010] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from typing import TYPE_CHECKING
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ImportError: cannot import name 'TYPE_CHECKING'
```

You need to handle `ImportError` to make it work:

```python
try:
    from typing import TYPE_CHECKING  # NOQA
except ImportError:
    # typing.TYPE_CHECKING doesn't exist before Python 3.5.2
    TYPE_CHECKING = False

if TYPE_CHECKING:
    from typing import Sequence

def double(a):
    # type: (Sequence[int]) -> Sequence[int]
    return [i * 2 for i in a]

print("TYPE_CHECKING: " + str(TYPE_CHECKING))
double("foo")  # type mismatch
```

The important thing is that mypy *does* work on the above snippet because it always defines `TYPE_CHECKING` as `True` even if `typing` module doesn't support it.

```bash
$ pyenv local 3.5.1
$ python import.py
TYPE_CHECKING: False
$ mypy import.py 
import.py:15: error: Argument 1 to "double" has incompatible type "str"; expected "Sequence[int]"
```
