### PR TITLE
Integration for TensorFlow's Estimator API

### DIFF
--- a/docs/source/tutorial/pruning.rst
+++ b/docs/source/tutorial/pruning.rst
@@ -79,6 +79,7 @@ To implement pruning mechanism in much simpler forms, Optuna provides integratio
 - LightGBM: :class:`optuna.integration.LightGBMPruningCallback`
 - Chainer: :class:`optuna.integration.ChainerPruningExtension`
 - Keras: :class:`optuna.integration.KerasPruningCallback`
+- TensorFlow :class:`optuna.integration.TensorFlowPruningHook`
 
 For example, :class:`~optuna.integration.XGBoostPruningCallback` introduces pruning without directly changing the logic of training iteration.
 (See also `example <https://github.com/pfnet/optuna/blob/master/examples/pruning/xgboost_integration.py>`_ for the entire script.)

--- a/optuna/integration/__init__.py
+++ b/optuna/integration/__init__.py
@@ -3,3 +3,4 @@ from optuna.integration.chainermn import ChainerMNStudy  # NOQA
 from optuna.integration.keras import KerasPruningCallback  # NOQA
 from optuna.integration.lightgbm import LightGBMPruningCallback  # NOQA
 from optuna.integration.xgboost import XGBoostPruningCallback  # NOQA
+from optuna.integration.tensorflow import TensorFlowPruningHook

--- a/optuna/integration/__init__.py
+++ b/optuna/integration/__init__.py
@@ -2,5 +2,5 @@ from optuna.integration.chainer import ChainerPruningExtension  # NOQA
 from optuna.integration.chainermn import ChainerMNStudy  # NOQA
 from optuna.integration.keras import KerasPruningCallback  # NOQA
 from optuna.integration.lightgbm import LightGBMPruningCallback  # NOQA
+from optuna.integration.tensorflow import TensorFlowPruningHook  # NOQA
 from optuna.integration.xgboost import XGBoostPruningCallback  # NOQA
-from optuna.integration.tensorflow import TensorFlowPruningHook

--- a/optuna/integration/tensorflow.py
+++ b/optuna/integration/tensorflow.py
@@ -77,6 +77,7 @@ class TensorFlowPruningHook(SessionRunHook):
         global_step = run_values.results
         # Get eval metrics every n steps
         if self._timer.should_trigger_for_step(global_step):
+            self._timer.update_last_triggered_step(global_step)
             eval_metrics = tf.contrib.estimator.read_eval_metrics(self.estimator.eval_dir())
         else:
             eval_metrics = None

--- a/optuna/integration/tensorflow.py
+++ b/optuna/integration/tensorflow.py
@@ -9,13 +9,13 @@ try:
     _available = True
 except ImportError as e:
     _import_error = e
-    # PruningHook is disabled because TensorFlow is not available.
+    # TensorFlowPruningHook is disabled because TensorFlow is not available.
     _available = False
     SessionRunHook = object
 
 
 class TensorFlowPruningHook(SessionRunHook):
-    """TensorFlow SessionRunHook to prune umpromising trials.
+    """TensorFlow SessionRunHook to prune unpromising trials.
 
     Example:
 
@@ -23,13 +23,14 @@ class TensorFlowPruningHook(SessionRunHook):
 
         .. code::
 
