### PR TITLE
Add an argument to show internal field of dataframe.

### DIFF
--- a/optuna/pruners.py
+++ b/optuna/pruners.py
@@ -76,9 +76,7 @@ class MedianPruner(BasePruner):
         # type: (BaseStorage, int, int, int) -> bool
         """Please consult the documentation for :func:`BasePruner.prune`."""
 
-        # TODO(Yanase): Implement a method of storage to just retrieve the number of trials.
-        n_trials = len([t for t in storage.get_all_trials(study_id)
-                        if t.state == TrialState.COMPLETE])
+        n_trials = storage.get_n_trials(study_id, TrialState.COMPLETE)
 
         if n_trials == 0:
             return False

--- a/optuna/storages/rdb/models.py
+++ b/optuna/storages/rdb/models.py
@@ -6,6 +6,7 @@ from sqlalchemy import Enum
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy import Float
 from sqlalchemy import ForeignKey
+from sqlalchemy import func
 from sqlalchemy import Integer
 from sqlalchemy import orm
 from sqlalchemy import String
@@ -171,13 +172,13 @@ class TrialModel(BaseModel):
     def count(cls, session, study=None, state=None):
         # type: (orm.Session, Optional[StudyModel], Optional[TrialState]) -> int
 
-        trials = session.query(cls)
+        trial_count = session.query(func.count(cls.trial_id))
         if study is not None:
-            trials = trials.filter(cls.study_id == study.study_id)
+            trial_count = trial_count.filter(cls.study_id == study.study_id)
         if state is not None:
-            trials = trials.filter(cls.state == state)
+            trial_count = trial_count.filter(cls.state == state)
 
-        return trials.count()
+        return trial_count.scalar()
 
     @classmethod
     def all(cls, session):

--- a/optuna/study.py
+++ b/optuna/study.py
@@ -249,8 +249,8 @@ class Study(object):
 
         self.storage.set_study_system_attr(self.study_id, key, value)
 
-    def trials_dataframe(self):
-        # type: () -> pd.DataFrame
+    def trials_dataframe(self, show_internal_fields=False):
+        # type: (bool) -> pd.DataFrame
         """Export trials as a pandas DataFrame_.
 
         The DataFrame_ provides various features to analyze studies. It is also useful to draw a
@@ -269,6 +269,12 @@ class Study(object):
             0.0
             >>> df.params.x[0]
             1.0
+
+        Args:
+            show_internal_fields:
+                By default, internal fields of :class:`~optuna.structs.FrozenTrial` are excluded
+                from a DataFrame of trials. If this argument is :obj:`True`, they will be included
+                in the DataFrame.
 
         Returns:
             A pandas DataFrame_ of trials in the :class:`~optuna.study.Study`.
@@ -289,7 +295,7 @@ class Study(object):
 
             record = {}
             for field, value in trial_dict.items():
-                if field in structs.FrozenTrial.internal_fields:
+                if not show_internal_fields and field in structs.FrozenTrial.internal_fields:
                     continue
                 if isinstance(value, dict):
                     for in_field, in_value in value.items():

--- a/optuna/study.py
+++ b/optuna/study.py
@@ -249,7 +249,7 @@ class Study(object):
 
         self.storage.set_study_system_attr(self.study_id, key, value)
 
-    def trials_dataframe(self, show_internal_fields=False):
+    def trials_dataframe(self, include_internal_fields=False):
         # type: (bool) -> pd.DataFrame
         """Export trials as a pandas DataFrame_.
 
@@ -271,7 +271,7 @@ class Study(object):
             1.0
 
         Args:
-            show_internal_fields:
+            include_internal_fields:
                 By default, internal fields of :class:`~optuna.structs.FrozenTrial` are excluded
                 from a DataFrame of trials. If this argument is :obj:`True`, they will be included
                 in the DataFrame.
@@ -295,7 +295,7 @@ class Study(object):
 
             record = {}
             for field, value in trial_dict.items():
-                if not show_internal_fields and field in structs.FrozenTrial.internal_fields:
+                if not include_internal_fields and field in structs.FrozenTrial.internal_fields:
                     continue
                 if isinstance(value, dict):
                     for in_field, in_value in value.items():

--- a/tests/test_study.py
+++ b/tests/test_study.py
@@ -393,7 +393,6 @@ def test_trials_dataframe(storage_mode, include_internal_fields):
     with StorageSupplier(storage_mode) as storage:
         study = optuna.create_study(storage=storage)
         study.optimize(f, n_trials=3)
-        print(study.trials[0].params_in_internal_repr)
         df = study.trials_dataframe(include_internal_fields=include_internal_fields)
         assert len(df) == 3
         # non-nested: 5, params: 2, user_attrs: 1 and 8 in total.

--- a/tests/test_study.py
+++ b/tests/test_study.py
@@ -378,8 +378,8 @@ def test_study_pickle():
 
 
 @pytest.mark.parametrize('storage_mode', STORAGE_MODES)
-@pytest.mark.parametrize('show_internal_fields', [True, False])
-def test_trials_dataframe(storage_mode, show_internal_fields):
+@pytest.mark.parametrize('include_internal_fields', [True, False])
+def test_trials_dataframe(storage_mode, include_internal_fields):
     # type: (str, bool) -> None
 
     def f(trial):
@@ -394,10 +394,10 @@ def test_trials_dataframe(storage_mode, show_internal_fields):
         study = optuna.create_study(storage=storage)
         study.optimize(f, n_trials=3)
         print(study.trials[0].params_in_internal_repr)
-        df = study.trials_dataframe(show_internal_fields=show_internal_fields)
+        df = study.trials_dataframe(include_internal_fields=include_internal_fields)
         assert len(df) == 3
         # non-nested: 5, params: 2, user_attrs: 1 and 8 in total.
-        if show_internal_fields:
+        if include_internal_fields:
             # params_in_internal_repr: 2
             assert len(df.columns) == 8 + 2
         else:
@@ -411,7 +411,7 @@ def test_trials_dataframe(storage_mode, show_internal_fields):
             assert df.params.x[i] == 1
             assert df.params.y[i] == 2.5
             assert df.user_attrs.train_loss[i] == 3
-            if show_internal_fields:
+            if include_internal_fields:
                 assert ('params_in_internal_repr', 'x') in df.columns
                 assert ('params_in_internal_repr', 'y') in df.columns
 


### PR DESCRIPTION
This PR adds an argument to show internal fields of `FrozenTrial` in dataframe.
This argument is used in the future PR which is revised version of https://github.com/pfnet/optuna/pull/279.
In the PR, `FrozenTrial.trial_id` will be an internal field, and users cannot access it without this argument.