### PR TITLE
Show coverage report in Codecov.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,7 @@ workflows:
       - tests-python36
       - tests-python35
       - tests-python27
+      - codecov
   daily-build:
     triggers:
       - schedule:
@@ -147,6 +148,31 @@ jobs:
       - image: circleci/python:2.7
     steps:
       [checkout, run: *install, run: *keras-install, run: *tests, run: *tests-mn]
+
+  codecov:
+    docker:
+      - image: circleci/python:3.7
+    steps:
+      - checkout
+
+      - run: *install
+
+      - run: *keras-install
+
+      - run:
+          name: install-codecov
+          command: |
+            . venv/bin/activate
+            pip install .[codecov]
+
+      - run:
+          name: codecov
+          command: |
+            . venv/bin/activate
+            pytest --cov=./ tests
+            codecov
+          environment:
+            OMP_NUM_THREADS: 1
 
   # Examples
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/pfnet/optuna)
 [![CircleCI](https://circleci.com/gh/pfnet/optuna.svg?style=svg)](https://circleci.com/gh/pfnet/optuna)
 [![Read the Docs](https://readthedocs.org/projects/optuna/badge/?version=stable)](https://optuna.readthedocs.io/en/stable/)
+[![Codecov](https://codecov.io/gh/pfnet/optuna/branch/master/graph/badge.svg)](https://codecov.io/gh/pfnet/optuna/branch/master)
 
 [**Website**](https://optuna.org/)
 | [**Docs**](https://optuna.readthedocs.io/en/stable/)

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ def get_extras_require():
         # TODO(higumachan): merge 'keras' to 'testing' after Tensorflow supports Python 3.7.
         'keras': ['keras', 'tensorflow'],
         'document': ['sphinx', 'sphinx_rtd_theme'],
+        'codecov': ['pytest-cov', 'codecov'],
     }
     if sys.version_info >= (3, 5):  # mypy does not support Python 2.x.
         extras_require['checking'].append('mypy')


### PR DESCRIPTION
This PR adds a CircleCI build job to make coverage reports and upload them to Codecov.

You can see an example of report here:
https://codecov.io/github/pfnet/optuna/commit/7307b3a597b580a0e2bf9aa25f093813db373713