### PR TITLE
Fix occasional OOM errors during execution of ChainerMN examples on CircleCI.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -180,9 +180,9 @@ jobs:
           command: |
             . venv/bin/activate
             STORAGE_URL=sqlite:///example.db
-            STUDY_NAME=`optuna create-study --storage $STORAGE_URL`
             for file in `find examples -name 'chainermn_*.py'`
             do
+                STUDY_NAME=`optuna create-study --storage $STORAGE_URL`
                 mpirun -n 2 -- python $file $STUDY_NAME $STORAGE_URL
             done
           environment:

--- a/examples/chainermn_simple.py
+++ b/examples/chainermn_simple.py
@@ -18,6 +18,7 @@ import chainer
 import chainer.functions as F
 import chainer.links as L
 import chainermn
+import gc
 import numpy as np
 import sys
 
@@ -46,6 +47,10 @@ def create_model(trial):
 # FYI: Objective functions can take additional arguments
 # (https://optuna.readthedocs.io/en/stable/faq.html#objective-func-additional-args).
 def objective(trial, comm):
+    # The following line is required for CircleCI
+    # (see https://github.com/pfnet/optuna/pull/325 for more details).
+    gc.collect()
+
     # Sample an architecture.
     model = L.Classifier(create_model(trial))
 

--- a/examples/chainermn_simple.py
+++ b/examples/chainermn_simple.py
@@ -47,10 +47,6 @@ def create_model(trial):
 # FYI: Objective functions can take additional arguments
 # (https://optuna.readthedocs.io/en/stable/faq.html#objective-func-additional-args).
 def objective(trial, comm):
-    # The following line mitigates the memory problem in CircleCI
-    # (see https://github.com/pfnet/optuna/pull/325 for more details).
-    gc.collect()
-
     # Sample an architecture.
     model = L.Classifier(create_model(trial))
 
@@ -86,6 +82,10 @@ def objective(trial, comm):
     evaluator = chainer.training.extensions.Evaluator(test_iter, model)
     evaluator = chainermn.create_multi_node_evaluator(evaluator, comm)
     report = evaluator()
+
+    # The following line mitigates the memory problem in CircleCI
+    # (see https://github.com/pfnet/optuna/pull/325 for more details).
+    gc.collect()
 
     return 1.0 - report['main/accuracy']
 

--- a/examples/chainermn_simple.py
+++ b/examples/chainermn_simple.py
@@ -47,7 +47,7 @@ def create_model(trial):
 # FYI: Objective functions can take additional arguments
 # (https://optuna.readthedocs.io/en/stable/faq.html#objective-func-additional-args).
 def objective(trial, comm):
-    # The following line is required for CircleCI
+    # The following line mitigates the memory problem in CircleCI
     # (see https://github.com/pfnet/optuna/pull/325 for more details).
     gc.collect()
 

--- a/examples/pruning/chainermn_integration.py
+++ b/examples/pruning/chainermn_integration.py
@@ -47,7 +47,7 @@ def create_model(trial):
 
 
 def objective(trial, comm):
-    # The following line is required for CircleCI
+    # The following line mitigates the memory problem in CircleCI
     # (see https://github.com/pfnet/optuna/pull/325 for more details).
     gc.collect()
 

--- a/examples/pruning/chainermn_integration.py
+++ b/examples/pruning/chainermn_integration.py
@@ -47,10 +47,6 @@ def create_model(trial):
 
 
 def objective(trial, comm):
-    # The following line mitigates the memory problem in CircleCI
-    # (see https://github.com/pfnet/optuna/pull/325 for more details).
-    gc.collect()
-
     # Sample an architecture.
     model = L.Classifier(create_model(trial))
 
@@ -98,6 +94,10 @@ def objective(trial, comm):
     evaluator = chainer.training.extensions.Evaluator(test_iter, model)
     evaluator = chainermn.create_multi_node_evaluator(evaluator, comm)
     report = evaluator()
+
+    # The following line mitigates the memory problem in CircleCI
+    # (see https://github.com/pfnet/optuna/pull/325 for more details).
+    gc.collect()
 
     return 1.0 - report['main/accuracy']
 

--- a/examples/pruning/chainermn_integration.py
+++ b/examples/pruning/chainermn_integration.py
@@ -19,6 +19,7 @@ import chainer
 import chainer.functions as F
 import chainer.links as L
 import chainermn
+import gc
 import numpy as np
 import sys
 
@@ -46,6 +47,10 @@ def create_model(trial):
 
 
 def objective(trial, comm):
+    # The following line is required for CircleCI
+    # (see https://github.com/pfnet/optuna/pull/325 for more details).
+    gc.collect()
+
     # Sample an architecture.
     model = L.Classifier(create_model(trial))
 


### PR DESCRIPTION
The execution of CircleCI's `examples-*` jobs sometimes fails because of OOM error due to ChainerMN example.

I guess the cause of this error as follows:
1. A VM of CircleCI is equipped with very large memory (about 70GB).
2. But only 4GB is available for normal users.
3. However, Python interpreter recognizes as if there is a lot of memory.
   - GCs are hardly triggered by the interpreter.
4. When the memory usage of a Python program exceeds the 4GB limit, the program will be suddenly killed.
   - If a GC were triggered, the program would have been able to continue execution.

In this PR, I added manual invocations of `gc.collect()` method to prevent the above scenario.

Memory Usage Comparison
-------------------------------

Without `gc.collect()` (the memory usage in each execution has varied between 2GB and 4GB):
```console
// Preparation.
$ ssh -p ${CIRCLE_CI_PORT} ${CIRCLE_CI_HOST}
$ cd project && . venv/bin/activate
$ STORAGE_URL=sqlite:///example.db
$ STUDY_NAME=`optuna create-study --storage $STORAGE_URL`
$ export OMP_NUM_THREADS=1

// Execute a ChainerMN example.
$ /usr/bin/time -v mpirun -n 2 -- python examples/chainermn_simple.py $STUDY_NAME $STORAGE_URL | grep 'Maximum resident'
        Maximum resident set size (kbytes): 2546996  // Memory Usage=2.5GB 
```

With `gc.collect()` (memory usage=0.9GB):
```console
// Preparation.
$ vim examples/chainermn_simple.py  // Add `gc.collect()`

// Execute a ChainerMN example.
$ /usr/bin/time -v mpirun -n 2 -- python examples/chainermn_simple.py $STUDY_NAME $STORAGE_URL | grep 'Maximum resident'
        Maximum resident set size (kbytes): 954336  // Memory Usage=0.9GB
```