### PR TITLE
Remove the workaround for numpy-v1.16.0.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,14 +164,6 @@ jobs:
             . venv/bin/activate
             pip install chainer lightgbm scikit-learn xgboost
 
-            # Using numpy-v1.16.0, the execution of `chainermn_simple.py` fails by memory shortage.
-            # To deal with this problem, we fix the version of numpy to v1.15.4.
-            #
-            # TODO(ohta):
-            # numpy-v1.16.1 may resolve this issue (https://github.com/numpy/numpy/pull/12624).
-            # Try the version when it is released.
-            pip install --force-reinstall numpy==1.15.4
-
       - run: &examples
           name: examples
           command: |


### PR DESCRIPTION
By using numpy-v1.16.1, the memory usage of `examples/chainermn_simple.py` was drastically reduced compared to numpy-v1.16.0.
Therefore I remove the workaround introduced at https://github.com/pfnet/optuna/pull/303.

```console
# numpy-v1.16.0  (memory usage = 6GB)
$ time -v python3 examples/chainermn_simple.py $STUDY_NAME $STORAGE_URL
        User time (seconds): 51.71
        System time (seconds): 52.23
        Percent of CPU this job got: 192%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 0:54.08
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 6042540       # 6GB
        Average resident set size (kbytes): 0
        Major (requiring I/O) page faults: 0
        Minor (reclaiming a frame) page faults: 4232913
        Voluntary context switches: 0
        Involuntary context switches: 0
        Swaps: 0
        File system inputs: 0
        File system outputs: 0
        Socket messages sent: 0
        Socket messages received: 0
        Signals delivered: 0
        Page size (bytes): 4096
        Exit status: 0

# numpy-v1.16.1  (memory usage = 900MB)
$ time -v python3 examples/chainermn_simple.py $STUDY_NAME $STORAGE_URL
        User time (seconds): 50.32
        System time (seconds): 52.03
        Percent of CPU this job got: 190%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 0:53.65
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 894284    # 900MB
        Average resident set size (kbytes): 0
        Major (requiring I/O) page faults: 0
        Minor (reclaiming a frame) page faults: 4048605
        Voluntary context switches: 0
        Involuntary context switches: 0
        Swaps: 0
        File system inputs: 0
        File system outputs: 0
        Socket messages sent: 0
        Socket messages received: 0
        Signals delivered: 0
        Page size (bytes): 4096
        Exit status: 0
```