### PR TITLE
Don't suggest "number of boosting iterations" parameter in GBDT examples.

### DIFF
--- a/docs/source/tutorial/pruning.rst
+++ b/docs/source/tutorial/pruning.rst
@@ -86,5 +86,4 @@ For example, :class:`~optuna.integration.XGBoostPruningCallback` introduces prun
 .. code-block:: python
 
         pruning_callback = optuna.integration.XGBoostPruningCallback(trial, 'validation-error')
-        bst = xgb.train(param, dtrain, n_round, evals=[(dtest, 'validation')],
-                        callbacks=[pruning_callback])
+        bst = xgb.train(param, dtrain, evals=[(dtest, 'validation')], callbacks=[pruning_callback])

--- a/examples/lightgbm_simple.py
+++ b/examples/lightgbm_simple.py
@@ -31,7 +31,6 @@ def objective(trial):
     train_x, test_x, train_y, test_y = train_test_split(data, target, test_size=0.25)
     dtrain = lgb.Dataset(train_x, label=train_y)
 
-    num_round = trial.suggest_int('num_round', 1, 500)
     param = {'objective': 'binary', 'metric': 'binary_logloss', 'verbosity': -1,
              'boosting_type': trial.suggest_categorical('boosting', ['gbdt', 'dart', 'goss']),
              'num_leaves': trial.suggest_int('num_leaves', 10, 1000),
@@ -45,7 +44,7 @@ def objective(trial):
         param['top_rate'] = trial.suggest_uniform('top_rate', 0.0, 1.0)
         param['other_rate'] = trial.suggest_uniform('other_rate', 0.0, 1.0 - param['top_rate'])
 
-    gbm = lgb.train(param, dtrain, num_round)
+    gbm = lgb.train(param, dtrain)
     preds = gbm.predict(test_x)
     pred_labels = np.rint(preds)
     accuracy = sklearn.metrics.accuracy_score(test_y, pred_labels)

--- a/examples/pruning/lightgbm_integration.py
+++ b/examples/pruning/lightgbm_integration.py
@@ -39,8 +39,8 @@ def objective(trial):
 
     # Add a callback for pruning.
     pruning_callback = optuna.integration.LightGBMPruningCallback(trial, 'binary_error')
-    gbm = lgb.train(param, dtrain, valid_sets=[dtest],
-                    verbose_eval=False, callbacks=[pruning_callback])
+    gbm = lgb.train(param, dtrain, valid_sets=[dtest], verbose_eval=False,
+                    callbacks=[pruning_callback])
 
     preds = gbm.predict(test_x)
     pred_labels = np.rint(preds)

--- a/examples/pruning/lightgbm_integration.py
+++ b/examples/pruning/lightgbm_integration.py
@@ -24,7 +24,6 @@ def objective(trial):
     dtrain = lgb.Dataset(train_x, label=train_y)
     dtest = lgb.Dataset(test_x, label=test_y)
 
-    num_round = trial.suggest_int('num_round', 1, 500)
     param = {'objective': 'binary', 'metric': 'binary_error', 'verbosity': -1,
              'boosting_type': trial.suggest_categorical('boosting', ['gbdt', 'dart', 'goss']),
              'num_leaves': trial.suggest_int('num_leaves', 10, 1000),
@@ -40,7 +39,7 @@ def objective(trial):
 
     # Add a callback for pruning.
     pruning_callback = optuna.integration.LightGBMPruningCallback(trial, 'binary_error')
-    gbm = lgb.train(param, dtrain, num_round, valid_sets=[dtest],
+    gbm = lgb.train(param, dtrain, valid_sets=[dtest],
                     verbose_eval=False, callbacks=[pruning_callback])
 
     preds = gbm.predict(test_x)

--- a/examples/pruning/xgboost_integration.py
+++ b/examples/pruning/xgboost_integration.py
@@ -27,7 +27,6 @@ def objective(trial):
     dtrain = xgb.DMatrix(train_x, label=train_y)
     dtest = xgb.DMatrix(test_x, label=test_y)
 
-    n_round = trial.suggest_int('n_round', 1, 9)
     param = {'silent': 1, 'objective': 'binary:logistic',
              'booster': trial.suggest_categorical('booster', ['gbtree', 'gblinear', 'dart']),
              'lambda': trial.suggest_loguniform('lambda', 1e-8, 1.0),
@@ -47,8 +46,7 @@ def objective(trial):
 
     # Add a callback for pruning.
     pruning_callback = optuna.integration.XGBoostPruningCallback(trial, 'validation-error')
-    bst = xgb.train(param, dtrain, n_round, evals=[(dtest, 'validation')],
-                    callbacks=[pruning_callback])
+    bst = xgb.train(param, dtrain, evals=[(dtest, 'validation')], callbacks=[pruning_callback])
     preds = bst.predict(dtest)
     pred_labels = np.rint(preds)
     accuracy = sklearn.metrics.accuracy_score(test_y, pred_labels)

--- a/examples/xgboost_simple.py
+++ b/examples/xgboost_simple.py
@@ -36,7 +36,6 @@ def objective(trial):
     dtrain = xgb.DMatrix(train_x, label=train_y)
     dtest = xgb.DMatrix(test_x, label=test_y)
 
-    n_round = trial.suggest_int('n_round', 1, 9)
     param = {'silent': 1, 'objective': 'binary:logistic',
              'booster': trial.suggest_categorical('booster', ['gbtree', 'gblinear', 'dart']),
              'lambda': trial.suggest_loguniform('lambda', 1e-8, 1.0),
@@ -54,7 +53,7 @@ def objective(trial):
         param['rate_drop'] = trial.suggest_loguniform('rate_drop', 1e-8, 1.0)
         param['skip_drop'] = trial.suggest_loguniform('skip_drop', 1e-8, 1.0)
 
-    bst = xgb.train(param, dtrain, n_round)
+    bst = xgb.train(param, dtrain)
     preds = bst.predict(dtest)
     pred_labels = np.rint(preds)
     accuracy = sklearn.metrics.accuracy_score(test_y, pred_labels)

--- a/optuna/integration/lightgbm.py
+++ b/optuna/integration/lightgbm.py
@@ -23,8 +23,7 @@ class LightGBMPruningCallback(object):
 
                 param = {'objective': 'binary', 'metric': 'binary_error'}
                 pruning_callback = LightGBMPruningCallback(trial, 'binary_error')
-                gbm = lgb.train(param, dtrain, num_round, valid_sets=[dtest],
-                                callbacks=[pruning_callback])
+                gbm = lgb.train(param, dtrain, valid_sets=[dtest], callbacks=[pruning_callback])
 
     Args:
         trial:

--- a/optuna/integration/xgboost.py
+++ b/optuna/integration/xgboost.py
@@ -22,7 +22,7 @@ class XGBoostPruningCallback(object):
         .. code::
 
                 pruning_callback = XGBoostPruningCallback(trial, 'validation-error')
-                bst = xgb.train(param, dtrain, n_round, evals=[(dtest, 'validation')],
+                bst = xgb.train(param, dtrain, evals=[(dtest, 'validation')],
                                 callbacks=[pruning_callback])
 
 


### PR DESCRIPTION
I updated GBDT examples to use the default value of `num_boost_round` parameter instead of suggested one because tuning of the parameter isn't so meaningful.

FYI. Default value for each library:
- [XGBoost]: `xgboost.train(..., num_boost_round=10, ...)`
- [LightGBM]: `lightgbm.train(..., num_boost_round=100, ...)`

[XGBoost]: https://xgboost.readthedocs.io/en/latest/python/python_api.html#xgboost.train
[LightGBM]: https://lightgbm.readthedocs.io/en/latest/Python-API.html#lightgbm.train