### PR TITLE
Enable `--disallow-untyped-defs` mypy flag.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,8 +66,8 @@ jobs:
           name: mypy
           command: |
             . venv/bin/activate
-            mypy --ignore-missing-imports .
-            mypy --py2 --ignore-missing-imports .
+            mypy --disallow-untyped-defs --ignore-missing-imports .
+            mypy --py2 --disallow-untyped-defs --ignore-missing-imports .
 
   document:
     docker:

--- a/optuna/dashboard.py
+++ b/optuna/dashboard.py
@@ -231,6 +231,8 @@ if _available:
 
 
 def _check_bokeh_availability():
+    # type: () -> None
+
     if not _available:
         raise ImportError(
             'Bokeh is not available. Please install Bokeh to use the dashboard. '
@@ -240,6 +242,8 @@ def _check_bokeh_availability():
 
 
 def _show_experimental_warning():
+    # type: () -> None
+
     logger = optuna.logging.get_logger(__name__)
     logger.warning('Optuna dashboard is still highly experimental. Please use with caution!')
 

--- a/optuna/integration/chainermn.py
+++ b/optuna/integration/chainermn.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
+from typing import Any  # NOQA
 from typing import Callable  # NOQA
 from typing import Optional  # NOQA
 from typing import Tuple  # NOQA
@@ -127,9 +128,13 @@ class ChainerMNStudy(object):
                 func(trial, self.comm)
 
     def __getattr__(self, attr_name):
+        # type: (str) -> Any
+
         return getattr(self.delegate, attr_name)
 
     def __setattr__(self, attr_name, value):
+        # type: (str, Any) -> None
+
         setattr(self.delegate, attr_name, value)
 
 

--- a/optuna/study.py
+++ b/optuna/study.py
@@ -3,6 +3,7 @@ import datetime
 import math
 import multiprocessing
 import multiprocessing.pool
+from multiprocessing import Queue  # NOQA
 import pandas as pd
 from six.moves import queue
 import time
@@ -355,6 +356,8 @@ class Study(object):
         # A queue is passed to each thread. When True is received, then the thread continues
         # the evaluation. When False is received, then it quits.
         def func_child_thread(que):
+            # type: (Queue) -> None
+
             while que.get():
                 self._run_trial(func, catch)
             self.storage.remove_session()

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,17 @@
 import os
 import pkg_resources
+from pkg_resources import Distribution  # NOQA
 from setuptools import find_packages
 from setuptools import setup
 import sys
+from typing import Dict  # NOQA
+from typing import List  # NOQA
+from typing import Optional  # NOQA
 
 
 def get_version():
+    # type: () -> str
+
     version_filepath = os.path.join(os.path.dirname(__file__), 'optuna', 'version.py')
     with open(version_filepath) as f:
         for line in f:
@@ -15,6 +21,8 @@ def get_version():
 
 
 def get_install_requires():
+    # type: () -> List[str]
+
     install_requires = [
         'sqlalchemy>=1.1.0', 'numpy', 'scipy', 'six', 'typing', 'cliff', 'colorlog', 'pandas']
     if sys.version_info[0] == 2:
@@ -23,6 +31,8 @@ def get_install_requires():
 
 
 def get_extras_require():
+    # type: () -> Dict[str, List[str]]
+
     extras_require = {
         'checking': ['autopep8', 'hacking'],
         'testing': ['pytest', 'mock', 'bokeh', 'chainer>=5.0.0', 'xgboost', 'mpi4py', 'lightgbm'],
@@ -36,6 +46,8 @@ def get_extras_require():
 
 
 def find_any_distribution(pkgs):
+    # type: (List[str]) -> Optional[Distribution]
+
     for pkg in pkgs:
         try:
             return pkg_resources.get_distribution(pkg)

--- a/setup.py
+++ b/setup.py
@@ -4,9 +4,16 @@ from pkg_resources import Distribution  # NOQA
 from setuptools import find_packages
 from setuptools import setup
 import sys
-from typing import Dict  # NOQA
-from typing import List  # NOQA
-from typing import Optional  # NOQA
+
+try:
+    from typing import Dict  # NOQA
+    from typing import List  # NOQA
+    from typing import Optional  # NOQA
+except ImportError:
+    # Built-in `typing` module is only available in Python 3.5 or newer.
+    # The above imports are only used by `mypy`, so we simply ignore them
+    # if they are unavailable in the execution environment.
+    pass
 
 
 def get_version():

--- a/tests/storages_tests/rdb_tests/test_models.py
+++ b/tests/storages_tests/rdb_tests/test_models.py
@@ -28,18 +28,23 @@ class TestStudySystemAttributeModel(object):
 
     @staticmethod
     def test_find_by_study_and_key(session):
+        # type: (Session) -> None
+
         study = StudyModel(study_id=1, study_name='test-study')
         session.add(StudySystemAttributeModel(study_id=study.study_id, key='sample-key',
                                               value_json='1'))
         session.commit()
 
-        assert '1' == StudySystemAttributeModel.find_by_study_and_key(study, 'sample-key',
-                                                                      session).value_json
+        attr = StudySystemAttributeModel.find_by_study_and_key(study, 'sample-key', session)
+        assert attr is not None and '1' == attr.value_json
+
         assert StudySystemAttributeModel.find_by_study_and_key(study, 'not-found',
                                                                session) is None
 
     @staticmethod
     def test_where_study_id(session):
+        # type: (Session) -> None
+
         sample_study = StudyModel(study_id=1, study_name='test-study')
         empty_study = StudyModel(study_id=2, study_name='test-study')
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -258,6 +258,8 @@ def test_dashboard_command(options):
 @pytest.mark.parametrize('origins', [['192.168.111.1:5006'],
                                      ['192.168.111.1:5006', '192.168.111.2:5006']])
 def test_dashboard_command_with_allow_websocket_origin(origins):
+    # type: (List[str]) -> None
+
     with \
             StorageConfigSupplier(TEST_CONFIG_TEMPLATE) as (storage_url, config_path), \
             tempfile.NamedTemporaryFile('r') as tf_report:

--- a/tests/test_study.py
+++ b/tests/test_study.py
@@ -207,6 +207,8 @@ def test_optimize_with_catch(storage_mode):
         study = optuna.create_study(storage=storage)
 
         def func_value_error(_):
+            # type: (optuna.trial.Trial) -> float
+
             raise ValueError
 
         # Test acceptable exception.
@@ -319,6 +321,8 @@ def test_run_trial(storage_mode):
 
         # Test trial with acceptable exception.
         def func_value_error(_):
+            # type: (optuna.trial.Trial) -> float
+
             raise ValueError
 
         trial = study._run_trial(func_value_error, catch=(ValueError,))
@@ -335,7 +339,9 @@ def test_run_trial(storage_mode):
 
         # Test trial with invalid objective value: None
         def func_none(_):
-            return None
+            # type: (optuna.trial.Trial) -> float
+
+            return None  # type: ignore
 
         trial = study._run_trial(func_none, catch=(Exception,))
         frozen_trial = study.storage.get_trial(trial.trial_id)
@@ -348,6 +354,8 @@ def test_run_trial(storage_mode):
 
         # Test trial with invalid objective value: nan
         def func_nan(_):
+            # type: (optuna.trial.Trial) -> float
+
             return float('nan')
 
         trial = study._run_trial(func_nan, catch=(Exception,))


### PR DESCRIPTION
This PR enables [`--disallow-untyped-defs`](https://mypy.readthedocs.io/en/stable/command_line.html#untyped-definitions-and-calls) mypy flag and adds type hints to untyped functions.