### PR TITLE
Optimize query of count trials.

### DIFF
--- a/optuna/pruners.py
+++ b/optuna/pruners.py
@@ -76,9 +76,7 @@ class MedianPruner(BasePruner):
         # type: (BaseStorage, int, int, int) -> bool
         """Please consult the documentation for :func:`BasePruner.prune`."""
 
-        # TODO(Yanase): Implement a method of storage to just retrieve the number of trials.
-        n_trials = len([t for t in storage.get_all_trials(study_id)
-                        if t.state == TrialState.COMPLETE])
+        n_trials = storage.get_n_trials(study_id, TrialState.COMPLETE)
 
         if n_trials == 0:
             return False

--- a/optuna/storages/rdb/models.py
+++ b/optuna/storages/rdb/models.py
@@ -6,6 +6,7 @@ from sqlalchemy import Enum
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy import Float
 from sqlalchemy import ForeignKey
+from sqlalchemy import func
 from sqlalchemy import Integer
 from sqlalchemy import orm
 from sqlalchemy import String
@@ -171,13 +172,13 @@ class TrialModel(BaseModel):
     def count(cls, session, study=None, state=None):
         # type: (orm.Session, Optional[StudyModel], Optional[TrialState]) -> int
 
-        trials = session.query(cls)
+        trial_count = session.query(func.count(cls.trial_id))
         if study is not None:
-            trials = trials.filter(cls.study_id == study.study_id)
+            trial_count = trial_count.filter(cls.study_id == study.study_id)
         if state is not None:
-            trials = trials.filter(cls.state == state)
+            trial_count = trial_count.filter(cls.state == state)
 
-        return trials.count()
+        return trial_count.scalar()
 
     @classmethod
     def all(cls, session):


### PR DESCRIPTION
This PR optimize a DB query to count trials. It is related to https://github.com/pfnet/optuna/pull/279#discussion_r242764796.

MedianPruner counts trials, and I used it for benchmarking.
The backend storage is sqlite.

The time per query in the following table shows that this PR greatly improve the performance to count trials. It is about ten times faster than master which does not use count query and 1.5 times faster than count query in master.

|method|total time|num of queries|time per query|
| --- | --- | --- | --- |
|master (without count query)|101.65| 3231 | 0.03146|
|count query in master|9.684| 2794 |0.00346|
|count query in this PR|11.03| 4606 |0.00239|
