### PR TITLE
fix `ets` is invalid parameter in xgboost example.

### DIFF
--- a/examples/xgboost_simple.py
+++ b/examples/xgboost_simple.py
@@ -45,7 +45,7 @@ def objective(trial):
 
     if param['booster'] == 'gbtree' or param['booster'] == 'dart':
         param['max_depth'] = trial.suggest_int('max_depth', 1, 9)
-        param['ets'] = trial.suggest_loguniform('eta', 1e-8, 1.0)
+        param['eta'] = trial.suggest_loguniform('eta', 1e-8, 1.0)
         param['gamma'] = trial.suggest_loguniform('gamma', 1e-8, 1.0)
         param['grow_policy'] = trial.suggest_categorical('grow_policy', ['depthwise', 'lossguide'])
     if param['booster'] == 'dart':


### PR DESCRIPTION
I could not found `ets` parameter in [here](https://xgboost.readthedocs.io/en/latest/parameter.html).

I think `ets` is `eta`. (trial.suggest_loguniform argument is correct).