### PR TITLE
Add test cases to check NaN handling of MedianPruner.

### DIFF
--- a/tests/test_pruners.py
+++ b/tests/test_pruners.py
@@ -36,6 +36,33 @@ def test_median_pruner_intermediate_values():
                         trial_id=trial.trial_id, step=1)
 
 
+def test_median_pruner_intermediate_values_nan():
+    # type: () -> None
+
+    pruner = optuna.pruners.MedianPruner(0, 0)
+    study = optuna.study.create_study()
+
+    trial = optuna.trial.Trial(study, study.storage.create_new_trial_id(study.study_id))
+    trial.report(float('nan'), 1)
+    # A pruner is not activated if the study does not have any previous trials.
+    assert not pruner.prune(storage=study.storage, study_id=study.study_id,
+                            trial_id=trial.trial_id, step=1)
+    study.storage.set_trial_state(trial.trial_id, TrialState.COMPLETE)
+
+    trial = optuna.trial.Trial(study, study.storage.create_new_trial_id(study.study_id))
+    trial.report(float('nan'), 1)
+    # A pruner is activated if the best intermediate value of this trial is NaN.
+    assert pruner.prune(storage=study.storage, study_id=study.study_id,
+                        trial_id=trial.trial_id, step=1)
+    study.storage.set_trial_state(trial.trial_id, TrialState.COMPLETE)
+
+    trial = optuna.trial.Trial(study, study.storage.create_new_trial_id(study.study_id))
+    trial.report(1, 1)
+    # A pruner is not activated if the median intermediate value is NaN.
+    assert not pruner.prune(storage=study.storage, study_id=study.study_id,
+                            trial_id=trial.trial_id, step=1)
+
+
 def test_median_pruner_n_startup_trials():
     # type: () -> None
 


### PR DESCRIPTION
This PR adds test cases of MedianPruner to `tests/test_pruners.py`.
The behavior of the current MedianPruner is a bit complicated as follows:

1. If it is the first trial in the study, then `MedianPruner.prune` returns False. (Not pruned.)
1. If the best intermediate value of the trial is `NaN` (i.e., all intermediate values are NaNs), then `MedianPruner.prune` returns True. (Pruned.)
1. If the best intermediate value is not NaN and the median of intermediate values is `NaN` (i.e., all previous trials returns NaNs at the target step), then `MedianPruner.prune` returns False. (Not pruned.)