### PR TITLE
Fix a typo in pruning example of xgboost.

### DIFF
--- a/examples/pruning/xgboost_integration.py
+++ b/examples/pruning/xgboost_integration.py
@@ -36,7 +36,7 @@ def objective(trial):
 
     if param['booster'] == 'gbtree' or param['booster'] == 'dart':
         param['max_depth'] = trial.suggest_int('max_depth', 1, 9)
-        param['ets'] = trial.suggest_loguniform('eta', 1e-8, 1.0)
+        param['eta'] = trial.suggest_loguniform('eta', 1e-8, 1.0)
         param['gamma'] = trial.suggest_loguniform('gamma', 1e-8, 1.0)
         param['grow_policy'] = trial.suggest_categorical('grow_policy', ['depthwise', 'lossguide'])
     if param['booster'] == 'dart':


### PR DESCRIPTION
Similarly to #265, this PR fixes a typo in the xgboost example.
current: `ets`
correct: `eta`