### PR TITLE
Add a blank line to show code example.

### DIFF
--- a/optuna/visualization.py
+++ b/optuna/visualization.py
@@ -22,6 +22,7 @@ def plot_intermediate_values(study):
         The following code snippet shows how to plot intermediate values inside Jupyter Notebook.
 
         .. code::
+
             import optuna
 
             def objective(trial):


### PR DESCRIPTION
Currently, the code example of intermediate value plot is not shown in the [document](https://optuna.readthedocs.io/en/stable/reference/visualization.html). This PR fixes this issue. 

<img width="709" alt="2019-01-24 13 30 09" src="https://user-images.githubusercontent.com/3255979/51654937-a6e88300-1fdd-11e9-9aa0-3ed724533303.png">