-                optuna_pruning_hook = OptunaPruningHook(
+                pruning_hook = TensorFlowPruningHook(
                     trial=trial,
                     estimator=clf,
                     metric="accuracy",
                     is_higher_better=True,
                     run_every_steps=10,
                 )
+                hooks = [pruning_hook]
                 tf.estimator.train_and_evaluate(
                     clf,
                     tf.estimator.TrainSpec(input_fn=train_input_fn, max_steps=500, hooks=hooks),
@@ -40,7 +41,7 @@ class TensorFlowPruningHook(SessionRunHook):
             A :class:`~optuna.trial.Trial` corresponding to the current evaluation of
             the objective function.
         estimator:
-            A :estimator which you will use.
+            An estimator which you will use.
         metric:
             An evaluation metric for pruning, e.g., ``accuracy`` and ``loss``.
         is_higher_better:

--- a/optuna/integration/tensorflow.py
+++ b/optuna/integration/tensorflow.py
@@ -1,0 +1,96 @@
+from __future__ import absolute_import
+
+import optuna
+
+
+try:
+    import tensorflow as tf
+    _available = True
+except ImportError as e:
+    _import_error = e
+    # PruningHook is disabled because TensorFlow is not available.
+    _available = False
+
+
+class TensorFlowPruningHook(tf.train.SessionRunHook):
+    """TensorFlow SessionRunHook to prune umpromising trials.
+
+    Example:
+
+        Add a pruning SessionRunHook which observes validation scores to training of a TensorFlow's Estimator.
+
+        .. code::
+
+                optuna_pruning_hook = OptunaPruningHook(
+                    trial=trial,
+                    estimator=clf,
+                    metric="accuracy",
+                    is_higher_better=True,
+                    run_every_steps=10,
+                )
+                tf.estimator.train_and_evaluate(
+                    clf,
+                    tf.estimator.TrainSpec(input_fn=train_input_fn, max_steps=500, hooks=hooks),
+                    eval_spec
+                )
+    Args:
+        trial:
+            A :class:`~optuna.trial.Trial` corresponding to the current evaluation of
+            the objective function.
+        estimator:
+            A :estimator which you will use.
+        metric:
+            An evaluation metric for pruning, e.g., ``accuracy`` and ``loss``.
+        is_higher_better:
+           It should be True if you use a metric to be maximize such as ``loss`.
+        run_every_steps:
+           An interval to watch the summary file.
+    """
+    def __init__(self, trial, estimator, metric, is_higher_better, run_every_steps):
+        self.trial = trial
+        self.estimator = estimator
+        self.current_summary_step = -1
+        self.metric = metric
+        self.is_higher_better = is_higher_better
+        self._global_step_tensor = None
+        self._timer = tf.train.SecondOrStepTimer(every_secs=None, every_steps=run_every_steps)
+
+    def begin(self):
+        self._global_step_tensor = tf.train.get_global_step()
+
+    def before_run(self, run_context):
+        del run_context
+        return tf.train.SessionRunArgs(self._global_step_tensor)
+
+    def after_run(self, run_context, run_value):
+        global_step = run_value.results
+        # Get eval metrics every n steps
+        if self._timer.should_trigger_for_step(global_step):
+            eval_metrics = tf.contrib.estimator.read_eval_metrics(self.estimator.eval_dir())
+        else:
+            eval_metrics = None
+        if eval_metrics:
+            summary_step = next(reversed(eval_metrics))
+            latest_eval_metrics = eval_metrics[summary_step]
+            # If there exists a new evaluation summary
+            if summary_step > self.current_summary_step:
+                if self.is_higher_better:
+                    current_score = 1.0 - latest_eval_metrics[self.metric]
+                else:
+                    current_score = latest_eval_metrics[self.metric]
+                self.trial.report(current_score, step=summary_step)
+                self.current_summary_step = summary_step
+            if self.trial.should_prune(self.current_summary_step):
+                message = "Trial was pruned at iteration {}.".format(self.current_summary_step)
+                raise optuna.structs.TrialPruned(message)
+
+
+def _check_tensorflow_availability():
+    # type: () -> None
+
+    if not _available:
+        raise ImportError(
+            'TensorFlow is not available. Please install TensorFlow to use this feature. '
+            'TensorFlow can be installed by executing `$ pip install tensorflow`. '
+            'For further information, please refer to the installation guide of TensorFlow. '
+            '(The actual import error is as follows: ' + str(_import_error) + ')')

--- a/optuna/integration/tensorflow.py
+++ b/optuna/integration/tensorflow.py
@@ -19,7 +19,7 @@ class TensorFlowPruningHook(SessionRunHook):
 
     Example:
 
-        Add a pruning SessionRunHook which observes validation scores to training of a TensorFlow's Estimator.
+        Add a pruning SessionRunHook for a TensorFlow's Estimator.
 
         .. code::
 

--- a/optuna/integration/tensorflow.py
+++ b/optuna/integration/tensorflow.py
@@ -50,6 +50,8 @@ class TensorFlowPruningHook(SessionRunHook):
            An interval to watch the summary file.
     """
     def __init__(self, trial, estimator, metric, is_higher_better, run_every_steps):
+        # type: (optuna.trial.Trial, tf.estimator.Estimator, str, bool, int) -> None
+
         self.trial = trial
         self.estimator = estimator
         self.current_summary_step = -1
@@ -59,14 +61,20 @@ class TensorFlowPruningHook(SessionRunHook):
         self._timer = tf.train.SecondOrStepTimer(every_secs=None, every_steps=run_every_steps)
 
     def begin(self):
+        # type: () -> None
+
         self._global_step_tensor = tf.train.get_global_step()
 
     def before_run(self, run_context):
+        # type: (tf.train.SessionRunContext) -> tf.train.SessionRunArgs
+
         del run_context
         return tf.train.SessionRunArgs(self._global_step_tensor)
 
-    def after_run(self, run_context, run_value):
-        global_step = run_value.results
+    def after_run(self, run_context, run_values):
+        # type: (tf.train.SessionRunContext, tf.train.SessionRunValues) -> None
+
+        global_step = run_values.results
         # Get eval metrics every n steps
         if self._timer.should_trigger_for_step(global_step):
             eval_metrics = tf.contrib.estimator.read_eval_metrics(self.estimator.eval_dir())

--- a/optuna/integration/tensorflow.py
+++ b/optuna/integration/tensorflow.py
@@ -5,14 +5,16 @@ import optuna
 
 try:
     import tensorflow as tf
+    from tensorflow.train import SessionRunHook
     _available = True
 except ImportError as e:
     _import_error = e
     # PruningHook is disabled because TensorFlow is not available.
     _available = False
+    SessionRunHook = object
 
 
-class TensorFlowPruningHook(tf.train.SessionRunHook):
+class TensorFlowPruningHook(SessionRunHook):
     """TensorFlow SessionRunHook to prune umpromising trials.
 
     Example:

--- a/optuna/integration/tensorflow.py
+++ b/optuna/integration/tensorflow.py
@@ -42,7 +42,7 @@ class TensorFlowPruningHook(tf.train.SessionRunHook):
         metric:
             An evaluation metric for pruning, e.g., ``accuracy`` and ``loss``.
         is_higher_better:
-           It should be True if you use a metric to be maximize such as ``loss`.
+           It should be True if you use a metric to be maximize such as ``loss``.
         run_every_steps:
            An interval to watch the summary file.
     """

--- a/tests/integration_tests/test_tensorflow.py
+++ b/tests/integration_tests/test_tensorflow.py
@@ -18,7 +18,7 @@ def fixed_value_input_fn():
     x_train = np.zeros([16, 20])
     y_train = np.zeros(16)
     dataset = tf.data.Dataset.from_tensor_slices((x_train, y_train))
-    dataset = dataset.shuffle(128).repeat().batch(16)
+    dataset = dataset.repeat().batch(8)
     iterator = dataset.make_one_shot_iterator()
     features, labels = iterator.get_next()
     return {"x": features}, labels

--- a/tests/integration_tests/test_tensorflow.py
+++ b/tests/integration_tests/test_tensorflow.py
@@ -1,6 +1,7 @@
 import numpy as np
 
 import pytest
+import typing  # NOQA
 
 try:
     import tensorflow as tf
@@ -15,6 +16,8 @@ from optuna.testing.integration import DeterministicPruner
 
 
 def fixed_value_input_fn():
+    # type: () -> typing.Tuple[typing.Dict[str, tf.Tensor], tf.Tensor]
+
     x_train = np.zeros([16, 20])
     y_train = np.zeros(16)
     dataset = tf.data.Dataset.from_tensor_slices((x_train, y_train))

--- a/tests/integration_tests/test_tensorflow.py
+++ b/tests/integration_tests/test_tensorflow.py
@@ -29,7 +29,8 @@ def test_tensorflow_pruning_hook():
 
     # TODO(sfujiwara): remove this "if" section after TensorFlow supports Python 3.7.
     if not _available:
-        pytest.skip('This test requires TensorFlow but this version can not install TensorFlow with pip.')
+        pytest.skip('This test requires TensorFlow '
+                    'but this version can not install TensorFlow with pip.')
 
     def objective(trial):
         # type: (optuna.trial.Trial) -> float
@@ -48,7 +49,11 @@ def test_tensorflow_pruning_hook():
             is_higher_better=True,
             run_every_steps=5,
         )
-        train_spec = tf.estimator.TrainSpec(input_fn=fixed_value_input_fn, max_steps=100, hooks=[hook])
+        train_spec = tf.estimator.TrainSpec(
+            input_fn=fixed_value_input_fn,
+            max_steps=100,
+            hooks=[hook]
+        )
         eval_spec = tf.estimator.EvalSpec(input_fn=fixed_value_input_fn, steps=1, hooks=[])
         tf.estimator.train_and_evaluate(estimator=clf, train_spec=train_spec, eval_spec=eval_spec)
         return 1.0

--- a/tests/integration_tests/test_tensorflow.py
+++ b/tests/integration_tests/test_tensorflow.py
@@ -1,0 +1,63 @@
+import numpy as np
+
+import pytest
+
+try:
+    import tensorflow as tf
+    _available = True
+except ImportError:
+    _available = False
+
+
+import optuna
+from optuna.integration import TensorFlowPruningHook
+from optuna.testing.integration import DeterministicPruner
+
+
+def fixed_value_input_fn():
+    x_train = np.zeros([16, 20])
+    y_train = np.zeros(16)
+    dataset = tf.data.Dataset.from_tensor_slices((x_train, y_train))
+    dataset = dataset.shuffle(128).repeat().batch(16)
+    iterator = dataset.make_one_shot_iterator()
+    features, labels = iterator.get_next()
+    return {"x": features}, labels
+
+
+def test_tensorflow_pruning_hook():
+    # type: () -> None
+
+    # TODO(sfujiwara): remove this "if" section after TensorFlow supports Python 3.7.
+    if not _available:
+        pytest.skip('This test requires TensorFlow but this version can not install TensorFlow with pip.')
+
+    def objective(trial):
+        # type: (optuna.trial.Trial) -> float
+
+        clf = tf.estimator.DNNClassifier(
+            hidden_units=[],
+            feature_columns=[tf.feature_column.numeric_column(key="x", shape=[20])],
+            model_dir=None,
+            n_classes=2,
+            config=tf.estimator.RunConfig(save_summary_steps=10, save_checkpoints_steps=10),
+        )
+        hook = TensorFlowPruningHook(
+            trial=trial,
+            estimator=clf,
+            metric="accuracy",
+            is_higher_better=True,
+            run_every_steps=5,
+        )
+        train_spec = tf.estimator.TrainSpec(input_fn=fixed_value_input_fn, max_steps=100, hooks=[hook])
+        eval_spec = tf.estimator.EvalSpec(input_fn=fixed_value_input_fn, steps=1, hooks=[])
+        tf.estimator.train_and_evaluate(estimator=clf, train_spec=train_spec, eval_spec=eval_spec)
+        return 1.0
+
+    study = optuna.create_study(pruner=DeterministicPruner(True))
+    study.optimize(objective, n_trials=1)
+    assert study.trials[0].state == optuna.structs.TrialState.PRUNED
+
+    study = optuna.create_study(pruner=DeterministicPruner(False))
+    study.optimize(objective, n_trials=1)
+    assert study.trials[0].state == optuna.structs.TrialState.COMPLETE
+    assert study.trials[0].value == 1.0


### PR DESCRIPTION
I implemented `TensorFlowPruningHook` for TensorFlow's Estimator API with [SessionRunHook](https://www.tensorflow.org/api_docs/python/tf/train/SessionRunHook).
We can use it as below (full example is [here](https://gist.github.com/sfujiwara/fa3b763943a1d4758a01c89a8f3df2a5)):

```python
def objective(trial):
    save_steps = 50
    # Create input functions for train and eval
    train_input_fn, eval_input_fn = create_input_fn()
    # Hyper parameters to be tuned with Optuna
    learning_rate = trial.suggest_loguniform("learning_rate", 1e-5, 1e-2)
    # Create Estimator config
    config = tf.estimator.RunConfig(save_summary_steps=save_steps, save_checkpoints_steps=save_steps)
    # Create Estimator
    clf = tf.estimator.DNNClassifier(
        feature_columns=[tf.feature_column.numeric_column(key="x", shape=[4])],
        n_classes=3,
        hidden_units=[],
        optimizer=tf.train.GradientDescentOptimizer(learning_rate=learning_rate),
        model_dir="outputs_pruning/lr_{}".format(learning_rate),
        config=config
    )
    # Create hooks
    early_stopping_hook = tf.contrib.estimator.stop_if_no_decrease_hook(clf, "accuracy", save_steps)
    optuna_pruning_hook = TensorFlowPruningHook(
        trial=trial,
        estimator=clf,
        metrics_name="accuracy",
        is_higher_better=True,
        run_every_steps=10,
    )
    hooks = [early_stopping_hook, optuna_pruning_hook]
    # Create TrainSpec and EvalSpec
    train_spec = tf.estimator.TrainSpec(input_fn=train_input_fn, max_steps=500, hooks=hooks)
    eval_spec = tf.estimator.EvalSpec(input_fn=eval_input_fn, steps=1000, start_delay_secs=0, throttle_secs=0)
    # Run training and evaluation
    tf.estimator.train_and_evaluate(clf, train_spec, eval_spec)
    result = clf.evaluate(input_fn=eval_input_fn, steps=100)
    accuracy = result["accuracy"]
    return 1.0 - accuracy
```

Note that multi-node distributed learning is not considered yet.