### PR TITLE
Add consecutive serial number of Trial.

### DIFF
--- a/optuna/integration/chainermn.py
+++ b/optuna/integration/chainermn.py
@@ -43,7 +43,7 @@ class ChainerMNObjectiveFunc(object):
     def __call__(self, trial):
         # type: (Trial) -> float
 
-        self.comm.mpi_comm.bcast((True, trial.trial_id))
+        self.comm.mpi_comm.bcast((True, trial.internal_trial_id))
         return self.objective(trial, self.comm)
 
 

--- a/optuna/pruners.py
+++ b/optuna/pruners.py
@@ -12,7 +12,7 @@ class BasePruner(object):
     """Base class for pruners."""
 
     @abc.abstractmethod
-    def prune(self, storage, study_id, trial_id, step):
+    def prune(self, storage, study_id, internal_trial_id, step):
         # type: (BaseStorage, int, int, int) -> bool
 
         """Judge whether the trial should be pruned at the given step.
@@ -26,8 +26,10 @@ class BasePruner(object):
                 Storage object.
             study_id:
                 Identifier of the target study.
-            trial_id:
-                Identifier of the target trial.
+            internal_trial_id:
+                Identifier of the target trial. Please specify
+                :func:`optuna.trial.Trial.internal_trial_id` which is unique in storage.
+                If you set :func:`optuna.trial.Trial.trial_id`, pruners may not work correctly.
             step:
                 Step number.
 
@@ -73,7 +75,7 @@ class MedianPruner(BasePruner):
         self.n_startup_trials = n_startup_trials
         self.n_warmup_steps = n_warmup_steps
 
-    def prune(self, storage, study_id, trial_id, step):
+    def prune(self, storage, study_id, internal_trial_id, step):
         # type: (BaseStorage, int, int, int) -> bool
 
         """Please consult the documentation for :func:`BasePruner.prune`."""
@@ -91,10 +93,11 @@ class MedianPruner(BasePruner):
         if step <= self.n_warmup_steps:
             return False
 
-        if len(storage.get_trial(trial_id).intermediate_values) == 0:
+        if len(storage.get_trial(internal_trial_id).intermediate_values) == 0:
             return False
 
-        best_intermediate_result = storage.get_best_intermediate_result_over_steps(trial_id)
+        best_intermediate_result = \
+            storage.get_best_intermediate_result_over_steps(internal_trial_id)
         if math.isnan(best_intermediate_result):
             return True
 

--- a/optuna/storages/in_memory.py
+++ b/optuna/storages/in_memory.py
@@ -140,7 +140,7 @@ class InMemoryStorage(base.BaseStorage):
                     state=structs.TrialState.RUNNING,
                     params={},
                     user_attrs={},
-                    system_attrs={},
+                    system_attrs={'serial_number': trial_id},
                     value=None,
                     intermediate_values={},
                     params_in_internal_repr={},

--- a/optuna/storages/in_memory.py
+++ b/optuna/storages/in_memory.py
@@ -133,14 +133,16 @@ class InMemoryStorage(base.BaseStorage):
 
         self._check_study_id(study_id)
         with self._lock:
+            # InMemoryStorage has only one study, and internal_trial_id is equal to trial_id.
             trial_id = len(self.trials)
             self.trials.append(
                 structs.FrozenTrial(
+                    internal_trial_id=trial_id,
                     trial_id=trial_id,
                     state=structs.TrialState.RUNNING,
                     params={},
                     user_attrs={},
-                    system_attrs={'serial_number': trial_id},
+                    system_attrs={},
                     value=None,
                     intermediate_values={},
                     params_in_internal_repr={},

--- a/optuna/storages/rdb/models.py
+++ b/optuna/storages/rdb/models.py
@@ -227,7 +227,13 @@ class TrialUserAttributeModel(BaseModel):
     def where_trial(cls, trial, session):
         # type: (TrialModel, orm.Session) -> List[TrialUserAttributeModel]
 
-        return session.query(cls).filter(cls.trial_id == trial.trial_id).all()
+        return cls.where_trial_id(trial.trial_id, session)
+
+    @classmethod
+    def where_trial_id(cls, trial_id, session):
+        # type: (int, orm.Session) -> List[TrialUserAttributeModel]
+
+        return session.query(cls).filter(cls.trial_id == trial_id).all()
 
     @classmethod
     def all(cls, session):
@@ -268,7 +274,13 @@ class TrialSystemAttributeModel(BaseModel):
     def where_trial(cls, trial, session):
         # type: (TrialModel, orm.Session) -> List[TrialSystemAttributeModel]
 
-        return session.query(cls).filter(cls.trial_id == trial.trial_id).all()
+        return cls.where_trial_id(trial.trial_id, session)
+
+    @classmethod
+    def where_trial_id(cls, trial_id, session):
+        # type: (int, orm.Session) -> List[TrialSystemAttributeModel]
+
+        return session.query(cls).filter(cls.trial_id == trial_id).all()
 
     @classmethod
     def all(cls, session):

--- a/optuna/storages/rdb/models.py
+++ b/optuna/storages/rdb/models.py
@@ -6,6 +6,7 @@ from sqlalchemy import Enum
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy import Float
 from sqlalchemy import ForeignKey
+from sqlalchemy import func
 from sqlalchemy import Integer
 from sqlalchemy import orm
 from sqlalchemy import String
@@ -188,9 +189,10 @@ class TrialModel(BaseModel):
     def count_past_trials(self, session):
         # type: (orm.Session) -> int
 
-        trials = session.query(TrialModel).filter(TrialModel.study_id == self.study_id,
-                                                  TrialModel.trial_id < self.trial_id)
-        return trials.count()
+        trial_count = session.query(func.count(TrialModel.trial_id))\
+            .filter(TrialModel.study_id == self.study_id,
+                    TrialModel.trial_id < self.trial_id)
+        return trial_count.scalar()
 
 
 class TrialUserAttributeModel(BaseModel):

--- a/optuna/storages/rdb/models.py
+++ b/optuna/storages/rdb/models.py
@@ -185,6 +185,13 @@ class TrialModel(BaseModel):
 
         return session.query(cls).all()
 
+    def count_past_trials(self, session):
+        # type: (orm.Session) -> int
+
+        trials = session.query(TrialModel).filter(TrialModel.study_id == self.study_id,
+                                                  TrialModel.trial_id < self.trial_id)
+        return trials.count()
+
 
 class TrialUserAttributeModel(BaseModel):
     __tablename__ = 'trial_user_attributes'

--- a/optuna/storages/rdb/storage.py
+++ b/optuna/storages/rdb/storage.py
@@ -256,6 +256,9 @@ class RDBStorage(BaseStorage):
         session.add(trial)
         self._commit(session)
 
+        serial_number = trial.count_past_trials(session)
+        self.set_trial_system_attr(trial.trial_id, 'serial_number', serial_number)
+
         return trial.trial_id
 
     def set_trial_state(self, trial_id, state):

--- a/optuna/structs.py
+++ b/optuna/structs.py
@@ -53,7 +53,8 @@ class StudyDirection(enum.Enum):
 class FrozenTrial(
     NamedTuple(
         '_BaseFrozenTrial',
-        [('trial_id', int),
+        [('internal_trial_id', int),
+         ('trial_id', int),
          ('state', TrialState),
          ('value', Optional[float]),
          ('datetime_start', Optional[datetime]),
@@ -68,8 +69,11 @@ class FrozenTrial(
     """Status and results of a :class:`~optuna.trial.Trial`.
 
     Attributes:
