### PR TITLE
Fix the range of return values of Trial.suggest_discrete_uniform().

### DIFF
--- a/optuna/samplers/random.py
+++ b/optuna/samplers/random.py
@@ -1,5 +1,7 @@
 import math
 import numpy
+from typing import Any  # NOQA
+from typing import Dict  # NOQA
 from typing import Optional  # NOQA
 
 from optuna import distributions
@@ -74,4 +76,3 @@ class RandomSampler(BaseSampler):
 
         self.__dict__.update(state)
         self.logger = logging.get_logger(__name__)
-

--- a/optuna/samplers/random.py
+++ b/optuna/samplers/random.py
@@ -47,8 +47,10 @@ class RandomSampler(BaseSampler):
             shifted_high = param_distribution.high - param_distribution.low
             if math.fmod(shifted_high, q) != 0:
                 shifted_high = (shifted_high // q) * q
-                self.logger.warning('`high` of suggest_discrete_uniform is not a multiple of `q`,'
-                                    ' and it will be replaced with {}.'.format(shifted_high))
+                self.logger.warning('`high - low` is not divisible by `q`. The range of '
+                                    'Trial.suggest_discrete_uniform() is replaced by [{}, {}].'
+                                    .format(param_distribution.low,
+                                            shifted_high + param_distribution.low))
             low = shifted_low - 0.5 * q
             high = shifted_high + 0.5 * q
             s = self.rng.uniform(low, high)

--- a/optuna/samplers/random.py
+++ b/optuna/samplers/random.py
@@ -1,7 +1,9 @@
+import math
 import numpy
 from typing import Optional  # NOQA
 
 from optuna import distributions
+from optuna import logging
 from optuna.samplers.base import BaseSampler
 from optuna.storages.base import BaseStorage  # NOQA
 
@@ -25,6 +27,7 @@ class RandomSampler(BaseSampler):
 
         self.seed = seed
         self.rng = numpy.random.RandomState(seed)
+        self.logger = logging.get_logger(__name__)
 
     def sample(self, storage, study_id, param_name, param_distribution):
         # type: (BaseStorage, int, str, distributions.BaseDistribution) -> float
@@ -38,10 +41,16 @@ class RandomSampler(BaseSampler):
             return numpy.exp(self.rng.uniform(log_low, log_high))
         elif isinstance(param_distribution, distributions.DiscreteUniformDistribution):
             q = param_distribution.q
-            low = param_distribution.low - 0.5 * q
-            high = param_distribution.high + 0.5 * q
+            shifted_low = 0
+            shifted_high = param_distribution.high - param_distribution.low
+            if math.fmod(shifted_high, q) != 0:
+                shifted_high = (shifted_high // q) * q
+                self.logger.warning('`high` of suggest_discrete_uniform is not a multiple of `q`,'
+                                    ' and it will be replaced with {}.'.format(shifted_high))
+            low = shifted_low - 0.5 * q
+            high = shifted_high + 0.5 * q
             s = self.rng.uniform(low, high)
-            v = numpy.round(s / q) * q
+            v = numpy.round(s / q) * q + param_distribution.low
             # v may slightly exceed range due to round-off errors.
             return min(max(v, param_distribution.low), param_distribution.high)
         elif isinstance(param_distribution, distributions.IntUniformDistribution):

--- a/optuna/samplers/random.py
+++ b/optuna/samplers/random.py
@@ -61,3 +61,17 @@ class RandomSampler(BaseSampler):
             return self.rng.randint(len(choices))
         else:
             raise NotImplementedError
+
+    def __getstate__(self):
+        # type: () -> Dict[Any, Any]
+
+        state = self.__dict__.copy()
+        del state['logger']
+        return state
+
+    def __setstate__(self, state):
+        # type: (Dict[Any, Any]) -> None
+
+        self.__dict__.update(state)
+        self.logger = logging.get_logger(__name__)
+

--- a/optuna/samplers/tpe/sampler.py
+++ b/optuna/samplers/tpe/sampler.py
@@ -152,8 +152,10 @@ class TPESampler(base.BaseSampler):
         shifted_high = distribution.high - distribution.low
         if math.fmod(shifted_high, q) != 0:
             shifted_high = (shifted_high // q) * q
-            self.logger.warning('`high` of suggest_discrete_uniform is not a multiple of `q`,'
-                                ' and it will be replaced with {}.'.format(shifted_high))
+            self.logger.warning('`high - low` is not divisible by `q`. The range of '
+                                'Trial.suggest_discrete_uniform() is replaced by [{}, {}].'
+                                .format(distribution.low,
+                                        shifted_high + distribution.low))
         low = shifted_low - 0.5 * q
         high = shifted_high + 0.5 * q
 

--- a/optuna/samplers/tpe/sampler.py
+++ b/optuna/samplers/tpe/sampler.py
@@ -151,7 +151,7 @@ class TPESampler(base.BaseSampler):
         q = distribution.q
 
         best_sample = self._sample_numerical(low, high, below, above, q=q)
-        return min(max(best_sample, low), high)
+        return min(max(best_sample, distribution.low), distribution.high)
 
     def _sample_int(self, distribution, below, above):
         # type: (distributions.IntUniformDistribution, np.ndarray, np.ndarray) -> float

--- a/optuna/samplers/tpe/sampler.py
+++ b/optuna/samplers/tpe/sampler.py
@@ -1,7 +1,9 @@
 import math
 import numpy as np
 import scipy.special
+from typing import Any  # NOQA
 from typing import Callable  # NOQA
+from typing import Dict  # NOQA
 from typing import List  # NOQA
 from typing import Optional  # NOQA
 from typing import Tuple  # NOQA

--- a/optuna/samplers/tpe/sampler.py
+++ b/optuna/samplers/tpe/sampler.py
@@ -441,3 +441,16 @@ class TPESampler(base.BaseSampler):
         numerator = np.maximum(np.sqrt(2) * sigma, EPS)
         z = denominator / numerator
         return .5 + .5 * scipy.special.erf(z)
+
+    def __getstate__(self):
+        # type: () -> Dict[Any, Any]
+
+        state = self.__dict__.copy()
+        del state['logger']
+        return state
+
+    def __setstate__(self, state):
+        # type: (Dict[Any, Any]) -> None
+
+        self.__dict__.update(state)
+        self.logger = logging.get_logger(__name__)

--- a/optuna/trial.py
+++ b/optuna/trial.py
@@ -187,9 +187,9 @@ class Trial(BaseTrial):
         """Suggest a value for the discrete parameter.
 
         The value is sampled from the range ``[low, high]``, and the step of discretization is
-        ``q``. More specifically, the returned value are ``low, low + q, low + 2 * q, ... ,
-        low + k * q <= high``, where ``k`` is an integer. Note that ``high`` may be excluded from
-        ranges due to round-off errors if ``q`` is not an integer.
+        ``q``. More specifically, this method returns one of the values in the sequence ``low,
+        low + q, low + 2 * q, ..., low + k * q <= high``, where `k`` denotes an integer. Note that
+        ``high`` may be excluded from ranges due to round-off errors if ``q`` is not an integer.
 
         Example:
 

--- a/optuna/trial.py
+++ b/optuna/trial.py
@@ -184,7 +184,9 @@ class Trial(BaseTrial):
         """Suggest a value for the discrete parameter.
 
         The value is sampled from the range ``[low, high]``, and the step of discretization is
-        ``q``.
+        ``q``. Note that ``high`` will be changed to the largest multiple of ``q`` that is smaller
+        than ``high`` if ``math.fmod(high, q) != 0``. For example, ``(low, high, q)=(0, 10, 3)``
+        is interpreted as ``(low, high, q)=(0, 9, 3)`` by this method.
 
         Example:
 

--- a/optuna/trial.py
+++ b/optuna/trial.py
@@ -1,7 +1,9 @@
 import abc
+import math
 import six
 
 from optuna import distributions
+from optuna import logging
 from optuna import types
 
 if types.TYPE_CHECKING:
@@ -112,6 +114,7 @@ class Trial(BaseTrial):
 
         self.study_id = self.study.study_id
         self.storage = self.study.storage
+        self.logger = logging.get_logger(__name__)
 
     def suggest_uniform(self, name, low, high):
         # type: (str, float, float) -> float
@@ -185,7 +188,8 @@ class Trial(BaseTrial):
 
         The value is sampled from the range ``[low, high]``, and the step of discretization is
         ``q``. More specifically, the returned value are ``low, low + q, low + 2 * q, ... ,
-        low + k * q <=high``, where ``k`` is an integer.
+        low + k * q <= high``, where ``k`` is an integer. Note that ``high`` may be excluded from
+        ranges due to round-off errors if ``q`` is not an integer.
 
         Example:
 
@@ -214,6 +218,13 @@ class Trial(BaseTrial):
         Returns:
             A suggested float value.
         """
+
+        r = high - low
+
+        if math.fmod(r, q) != 0:
+            high = (r // q) * q + low
+            self.logger.warning('The range of parameter `{}` is not divisible by `q`, and is '
+                                'replaced by [{}, {}].'.format(name, low, high))
 
         discrete = distributions.DiscreteUniformDistribution(low=low, high=high, q=q)
         return self._suggest(name, discrete)

--- a/optuna/trial.py
+++ b/optuna/trial.py
@@ -184,9 +184,8 @@ class Trial(BaseTrial):
         """Suggest a value for the discrete parameter.
 
         The value is sampled from the range ``[low, high]``, and the step of discretization is
-        ``q``. Note that ``high`` will be changed to the largest multiple of ``q`` that is smaller
-        than ``high`` if ``math.fmod(high, q) != 0``. For example, ``(low, high, q)=(0, 10, 3)``
-        is interpreted as ``(low, high, q)=(0, 9, 3)`` by this method.
+        ``q``. More specifically, the returned value are ``low, low + q, low + 2 * q, ... ,
+        low + k * q <=high``, where ``k`` is an integer.
 
         Example:
 

--- a/tests/samplers_tests/test_samplers.py
+++ b/tests/samplers_tests/test_samplers.py
@@ -1,9 +1,18 @@
+import math
 import numpy as np
 import pytest
 import typing  # NOQA
 
 import optuna
+from optuna.distributions import CategoricalDistribution
+from optuna.distributions import DiscreteUniformDistribution
+from optuna.distributions import IntUniformDistribution
+from optuna.distributions import LogUniformDistribution
+from optuna.distributions import UniformDistribution
+from optuna.samplers import BaseSampler  # NOQA
 
+if optuna.types.TYPE_CHECKING:
+    from optuna.trial import T  # NOQA
 
 parametrize_sampler = pytest.mark.parametrize(
     'sampler_class',
@@ -12,56 +21,162 @@ parametrize_sampler = pytest.mark.parametrize(
 
 
 @parametrize_sampler
-def test_uniform(sampler_class):
-    # type: (typing.Callable[[], optuna.samplers.BaseSampler]) -> None
+@pytest.mark.parametrize('distribution', [UniformDistribution(-1., 1.),
+                                          UniformDistribution(0., 1.),
+                                          UniformDistribution(-1., 0.)])
+def test_uniform(sampler_class, distribution):
+    # type: (typing.Callable[[], BaseSampler], UniformDistribution) -> None
 
-    storage = optuna.storages.get_storage(None)
-    study_id = storage.create_new_study_id()
+    def objective(trial):
+        # type: (optuna.trial.Trial) -> float
 
-    sampler = sampler_class()
-    distribution = optuna.distributions.UniformDistribution(-1., 1.)
-    points = np.array([sampler.sample(storage, study_id, 'x', distribution) for _ in range(100)])
-    assert np.all(points >= -1.)
-    assert np.all(points < 1.)
+        return trial.suggest_uniform('x', distribution.low, distribution.high)
 
+    def check(study):
+        # type: (optuna.study.Study) -> None
 
-@parametrize_sampler
-def test_discrete_uniform(sampler_class):
-    # type: (typing.Callable[[], optuna.samplers.BaseSampler]) -> None
+        points = np.array([study.sampler.sample(study.storage, study.study_id, 'x', distribution)
+                           for _ in range(100)])
+        assert np.all(points >= distribution.low)
+        assert np.all(points < distribution.high)
 
-    sampler = sampler_class()
+    _study = optuna.study.create_study(sampler=sampler_class())
 
-    # Test to sample integer value: q = 1
-    storage = optuna.storages.get_storage(None)
-    study_id = storage.create_new_study_id()
+    check(_study)
 
-    distribution = optuna.distributions.DiscreteUniformDistribution(-10., 10., 1.)
-    points = np.array([sampler.sample(storage, study_id, 'x', distribution) for _ in range(100)])
-    assert np.all(points >= -10)
-    assert np.all(points <= 10)
-    round_points = np.round(points)
-    np.testing.assert_almost_equal(round_points, points)
+    # Execute optimization for samplers which have startup trials such as TPESampler.
+    _study.optimize(objective, n_trials=10)
 
-    # Test to sample quantized floating point value: [-10.2, 10.2], q = 0.1
-    distribution = optuna.distributions.DiscreteUniformDistribution(-10.2, 10.2, 0.1)
-    points = np.array([sampler.sample(storage, study_id, 'y', distribution) for _ in range(100)])
-    assert np.all(points >= -10.2)
-    assert np.all(points <= 10.2)
-    round_points = np.round(10 * points)
-    np.testing.assert_almost_equal(round_points, 10 * points)
+    check(_study)
 
 
 @parametrize_sampler
-def test_int(sampler_class):
-    # type: (typing.Callable[[], optuna.samplers.BaseSampler]) -> None
+@pytest.mark.parametrize('distribution', [LogUniformDistribution(1e-7, 1.)])
+def test_log_uniform(sampler_class, distribution):
+    # type: (typing.Callable[[], BaseSampler], LogUniformDistribution) -> None
 
-    sampler = sampler_class()
-    storage = optuna.storages.get_storage(None)
-    study_id = storage.create_new_study_id()
+    def objective(trial):
+        # type: (optuna.trial.Trial) -> float
 
-    distribution = optuna.distributions.IntUniformDistribution(-10, 10)
-    points = np.array([sampler.sample(storage, study_id, 'x', distribution) for _ in range(100)])
-    assert np.all(points >= -10)
-    assert np.all(points <= 10)
-    round_points = np.round(points)
-    np.testing.assert_almost_equal(round_points, points)
+        return trial.suggest_loguniform('x', distribution.low, distribution.high)
+
+    def check(study):
+        # type: (optuna.study.Study) -> None
+
+        points = np.array([study.sampler.sample(study.storage, study.study_id, 'x', distribution)
+                           for _ in range(100)])
+        assert np.all(points >= distribution.low)
+        assert np.all(points < distribution.high)
+
+    _study = optuna.study.create_study(sampler=sampler_class())
+
+    check(_study)
+
+    # Execute optimization for samplers which have startup trials such as TPESampler.
+    _study.optimize(objective, n_trials=10)
+
+    check(_study)
+
+
+@parametrize_sampler
+@pytest.mark.parametrize('distribution', [DiscreteUniformDistribution(-10, 10, 1),
+                                          DiscreteUniformDistribution(-10.2, 10.2, 0.1),
+                                          DiscreteUniformDistribution(64., 1312., 160.),
+                                          DiscreteUniformDistribution(0, 10, math.pi)])
+def test_discrete_uniform(sampler_class, distribution):
+    # type: (typing.Callable[[], BaseSampler], DiscreteUniformDistribution) -> None
+
+    def objective(trial):
+        # type: (optuna.trial.Trial) -> float
+
+        return trial.suggest_discrete_uniform('x', distribution.low, distribution.high,
+                                              distribution.q)
+
+    def check(study):
+        # type: (optuna.study.Study) -> None
+
+        points = np.array([study.sampler.sample(study.storage, study.study_id, 'x', distribution)
+                           for _ in range(100)])
+        assert np.all(points >= distribution.low)
+        assert np.all(points <= distribution.high)
+
+        # Check all points are multiples of distribution.q except endpoints.
+        points = points[points != distribution.low]
+        points = points[points != distribution.high]
+        points /= distribution.q
+        round_points = np.round(points)
+        np.testing.assert_almost_equal(round_points, points)
+
+    _study = optuna.study.create_study(sampler=sampler_class())
+
+    check(_study)
+
+    # Execute optimization for samplers which have startup trials such as TPESampler.
+    _study.optimize(objective, n_trials=10)
+
+    check(_study)
+
+
+@parametrize_sampler
+@pytest.mark.parametrize('distribution', [IntUniformDistribution(-10, 10),
+                                          IntUniformDistribution(0, 10),
+                                          IntUniformDistribution(-10, 0)])
+def test_int(sampler_class, distribution):
+    # type: (typing.Callable[[], BaseSampler], IntUniformDistribution) -> None
+
+    def objective(trial):
+        # type: (optuna.trial.Trial) -> float
+
+        return trial.suggest_int('x', distribution.low, distribution.high)
+
+    def check(study):
+        # type: (optuna.study.Study) -> None
+
+        points = np.array([study.sampler.sample(study.storage, study.study_id, 'x', distribution)
+                           for _ in range(100)])
+        assert np.all(points >= distribution.low)
+        assert np.all(points <= distribution.high)
+
+    _study = optuna.study.create_study(sampler=sampler_class())
+
+    check(_study)
+
+    # Execute optimization for samplers which have startup trials such as TPESampler.
+    _study.optimize(objective, n_trials=10)
+
+    check(_study)
+
+
+@parametrize_sampler
+@pytest.mark.parametrize('choices', [(1, 2, 3),
+                                     ('a', 'b', 'c')])
+def test_categorical(sampler_class, choices):
+    # type: (typing.Callable[[], BaseSampler], typing.Tuple[T, ...]) -> None
+
+    distribution = CategoricalDistribution(choices)
+
+    def objective(trial):
+        # type: (optuna.trial.Trial) -> float
+
+        trial.suggest_categorical('x', choices)
+        return 1.0
+
+    def check(study):
+        # type: (optuna.study.Study) -> None
+
+        points = np.array([study.sampler.sample(study.storage, study.study_id, 'x', distribution)
+                           for _ in range(100)])
+        # 'x' value is corresponding to an index of distribution.choices.
+        assert np.all(points >= 0)
+        assert np.all(points <= len(distribution.choices) - 1)
+        round_points = np.round(points)
+        np.testing.assert_almost_equal(round_points, points)
+
+    _study = optuna.study.create_study(sampler=sampler_class())
+
+    check(_study)
+
+    # Execute optimization for samplers which have startup trials such as TPESampler.
+    _study.optimize(objective, n_trials=10)
+
+    check(_study)

--- a/tests/samplers_tests/test_samplers.py
+++ b/tests/samplers_tests/test_samplers.py
@@ -101,6 +101,7 @@ def test_discrete_uniform(sampler_class, distribution):
         # Check all points are multiples of distribution.q except endpoints.
         points = points[points != distribution.low]
         points = points[points != distribution.high]
+        points -= distribution.low
         points /= distribution.q
         round_points = np.round(points)
         np.testing.assert_almost_equal(round_points, points)

--- a/tests/samplers_tests/test_samplers.py
+++ b/tests/samplers_tests/test_samplers.py
@@ -66,7 +66,6 @@ def test_discrete_uniform(sampler_class, distribution):
 
     # Check all points are multiples of distribution.q.
     points = points
-    points = points
     points -= distribution.low
     points /= distribution.q
     round_points = np.round(points)

--- a/tests/samplers_tests/test_samplers.py
+++ b/tests/samplers_tests/test_samplers.py
@@ -1,4 +1,3 @@
-import math
 import numpy as np
 import pytest
 import typing  # NOQA
@@ -77,10 +76,8 @@ def test_log_uniform(sampler_class, distribution):
 
 
 @parametrize_sampler
-@pytest.mark.parametrize('distribution', [DiscreteUniformDistribution(-10, 10, 1),
-                                          DiscreteUniformDistribution(-10.2, 10.2, 0.1),
-                                          DiscreteUniformDistribution(64., 1312., 160.),
-                                          DiscreteUniformDistribution(0, 10, math.pi)])
+@pytest.mark.parametrize('distribution', [DiscreteUniformDistribution(-10, 10, 0.1),
+                                          DiscreteUniformDistribution(-10.2, 10.2, 0.1)])
 def test_discrete_uniform(sampler_class, distribution):
     # type: (typing.Callable[[], BaseSampler], DiscreteUniformDistribution) -> None
 

--- a/tests/samplers_tests/test_samplers.py
+++ b/tests/samplers_tests/test_samplers.py
@@ -18,9 +18,11 @@ parametrize_sampler = pytest.mark.parametrize(
 
 
 @parametrize_sampler
-@pytest.mark.parametrize('distribution', [UniformDistribution(-1., 1.),
-                                          UniformDistribution(0., 1.),
-                                          UniformDistribution(-1., 0.)])
+@pytest.mark.parametrize(
+    'distribution',
+    [UniformDistribution(-1., 1.),
+     UniformDistribution(0., 1.),
+     UniformDistribution(-1., 0.)])
 def test_uniform(sampler_class, distribution):
     # type: (typing.Callable[[], BaseSampler], UniformDistribution) -> None
 
@@ -32,8 +34,10 @@ def test_uniform(sampler_class, distribution):
     def check(study):
         # type: (optuna.study.Study) -> None
 
-        points = np.array([study.sampler.sample(study.storage, study.study_id, 'x', distribution)
-                           for _ in range(100)])
+        points = np.array([
+            study.sampler.sample(study.storage, study.study_id, 'x', distribution)
+            for _ in range(100)
+        ])
         assert np.all(points >= distribution.low)
         assert np.all(points < distribution.high)
 
@@ -60,8 +64,10 @@ def test_log_uniform(sampler_class, distribution):
     def check(study):
         # type: (optuna.study.Study) -> None
 
-        points = np.array([study.sampler.sample(study.storage, study.study_id, 'x', distribution)
-                           for _ in range(100)])
+        points = np.array([
+            study.sampler.sample(study.storage, study.study_id, 'x', distribution)
+            for _ in range(100)
+        ])
         assert np.all(points >= distribution.low)
         assert np.all(points < distribution.high)
 
@@ -76,8 +82,10 @@ def test_log_uniform(sampler_class, distribution):
 
 
 @parametrize_sampler
-@pytest.mark.parametrize('distribution', [DiscreteUniformDistribution(-10, 10, 0.1),
-                                          DiscreteUniformDistribution(-10.2, 10.2, 0.1)])
+@pytest.mark.parametrize(
+    'distribution',
+    [DiscreteUniformDistribution(-10, 10, 0.1),
+     DiscreteUniformDistribution(-10.2, 10.2, 0.1)])
 def test_discrete_uniform(sampler_class, distribution):
     # type: (typing.Callable[[], BaseSampler], DiscreteUniformDistribution) -> None
 
@@ -90,8 +98,10 @@ def test_discrete_uniform(sampler_class, distribution):
     def check(study):
         # type: (optuna.study.Study) -> None
 
-        points = np.array([study.sampler.sample(study.storage, study.study_id, 'x', distribution)
-                           for _ in range(100)])
+        points = np.array([
+            study.sampler.sample(study.storage, study.study_id, 'x', distribution)
+            for _ in range(100)
+        ])
         assert np.all(points >= distribution.low)
         assert np.all(points <= distribution.high)
 
@@ -114,9 +124,11 @@ def test_discrete_uniform(sampler_class, distribution):
 
 
 @parametrize_sampler
-@pytest.mark.parametrize('distribution', [IntUniformDistribution(-10, 10),
-                                          IntUniformDistribution(0, 10),
-                                          IntUniformDistribution(-10, 0)])
+@pytest.mark.parametrize('distribution', [
+    IntUniformDistribution(-10, 10),
+    IntUniformDistribution(0, 10),
+    IntUniformDistribution(-10, 0)
+])
 def test_int(sampler_class, distribution):
     # type: (typing.Callable[[], BaseSampler], IntUniformDistribution) -> None
 
@@ -128,8 +140,10 @@ def test_int(sampler_class, distribution):
     def check(study):
         # type: (optuna.study.Study) -> None
 
-        points = np.array([study.sampler.sample(study.storage, study.study_id, 'x', distribution)
-                           for _ in range(100)])
+        points = np.array([
+            study.sampler.sample(study.storage, study.study_id, 'x', distribution)
+            for _ in range(100)
+        ])
         assert np.all(points >= distribution.low)
         assert np.all(points <= distribution.high)
 
@@ -144,8 +158,7 @@ def test_int(sampler_class, distribution):
 
 
 @parametrize_sampler
-@pytest.mark.parametrize('choices', [(1, 2, 3),
-                                     ('a', 'b', 'c')])
+@pytest.mark.parametrize('choices', [(1, 2, 3), ('a', 'b', 'c')])
 def test_categorical(sampler_class, choices):
     # type: (typing.Callable[[], BaseSampler], typing.Tuple[T, ...]) -> None
 
@@ -160,8 +173,10 @@ def test_categorical(sampler_class, choices):
     def check(study):
         # type: (optuna.study.Study) -> None
 
-        points = np.array([study.sampler.sample(study.storage, study.study_id, 'x', distribution)
-                           for _ in range(100)])
+        points = np.array([
+            study.sampler.sample(study.storage, study.study_id, 'x', distribution)
+            for _ in range(100)
+        ])
         # 'x' value is corresponding to an index of distribution.choices.
         assert np.all(points >= 0)
         assert np.all(points <= len(distribution.choices) - 1)

--- a/tests/test_trial.py
+++ b/tests/test_trial.py
@@ -1,3 +1,4 @@
+import math
 from mock import Mock
 from mock import patch
 import pytest
@@ -53,6 +54,46 @@ def test_suggest_discrete_uniform(storage_init_func):
         assert trial._suggest('y', distribution) == 3.  # Test suggesting a different param.
         assert trial.params == {'x': 1., 'y': 3.}
         assert mock_object.call_count == 3
+
+
+@parametrize_storage
+@pytest.mark.parametrize('range_config',
+                         [{'low': 0., 'high': 10., 'q': 3., 'mod_high': 9.},
+                          {'low': 1., 'high': 11., 'q': 3., 'mod_high': 10.},
+                          {'low': 64., 'high': 1312., 'q': 160., 'mod_high': 1184.},
+                          # high is excluded due to the round-off error of 10 // 0.1.
+                          {'low': 0., 'high': 10., 'q': 0.1, 'mod_high': 9.9},
+                          # high is excluded doe to the round-off error of 10.1 // 0.1
+                          {'low': 0., 'high': 10.1, 'q': 0.1, 'mod_high': 10.},
+                          {'low': 0., 'high': 10., 'q': math.pi, 'mod_high': 3 * math.pi}])
+def test_suggest_discrete_uniform_range(storage_init_func, range_config):
+    # type: (typing.Callable[[], storages.BaseStorage], typing.Dict[str, float]) -> None
+
+    sampler = samplers.RandomSampler()
+
+    # Check upper endpoints.
+    mock = Mock()
+    mock.side_effect = lambda storage, study_id, param_name, distribution: distribution.high
+    with patch.object(sampler, 'sample', mock) as mock_object:
+        study = create_study(storage_init_func(), sampler=sampler)
+        trial = Trial(study, study.storage.create_new_trial_id(study.study_id))
+
+        x = trial.suggest_discrete_uniform('x', range_config['low'], range_config['high'],
+                                           range_config['q'])
+        assert x == range_config['mod_high']
+        assert mock_object.call_count == 1
+
+    # Check lower endpoints
+    mock = Mock()
+    mock.side_effect = lambda storage, study_id, param_name, distribution: distribution.low
+    with patch.object(sampler, 'sample', mock) as mock_object:
+        study = create_study(storage_init_func(), sampler=sampler)
+        trial = Trial(study, study.storage.create_new_trial_id(study.study_id))
+
+        x = trial.suggest_discrete_uniform('x', range_config['low'], range_config['high'],
+                                           range_config['q'])
+        assert x == range_config['low']
+        assert mock_object.call_count == 1
 
 
 @parametrize_storage

--- a/tests/test_trial.py
+++ b/tests/test_trial.py
@@ -57,15 +57,48 @@ def test_suggest_discrete_uniform(storage_init_func):
 
 
 @parametrize_storage
-@pytest.mark.parametrize('range_config',
-                         [{'low': 0., 'high': 10., 'q': 3., 'mod_high': 9.},
-                          {'low': 1., 'high': 11., 'q': 3., 'mod_high': 10.},
-                          {'low': 64., 'high': 1312., 'q': 160., 'mod_high': 1184.},
-                          # high is excluded due to the round-off error of 10 // 0.1.
-                          {'low': 0., 'high': 10., 'q': 0.1, 'mod_high': 9.9},
-                          # high is excluded doe to the round-off error of 10.1 // 0.1
-                          {'low': 0., 'high': 10.1, 'q': 0.1, 'mod_high': 10.},
-                          {'low': 0., 'high': 10., 'q': math.pi, 'mod_high': 3 * math.pi}])
+@pytest.mark.parametrize(
+    'range_config',
+    [
+        {
+            'low': 0.,
+            'high': 10.,
+            'q': 3.,
+            'mod_high': 9.
+        },
+        {
+            'low': 1.,
+            'high': 11.,
+            'q': 3.,
+            'mod_high': 10.
+        },
+        {
+            'low': 64.,
+            'high': 1312.,
+            'q': 160.,
+            'mod_high': 1184.
+        },
+        # high is excluded due to the round-off error of 10 // 0.1.
+        {
+            'low': 0.,
+            'high': 10.,
+            'q': 0.1,
+            'mod_high': 9.9
+        },
+        # high is excluded doe to the round-off error of 10.1 // 0.1
+        {
+            'low': 0.,
+            'high': 10.1,
+            'q': 0.1,
+            'mod_high': 10.
+        },
+        {
+            'low': 0.,
+            'high': 10.,
+            'q': math.pi,
+            'mod_high': 3 * math.pi
+        }
+    ])
 def test_suggest_discrete_uniform_range(storage_init_func, range_config):
     # type: (typing.Callable[[], storages.BaseStorage], typing.Dict[str, float]) -> None
 

--- a/tests/test_trial.py
+++ b/tests/test_trial.py
@@ -116,7 +116,7 @@ def test_suggest_discrete_uniform_range(storage_init_func, range_config):
         assert x == range_config['mod_high']
         assert mock_object.call_count == 1
 
-    # Check lower endpoints
+    # Check lower endpoints.
     mock = Mock()
     mock.side_effect = lambda storage, study_id, param_name, distribution: distribution.low
     with patch.object(sampler, 'sample', mock) as mock_object:


### PR DESCRIPTION
`Trial.suggest_discrete_uniform()` sometimes suggests smaller values than `low` or larger values than `high`. For example `trial.suggest_discrete_uniform('x', 64, 1312, 160)` will return `0`.

This is caused by the following three problems:
- Wrong range setting in TPESampler,
- Test cases skipping TPESampler due to its startup period,
- Definition of returned values of `trial.suggest_discrete_uniform`.

1.  Wrong range setting in TPESampler.

This issue may be caused when we refactored the TPESampler at v0.4.0.

before
https://github.com/pfnet/optuna/blob/v0.3.0/optuna/samplers/tpe.py#L109

after
https://github.com/pfnet/optuna/blob/v0.4.0/optuna/samplers/tpe/sampler.py#L154

This PR fixes the issue by reverting the range of `TPESampler._sample_discrete_uniform` to v0.3.0.

2. Test cases skipping TPESampler due to its startup period.

TPESampler delegates parameter suggestions to RandomSampler until the number of observations exceeds `n_startup_trials`. Current test cases do not store any observations, and TPESampler does not suggest any parameters.  In this PR, I added the `study.optmize` to store observations to activate TPESampler.

3. Definition of returned values of `trial.suggest_discrete_uniform`.

Currently, optuna tries to return multiples of `q` in `[low, high]` with `low` and `high` as boundary values.
In this PR, I'd like to change this definition according to the convention of `range` function in Python as follows:
the returned value would be `low + q * k <= high (k = 0, 1, 2, ...)`. With this change, we can ensure that the returned values are arranged in an equal interval while the current ones are not if `low % q != 0` or `high % q != 0`.

For example, `trial.suggest_discrete_uniform('x', 64, 1312, 160)` will return following values:
```
Current (w/o the bug reported in 1)
64, 160, 320, ..., 1280, 1312

This PR: 
64, 224, 384, ..., 1024, 1284
```

Note that `high` may be excluded from ranges due to round-off errors if `q` is not an integer.
Please refer to the following test case:
https://github.com/pfnet/optuna/pull/321/files#diff-1b9dd0f25ba98f584018a94420395c5cR81