+        internal_trial_id:
+            Internal identifier of the :class:`~optuna.trial.Trial`, which is unique in storage.
         trial_id:
-            Identifier of the :class:`~optuna.trial.Trial`.
+            Identifier of the :class:`~optuna.trial.Trial`, which is unique and consecutive in a
+            study.
         state:
             :class:`TrialState` of the :class:`~optuna.trial.Trial`.
         value:
@@ -92,7 +96,7 @@ class FrozenTrial(
             Optuna's internal representation of :attr:`params`.
     """
 
-    internal_fields = ['params_in_internal_repr']
+    internal_fields = ['params_in_internal_repr', 'internal_trial_id']
 
 
 class StudySummary(

--- a/optuna/study.py
+++ b/optuna/study.py
@@ -395,18 +395,19 @@ class Study(object):
 
         trial_id = self.storage.create_new_trial_id(self.study_id)
         trial = trial_module.Trial(self, trial_id)
+        trial_serial_number = trial.system_attrs['serial_number']
 
         try:
             result = func(trial)
         except structs.TrialPruned as e:
-            message = 'Setting trial status as {}. {}'.format(
-                structs.TrialState.PRUNED, str(e))
+            message = 'Setting status of trial #{} as {}. {}'.format(
+                trial_serial_number, structs.TrialState.PRUNED, str(e))
             self.logger.info(message)
             self.storage.set_trial_state(trial_id, structs.TrialState.PRUNED)
             return trial
         except catch as e:
-            message = 'Setting trial status as {} because of the following error: {}'.format(
-                structs.TrialState.FAIL, repr(e))
+            message = 'Setting status of trial #{} as {} because of the following error: {}' \
+                .format(trial_serial_number, structs.TrialState.FAIL, repr(e))
             self.logger.warning(message, exc_info=True)
             self.storage.set_trial_state(trial_id, structs.TrialState.FAIL)
             self.storage.set_trial_system_attr(trial_id, 'fail_reason', message)
@@ -415,17 +416,17 @@ class Study(object):
         try:
             result = float(result)
         except (ValueError, TypeError,):
-            message = 'Setting trial status as {} because the returned value from the ' \
+            message = 'Setting status of trial #{} as {} because the returned value from the ' \
                       'objective function cannot be casted to float. Returned value is: ' \
-                      '{}'.format(structs.TrialState.FAIL, repr(result))
+                      '{}'.format(trial_serial_number, structs.TrialState.FAIL, repr(result))
             self.logger.warning(message)
             self.storage.set_trial_state(trial_id, structs.TrialState.FAIL)
             self.storage.set_trial_system_attr(trial_id, 'fail_reason', message)
             return trial
 
         if math.isnan(result):
-            message = 'Setting trial status as {} because the objective function returned ' \
-                      '{}.'.format(structs.TrialState.FAIL, result)
+            message = 'Setting status of trial #{} as {} because the objective function ' \
+                      'returned {}.'.format(trial_serial_number, structs.TrialState.FAIL, result)
             self.logger.warning(message)
             self.storage.set_trial_state(trial_id, structs.TrialState.FAIL)
             self.storage.set_trial_system_attr(trial_id, 'fail_reason', message)
@@ -433,17 +434,17 @@ class Study(object):
 
         trial.report(result)
         self.storage.set_trial_state(trial_id, structs.TrialState.COMPLETE)
-        self._log_completed_trial(result)
+        self._log_completed_trial(trial_serial_number, result)
 
         return trial
 
-    def _log_completed_trial(self, value):
-        # type: (float) -> None
+    def _log_completed_trial(self, trial_serial_number, value):
+        # type: (int, float) -> None
 
         self.logger.info(
-            'Finished a trial resulted in value: {}. '
+            'Finished trial #{} resulted in value: {}. '
             'Current best value is {} with parameters: {}.'.format(
-                value, self.best_value, self.best_params))
+                trial_serial_number, value, self.best_value, self.best_params))
 
 
 def create_study(

--- a/tests/integration_tests/test_chainermn.py
+++ b/tests/integration_tests/test_chainermn.py
@@ -52,10 +52,10 @@ class Func(object):
         y = trial.suggest_loguniform('y', 20, 30)
         z = trial.suggest_categorical('z', (-1.0, 1.0))
 
-        self.suggested_values[trial.trial_id] = {}
-        self.suggested_values[trial.trial_id]['x'] = x
-        self.suggested_values[trial.trial_id]['y'] = y
-        self.suggested_values[trial.trial_id]['z'] = z
+        self.suggested_values[trial.internal_trial_id] = {}
+        self.suggested_values[trial.internal_trial_id]['x'] = x
+        self.suggested_values[trial.internal_trial_id]['y'] = y
+        self.suggested_values[trial.internal_trial_id]['z'] = z
 
         return (x - 2) ** 2 + (y - 25) ** 2 + z
 
@@ -161,7 +161,7 @@ class TestChainerMNStudy(object):
 
             # Assert the same parameters have been suggested among all nodes.
             for trial in mn_study.trials:
-                assert trial.params == func.suggested_values[trial.trial_id]
+                assert trial.params == func.suggested_values[trial.internal_trial_id]
 
     @staticmethod
     def _create_shared_study(storage, comm):

--- a/tests/storages_tests/rdb_tests/test_models.py
+++ b/tests/storages_tests/rdb_tests/test_models.py
@@ -85,6 +85,28 @@ class TestTrialModel(object):
         assert 2 == TrialModel.count(session, study=study_1)
         assert 1 == TrialModel.count(session, state=TrialState.COMPLETE)
 
+    @staticmethod
+    def test_count_past_trials(session):
+        # type: (Session) -> None
+
+        study_1 = StudyModel(study_id=1, study_name='test-study-1')
+        study_2 = StudyModel(study_id=2, study_name='test-study-2')
+
+        trial_1_1 = TrialModel(study_id=study_1.study_id, state=TrialState.COMPLETE)
+        session.add(trial_1_1)
+        session.commit()
+        assert 0 == trial_1_1.count_past_trials(session)
+
+        trial_1_2 = TrialModel(study_id=study_1.study_id, state=TrialState.RUNNING)
+        session.add(trial_1_2)
+        session.commit()
+        assert 1 == trial_1_2.count_past_trials(session)
+
+        trial_2_1 = TrialModel(study_id=study_2.study_id, state=TrialState.RUNNING)
+        session.add(trial_2_1)
+        session.commit()
+        assert 0 == trial_2_1.count_past_trials(session)
+
 
 class TestTrialUserAttributeModel(object):
 

--- a/tests/storages_tests/test_storages.py
+++ b/tests/storages_tests/test_storages.py
@@ -213,7 +213,7 @@ def test_create_new_trial_id(storage_init_func):
     assert trials[0].trial_id == trial_id
     assert trials[0].state == TrialState.RUNNING
     assert trials[0].user_attrs == {}
-    assert trials[0].system_attrs == {}
+    assert trials[0].system_attrs == {'serial_number': 0}
 
 
 @parametrize_storage
@@ -376,7 +376,7 @@ def test_set_trial_user_attr(storage_init_func):
 
 
 @parametrize_storage
-def test_set_and_get_tiral_system_attr(storage_init_func):
+def test_set_and_get_trial_system_attr(storage_init_func):
     # type: (Callable[[], BaseStorage]) -> None
 
     storage = storage_init_func()
@@ -392,6 +392,7 @@ def test_set_and_get_tiral_system_attr(storage_init_func):
     for key, value in EXAMPLE_ATTRS.items():
         check_set_and_get(trial_id_1, key, value)
     system_attrs = storage.get_trial(trial_id_1).system_attrs
+    del system_attrs['serial_number']
     assert system_attrs == EXAMPLE_ATTRS
 
     # Test overwriting value.
@@ -401,6 +402,7 @@ def test_set_and_get_tiral_system_attr(storage_init_func):
     trial_id_2 = storage.create_new_trial_id(storage.create_new_study_id())
     check_set_and_get(trial_id_2, 'baseline_score', 0.001)
     system_attrs = storage.get_trial(trial_id_2).system_attrs
+    del system_attrs['serial_number']
     assert system_attrs == {'baseline_score': 0.001}
 
 
@@ -623,7 +625,17 @@ def _check_example_trial_static_attributes(trial_1, trial_2):
     assert trial_1 is not None
     assert trial_2 is not None
 
-    trial_1 = trial_1._replace(trial_id=-1, datetime_start=None, datetime_complete=None)
-    trial_2 = trial_2._replace(trial_id=-1, datetime_start=None, datetime_complete=None)
+    # Remove serial_number in system_attrs because it is not a static attribute.
+    trial_1_system_attrs = trial_1.system_attrs
+    if 'serial_number' in trial_1_system_attrs:
+        del trial_1_system_attrs['serial_number']
+    trial_2_system_attrs = trial_2.system_attrs
+    if 'serial_number' in trial_2_system_attrs:
+        del trial_2_system_attrs['serial_number']
+
+    trial_1 = trial_1._replace(trial_id=-1, datetime_start=None, datetime_complete=None,
+                               system_attrs=trial_1_system_attrs)
+    trial_2 = trial_2._replace(trial_id=-1, datetime_start=None, datetime_complete=None,
+                               system_attrs=trial_2_system_attrs)
 
     assert trial_1 == trial_2

--- a/tests/test_pruners.py
+++ b/tests/test_pruners.py
@@ -12,7 +12,7 @@ def test_median_pruner_with_one_trial():
 
     # A pruner is not activated at a first trial.
     assert not pruner.prune(storage=study.storage, study_id=study.study_id,
-                            trial_id=trial.trial_id, step=1)
+                            internal_trial_id=trial.internal_trial_id, step=1)
 
 
 def test_median_pruner_intermediate_values():
@@ -23,17 +23,17 @@ def test_median_pruner_intermediate_values():
 
     trial = optuna.trial.Trial(study, study.storage.create_new_trial_id(study.study_id))
     trial.report(1, 1)
-    study.storage.set_trial_state(trial.trial_id, TrialState.COMPLETE)
+    study.storage.set_trial_state(trial.internal_trial_id, TrialState.COMPLETE)
 
     trial = optuna.trial.Trial(study, study.storage.create_new_trial_id(study.study_id))
     # A pruner is not activated if a trial has no intermediate values.
     assert not pruner.prune(storage=study.storage, study_id=study.study_id,
-                            trial_id=trial.trial_id, step=1)
+                            internal_trial_id=trial.internal_trial_id, step=1)
 
     trial.report(2, 1)
     # A pruner is activated if a trial has an intermediate value.
     assert pruner.prune(storage=study.storage, study_id=study.study_id,
-                        trial_id=trial.trial_id, step=1)
+                        internal_trial_id=trial.internal_trial_id, step=1)
 
 
 def test_median_pruner_intermediate_values_nan():
@@ -46,21 +46,21 @@ def test_median_pruner_intermediate_values_nan():
     trial.report(float('nan'), 1)
     # A pruner is not activated if the study does not have any previous trials.
     assert not pruner.prune(storage=study.storage, study_id=study.study_id,
-                            trial_id=trial.trial_id, step=1)
-    study.storage.set_trial_state(trial.trial_id, TrialState.COMPLETE)
+                            internal_trial_id=trial.internal_trial_id, step=1)
+    study.storage.set_trial_state(trial.internal_trial_id, TrialState.COMPLETE)
 
     trial = optuna.trial.Trial(study, study.storage.create_new_trial_id(study.study_id))
     trial.report(float('nan'), 1)
     # A pruner is activated if the best intermediate value of this trial is NaN.
     assert pruner.prune(storage=study.storage, study_id=study.study_id,
-                        trial_id=trial.trial_id, step=1)
-    study.storage.set_trial_state(trial.trial_id, TrialState.COMPLETE)
+                        internal_trial_id=trial.internal_trial_id, step=1)
+    study.storage.set_trial_state(trial.internal_trial_id, TrialState.COMPLETE)
 
     trial = optuna.trial.Trial(study, study.storage.create_new_trial_id(study.study_id))
     trial.report(1, 1)
     # A pruner is not activated if the median intermediate value is NaN.
     assert not pruner.prune(storage=study.storage, study_id=study.study_id,
-                            trial_id=trial.trial_id, step=1)
+                            internal_trial_id=trial.internal_trial_id, step=1)
 
 
 def test_median_pruner_n_startup_trials():
@@ -71,20 +71,20 @@ def test_median_pruner_n_startup_trials():
 
     trial = optuna.trial.Trial(study, study.storage.create_new_trial_id(study.study_id))
     trial.report(1, 1)
-    study.storage.set_trial_state(trial.trial_id, TrialState.COMPLETE)
+    study.storage.set_trial_state(trial.internal_trial_id, TrialState.COMPLETE)
 
     trial = optuna.trial.Trial(study, study.storage.create_new_trial_id(study.study_id))
     trial.report(2, 1)
     # A pruner is not activated during startup trials.
     assert not pruner.prune(storage=study.storage, study_id=study.study_id,
-                            trial_id=trial.trial_id, step=1)
-    study.storage.set_trial_state(trial.trial_id, TrialState.COMPLETE)
+                            internal_trial_id=trial.internal_trial_id, step=1)
+    study.storage.set_trial_state(trial.internal_trial_id, TrialState.COMPLETE)
 
     trial = optuna.trial.Trial(study, study.storage.create_new_trial_id(study.study_id))
     trial.report(3, 1)
     # A pruner is activated after startup trials.
     assert pruner.prune(storage=study.storage, study_id=study.study_id,
-                        trial_id=trial.trial_id, step=1)
+                        internal_trial_id=trial.internal_trial_id, step=1)
 
 
 def test_median_pruner_n_warmup_steps():
@@ -96,15 +96,15 @@ def test_median_pruner_n_warmup_steps():
     trial = optuna.trial.Trial(study, study.storage.create_new_trial_id(study.study_id))
     trial.report(1, 1)
     trial.report(1, 2)
-    study.storage.set_trial_state(trial.trial_id, TrialState.COMPLETE)
+    study.storage.set_trial_state(trial.internal_trial_id, TrialState.COMPLETE)
 
     trial = optuna.trial.Trial(study, study.storage.create_new_trial_id(study.study_id))
     trial.report(2, 1)
     # A pruner is not activated during warm-up steps.
     assert not pruner.prune(storage=study.storage, study_id=study.study_id,
-                            trial_id=trial.trial_id, step=1)
+                            internal_trial_id=trial.internal_trial_id, step=1)
 
     trial.report(2, 2)
     # A pruner is activated after warm-up steps.
     assert pruner.prune(storage=study.storage, study_id=study.study_id,
-                        trial_id=trial.trial_id, step=2)
+                        internal_trial_id=trial.internal_trial_id, step=2)

--- a/tests/test_study.py
+++ b/tests/test_study.py
@@ -324,8 +324,8 @@ def test_run_trial(storage_mode):
         trial = study._run_trial(func_value_error, catch=(ValueError,))
         frozen_trial = study.storage.get_trial(trial.trial_id)
 
-        expected_message = 'Setting trial status as TrialState.FAIL because of the following ' \
-                           'error: ValueError()'
+        expected_message = 'Setting status of trial #1 as TrialState.FAIL because of the ' \
+                           'following error: ValueError()'
         assert frozen_trial.state == optuna.structs.TrialState.FAIL
         assert frozen_trial.system_attrs['fail_reason'] == expected_message
 
@@ -340,9 +340,9 @@ def test_run_trial(storage_mode):
         trial = study._run_trial(func_none, catch=(Exception,))
         frozen_trial = study.storage.get_trial(trial.trial_id)
 
-        expected_message = 'Setting trial status as TrialState.FAIL because the returned value ' \
-                           'from the objective function cannot be casted to float. Returned ' \
-                           'value is: None'
+        expected_message = 'Setting status of trial #3 as TrialState.FAIL because the returned ' \
+                           'value from the objective function cannot be casted to float. ' \
+                           'Returned value is: None'
         assert frozen_trial.state == optuna.structs.TrialState.FAIL
         assert frozen_trial.system_attrs['fail_reason'] == expected_message
 
@@ -353,8 +353,8 @@ def test_run_trial(storage_mode):
         trial = study._run_trial(func_nan, catch=(Exception,))
         frozen_trial = study.storage.get_trial(trial.trial_id)
 
-        expected_message = 'Setting trial status as TrialState.FAIL because the objective ' \
-                           'function returned nan.'
+        expected_message = 'Setting status of trial #4 as TrialState.FAIL because the ' \
+                           'objective function returned nan.'
         assert frozen_trial.state == optuna.structs.TrialState.FAIL
         assert frozen_trial.system_attrs['fail_reason'] == expected_message
 
@@ -394,8 +394,8 @@ def test_trials_dataframe(storage_mode):
         study.optimize(f, n_trials=3)
         df = study.trials_dataframe()
         assert len(df) == 3
-        # non-nested: 5, params: 2, user_attrs: 1
-        assert len(df.columns) == 8
+        # non-nested: 5, params: 2, user_attrs: 1, system_attrs: 1
+        assert len(df.columns) == 9
         for i in range(3):
             assert ('trial_id', '') in df.columns  # trial_id depends on other tests.
             assert df.state[i] == optuna.structs.TrialState.COMPLETE
@@ -405,6 +405,7 @@ def test_trials_dataframe(storage_mode):
             assert df.params.x[i] == 1
             assert df.params.y[i] == 2.5
             assert df.user_attrs.train_loss[i] == 3
+            assert ('system_attrs', 'serial_number') in df.columns
 
 
 @pytest.mark.parametrize('storage_mode', STORAGE_MODES)
@@ -425,8 +426,8 @@ def test_trials_dataframe_with_failure(storage_mode):
         study.optimize(f, n_trials=3)
         df = study.trials_dataframe()
         assert len(df) == 3
-        # non-nested: 5, params: 2, user_attrs: 1 system_attrs: 1
-        assert len(df.columns) == 9
+        # non-nested: 5, params: 2, user_attrs: 1 system_attrs: 2
+        assert len(df.columns) == 10
         for i in range(3):
             assert ('trial_id', '') in df.columns  # trial_id depends on other tests.
             assert df.state[i] == optuna.structs.TrialState.FAIL
@@ -437,6 +438,7 @@ def test_trials_dataframe_with_failure(storage_mode):
             assert df.params.y[i] == 2.5
             assert df.user_attrs.train_loss[i] == 3
             assert ('system_attrs', 'fail_reason') in df.columns
+            assert ('system_attrs', 'serial_number') in df.columns
 
 
 @pytest.mark.parametrize('storage_mode', STORAGE_MODES)

--- a/tests/test_study.py
+++ b/tests/test_study.py
@@ -322,7 +322,7 @@ def test_run_trial(storage_mode):
             raise ValueError
 
         trial = study._run_trial(func_value_error, catch=(ValueError,))
-        frozen_trial = study.storage.get_trial(trial.trial_id)
+        frozen_trial = study.storage.get_trial(trial.internal_trial_id)
 
         expected_message = 'Setting status of trial #1 as TrialState.FAIL because of the ' \
                            'following error: ValueError()'
@@ -338,7 +338,7 @@ def test_run_trial(storage_mode):
             return None
 
         trial = study._run_trial(func_none, catch=(Exception,))
-        frozen_trial = study.storage.get_trial(trial.trial_id)
+        frozen_trial = study.storage.get_trial(trial.internal_trial_id)
 
         expected_message = 'Setting status of trial #3 as TrialState.FAIL because the returned ' \
                            'value from the objective function cannot be casted to float. ' \
@@ -351,7 +351,7 @@ def test_run_trial(storage_mode):
             return float('nan')
 
         trial = study._run_trial(func_nan, catch=(Exception,))
-        frozen_trial = study.storage.get_trial(trial.trial_id)
+        frozen_trial = study.storage.get_trial(trial.internal_trial_id)
 
         expected_message = 'Setting status of trial #4 as TrialState.FAIL because the ' \
                            'objective function returned nan.'
@@ -394,8 +394,8 @@ def test_trials_dataframe(storage_mode):
         study.optimize(f, n_trials=3)
         df = study.trials_dataframe()
         assert len(df) == 3
-        # non-nested: 5, params: 2, user_attrs: 1, system_attrs: 1
-        assert len(df.columns) == 9
+        # non-nested: 5, params: 2, user_attrs: 1
+        assert len(df.columns) == 8
         for i in range(3):
             assert ('trial_id', '') in df.columns  # trial_id depends on other tests.
             assert df.state[i] == optuna.structs.TrialState.COMPLETE
@@ -405,7 +405,6 @@ def test_trials_dataframe(storage_mode):
             assert df.params.x[i] == 1
             assert df.params.y[i] == 2.5
             assert df.user_attrs.train_loss[i] == 3
-            assert ('system_attrs', 'serial_number') in df.columns
 
 
 @pytest.mark.parametrize('storage_mode', STORAGE_MODES)
@@ -426,8 +425,8 @@ def test_trials_dataframe_with_failure(storage_mode):
         study.optimize(f, n_trials=3)
         df = study.trials_dataframe()
         assert len(df) == 3
-        # non-nested: 5, params: 2, user_attrs: 1 system_attrs: 2
-        assert len(df.columns) == 10
+        # non-nested: 5, params: 2, user_attrs: 1 system_attrs: 1
+        assert len(df.columns) == 9
         for i in range(3):
             assert ('trial_id', '') in df.columns  # trial_id depends on other tests.
             assert df.state[i] == optuna.structs.TrialState.FAIL
@@ -438,7 +437,6 @@ def test_trials_dataframe_with_failure(storage_mode):
             assert df.params.y[i] == 2.5
             assert df.user_attrs.train_loss[i] == 3
             assert ('system_attrs', 'fail_reason') in df.columns
-            assert ('system_attrs', 'serial_number') in df.columns
 
 
 @pytest.mark.parametrize('storage_mode', STORAGE_MODES)


### PR DESCRIPTION
This PR adds a serial number of `Trial` class. Currently, `Trial` has `trial_id` to identify each trial object, but it is not always consecutive in a study because it is shared among multiple studies in storage. So, I create `serial_number` which is consecutive and unique in a study.

I selected to use `Trial.system_attrs` to save `serial_number` to avoid schema change of RDB.