### PR TITLE
Fix import errors in Python3.5.0 and Python3.5.1

### DIFF
--- a/optuna/cli.py
+++ b/optuna/cli.py
@@ -9,14 +9,17 @@ from cliff.lister import Lister
 import imp
 import logging
 import sys
-from typing import Any  # NOQA
-from typing import Dict  # NOQA
-from typing import List  # NOQA
-from typing import Optional  # NOQA
-from typing import Tuple  # NOQA
 
 import optuna
 from optuna.structs import CLIUsageError
+from optuna import types
+
+if types.TYPE_CHECKING:
+    from typing import Any  # NOQA
+    from typing import Dict  # NOQA
+    from typing import List  # NOQA
+    from typing import Optional  # NOQA
+    from typing import Tuple  # NOQA
 
 
 def get_storage_url(storage_url, config):

--- a/optuna/dashboard.py
+++ b/optuna/dashboard.py
@@ -16,14 +16,17 @@ import collections
 import numpy as np
 import threading
 import time
-from typing import Any  # NOQA
-from typing import Dict  # NOQA
-from typing import List  # NOQA
-from typing import Optional  # NOQA
 
 import optuna.logging
 import optuna.structs
 import optuna.study
+from optuna import types
+
+if types.TYPE_CHECKING:
+    from typing import Any  # NOQA
+    from typing import Dict  # NOQA
+    from typing import List  # NOQA
+    from typing import Optional  # NOQA
 
 _mode = None  # type: Optional[str]
 _study = None  # type: Optional[optuna.study.Study]

--- a/optuna/distributions.py
+++ b/optuna/distributions.py
@@ -1,11 +1,15 @@
 import abc
 import json
 import six
-from typing import Any  # NOQA
-from typing import Dict  # NOQA
 from typing import NamedTuple
 from typing import Tuple
 from typing import Union
+
+from optuna import types
+
+if types.TYPE_CHECKING:
+    from typing import Any  # NOQA
+    from typing import Dict  # NOQA
 
 
 @six.add_metaclass(abc.ABCMeta)

--- a/optuna/integration/chainermn.py
+++ b/optuna/integration/chainermn.py
@@ -1,12 +1,5 @@
 from __future__ import absolute_import
 
-from typing import Any  # NOQA
-from typing import Callable  # NOQA
-from typing import Optional  # NOQA
-from typing import Tuple  # NOQA
-from typing import Type  # NOQA
-from typing import Union  # NOQA
-
 from optuna.logging import get_logger
 from optuna.pruners import BasePruner  # NOQA
 from optuna.storages import BaseStorage  # NOQA
@@ -15,6 +8,15 @@ from optuna.storages import RDBStorage
 from optuna.structs import TrialPruned
 from optuna.study import Study  # NOQA
 from optuna.trial import Trial  # NOQA
+from optuna import types
+
+if types.TYPE_CHECKING:
+    from typing import Any  # NOQA
+    from typing import Callable  # NOQA
+    from typing import Optional  # NOQA
+    from typing import Tuple  # NOQA
+    from typing import Type  # NOQA
+    from typing import Union  # NOQA
 
 try:
     from chainermn.communicators.communicator_base import CommunicatorBase  # NOQA

--- a/optuna/integration/keras.py
+++ b/optuna/integration/keras.py
@@ -1,8 +1,10 @@
 from __future__ import absolute_import
 
-from typing import Dict  # NOQA
-
 import optuna
+from optuna import types
+
+if types.TYPE_CHECKING:
+    from typing import Dict  # NOQA
 
 try:
     from keras.callbacks import Callback

--- a/optuna/logging.py
+++ b/optuna/logging.py
@@ -11,7 +11,11 @@ from logging import INFO  # NOQA
 from logging import WARN  # NOQA
 from logging import WARNING  # NOQA
 import threading
-from typing import Optional  # NOQA
+
+from optuna import types
+
+if types.TYPE_CHECKING:
+    from typing import Optional  # NOQA
 
 _lock = threading.Lock()
 _default_handler = None  # type: Optional[logging.Handler]

--- a/optuna/pruners/successive_halving.py
+++ b/optuna/pruners/successive_halving.py
@@ -1,9 +1,12 @@
 import math
-from typing import List  # NOQA
 
 from optuna.pruners.base import BasePruner
 from optuna.storages import BaseStorage  # NOQA
 from optuna.structs import FrozenTrial  # NOQA
+from optuna import types
+
+if types.TYPE_CHECKING:
+    from typing import List  # NOQA
 
 
 class SuccessiveHalvingPruner(BasePruner):

--- a/optuna/samplers/random.py
+++ b/optuna/samplers/random.py
@@ -1,9 +1,12 @@
 import numpy
-from typing import Optional  # NOQA
 
 from optuna import distributions
 from optuna.samplers.base import BaseSampler
 from optuna.storages.base import BaseStorage  # NOQA
+from optuna import types
+
+if types.TYPE_CHECKING:
+    from typing import Optional  # NOQA
 
 
 class RandomSampler(BaseSampler):

--- a/optuna/samplers/tpe/parzen_estimator.py
+++ b/optuna/samplers/tpe/parzen_estimator.py
@@ -1,10 +1,14 @@
 import numpy
 from numpy import ndarray
-from typing import Callable  # NOQA
-from typing import List  # NOQA
-from typing import NamedTuple  # NOQA
-from typing import Optional  # NOQA
-from typing import Tuple  # NOQA
+from typing import Callable
+from typing import NamedTuple
+from typing import Optional
+
+from optuna import types
+
+if types.TYPE_CHECKING:
+    from typing import List  # NOQA
+    from typing import Tuple  # NOQA
 
 
 class ParzenEstimatorParameters(

--- a/optuna/samplers/tpe/sampler.py
+++ b/optuna/samplers/tpe/sampler.py
@@ -1,10 +1,5 @@
 import numpy as np
 import scipy.special
-from typing import Callable  # NOQA
-from typing import List  # NOQA
-from typing import Optional  # NOQA
-from typing import Tuple  # NOQA
-from typing import Union  # NOQA
 
 from optuna import distributions  # NOQA
 from optuna.distributions import BaseDistribution  # NOQA
@@ -13,6 +8,14 @@ from optuna.samplers import random  # NOQA
 from optuna.samplers.tpe.parzen_estimator import ParzenEstimator  # NOQA
 from optuna.samplers.tpe.parzen_estimator import ParzenEstimatorParameters  # NOQA
 from optuna.storages.base import BaseStorage  # NOQA
+from optuna import types
+
+if types.TYPE_CHECKING:
+    from typing import Callable  # NOQA
+    from typing import List  # NOQA
+    from typing import Optional  # NOQA
+    from typing import Tuple  # NOQA
+    from typing import Union  # NOQA
 
 EPS = 1e-12
 

--- a/optuna/storages/base.py
+++ b/optuna/storages/base.py
@@ -1,14 +1,17 @@
 import abc
 import numpy as np
 import six
-from typing import Any  # NOQA
-from typing import Dict  # NOQA
-from typing import List  # NOQA
-from typing import Optional  # NOQA
-from typing import Tuple  # NOQA
 
 from optuna import distributions  # NOQA
 from optuna import structs  # NOQA
+from optuna import types
+
+if types.TYPE_CHECKING:
+    from typing import Any  # NOQA
+    from typing import Dict  # NOQA
+    from typing import List  # NOQA
+    from typing import Optional  # NOQA
+    from typing import Tuple  # NOQA
 
 DEFAULT_STUDY_NAME_PREFIX = 'no-name-'
 

--- a/optuna/storages/in_memory.py
+++ b/optuna/storages/in_memory.py
@@ -1,15 +1,18 @@
 import copy
 from datetime import datetime
 import threading
-from typing import Any  # NOQA
-from typing import Dict  # NOQA
-from typing import List  # NOQA
-from typing import Optional  # NOQA
 
 from optuna import distributions  # NOQA
 from optuna.storages import base
 from optuna.storages.base import DEFAULT_STUDY_NAME_PREFIX
 from optuna import structs
+from optuna import types
+
+if types.TYPE_CHECKING:
+    from typing import Any  # NOQA
+    from typing import Dict  # NOQA
+    from typing import List  # NOQA
+    from typing import Optional  # NOQA
 
 IN_MEMORY_STORAGE_STUDY_ID = 0
 IN_MEMORY_STORAGE_STUDY_UUID = '00000000-0000-0000-0000-000000000000'

--- a/optuna/storages/rdb/models.py
+++ b/optuna/storages/rdb/models.py
@@ -11,13 +11,16 @@ from sqlalchemy import Integer
 from sqlalchemy import orm
 from sqlalchemy import String
 from sqlalchemy import UniqueConstraint
-from typing import Any  # NOQA
-from typing import List  # NOQA
-from typing import Optional  # NOQA
 
 from optuna import distributions
 from optuna.structs import StudyDirection
 from optuna.structs import TrialState
+from optuna import types
+
+if types.TYPE_CHECKING:
+    from typing import Any  # NOQA
+    from typing import List  # NOQA
+    from typing import Optional  # NOQA
 
 SCHEMA_VERSION = 11
 

--- a/optuna/storages/rdb/storage.py
+++ b/optuna/storages/rdb/storage.py
@@ -7,10 +7,6 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy import orm
 import sys
-from typing import Any  # NOQA
-from typing import Dict  # NOQA
-from typing import List  # NOQA
-from typing import Optional  # NOQA
 import uuid
 
 from optuna import distributions
@@ -19,7 +15,14 @@ from optuna.storages.base import BaseStorage
 from optuna.storages.base import DEFAULT_STUDY_NAME_PREFIX
 from optuna.storages.rdb import models
 from optuna import structs
+from optuna import types
 from optuna import version
+
+if types.TYPE_CHECKING:
+    from typing import Any  # NOQA
+    from typing import Dict  # NOQA
+    from typing import List  # NOQA
+    from typing import Optional  # NOQA
 
 
 class RDBStorage(BaseStorage):

--- a/optuna/study.py
+++ b/optuna/study.py
@@ -7,15 +7,7 @@ from multiprocessing import Queue  # NOQA
 import pandas as pd
 from six.moves import queue
 import time
-from typing import Any  # NOQA
-from typing import Callable  # NOQA
-from typing import Dict  # NOQA
-from typing import List  # NOQA
-from typing import Optional  # NOQA
-from typing import Set  # NOQA
-from typing import Tuple  # NOQA
-from typing import Type  # NOQA
-from typing import Union  # NOQA
+from typing import Callable
 
 from optuna import logging
 from optuna import pruners
@@ -23,6 +15,17 @@ from optuna import samplers
 from optuna import storages
 from optuna import structs
 from optuna import trial as trial_module
+from optuna import types
+
+if types.TYPE_CHECKING:
+    from typing import Any  # NOQA
+    from typing import Dict  # NOQA
+    from typing import List  # NOQA
+    from typing import Optional  # NOQA
+    from typing import Set  # NOQA
+    from typing import Tuple  # NOQA
+    from typing import Type  # NOQA
+    from typing import Union  # NOQA
 
 ObjectiveFuncType = Callable[[trial_module.Trial], float]
 

--- a/optuna/study.py
+++ b/optuna/study.py
@@ -7,7 +7,6 @@ from multiprocessing import Queue  # NOQA
 import pandas as pd
 from six.moves import queue
 import time
-from typing import Callable
 
 from optuna import logging
 from optuna import pruners
@@ -19,6 +18,7 @@ from optuna import types
 
 if types.TYPE_CHECKING:
     from typing import Any  # NOQA
+    from typing import Callable
     from typing import Dict  # NOQA
     from typing import List  # NOQA
     from typing import Optional  # NOQA
@@ -27,7 +27,7 @@ if types.TYPE_CHECKING:
     from typing import Type  # NOQA
     from typing import Union  # NOQA
 
-ObjectiveFuncType = Callable[[trial_module.Trial], float]
+    ObjectiveFuncType = Callable[[trial_module.Trial], float]
 
 
 class Study(object):

--- a/optuna/testing/storage.py
+++ b/optuna/testing/storage.py
@@ -1,11 +1,14 @@
 import tempfile
-from types import TracebackType  # NOQA
-from typing import Any  # NOQA
-from typing import IO  # NOQA
-from typing import Optional  # NOQA
-from typing import Type  # NOQA
 
 import optuna
+from optuna import types
+
+if types.TYPE_CHECKING:
+    from types import TracebackType  # NOQA
+    from typing import Any  # NOQA
+    from typing import IO  # NOQA
+    from typing import Optional  # NOQA
+    from typing import Type  # NOQA
 
 SQLITE3_TIMEOUT = 300
 

--- a/optuna/visualization.py
+++ b/optuna/visualization.py
@@ -1,6 +1,9 @@
 from optuna.structs import TrialState
 from optuna.study import Study  # NOQA
-from typing import List  # NOQA
+from optuna import types
+
+if types.TYPE_CHECKING:
+    from typing import List  # NOQA
 
 try:
     import plotly.graph_objs as go

--- a/tests/integration_tests/test_chainer.py
+++ b/tests/integration_tests/test_chainer.py
@@ -7,12 +7,15 @@ from mock import Mock
 from mock import patch
 import numpy as np
 import pytest
-import typing  # NOQA
 
 import optuna
 from optuna.integration.chainer import ChainerPruningExtension
 from optuna.structs import TrialPruned
 from optuna.testing.integration import DeterministicPruner
+from optuna import types
+
+if types.TYPE_CHECKING:
+    import typing  # NOQA
 
 
 class FixedValueDataset(chainer.dataset.DatasetMixin):

--- a/tests/integration_tests/test_chainermn.py
+++ b/tests/integration_tests/test_chainermn.py
@@ -1,11 +1,5 @@
 import gc
 import pytest
-from types import TracebackType  # NOQA
-from typing import Any  # NOQA
-from typing import Callable  # NOQA
-from typing import Dict  # NOQA
-from typing import Optional  # NOQA
-from typing import Type  # NOQA
 
 from optuna import create_study
 from optuna.integration import ChainerMNStudy
@@ -19,6 +13,15 @@ from optuna.structs import TrialState
 from optuna import Study
 from optuna.testing.storage import StorageSupplier
 from optuna.trial import Trial  # NOQA
+from optuna import types
+
+if types.TYPE_CHECKING:
+    from types import TracebackType  # NOQA
+    from typing import Any  # NOQA
+    from typing import Callable  # NOQA
+    from typing import Dict  # NOQA
+    from typing import Optional  # NOQA
+    from typing import Type  # NOQA
 
 try:
     import chainermn

--- a/tests/integration_tests/test_tensorflow.py
+++ b/tests/integration_tests/test_tensorflow.py
@@ -1,7 +1,6 @@
 import numpy as np
 
 import pytest
-import typing  # NOQA
 
 try:
     import tensorflow as tf
@@ -12,6 +11,10 @@ except ImportError:
 import optuna
 from optuna.integration import TensorFlowPruningHook
 from optuna.testing.integration import DeterministicPruner
+from optuna import types
+
+if types.TYPE_CHECKING:
+    import typing  # NOQA
 
 
 def fixed_value_input_fn():

--- a/tests/samplers_tests/test_samplers.py
+++ b/tests/samplers_tests/test_samplers.py
@@ -1,8 +1,11 @@
 import numpy as np
 import pytest
-import typing  # NOQA
 
 import optuna
+from optuna import types
+
+if types.TYPE_CHECKING:
+    import typing  # NOQA
 
 parametrize_sampler = pytest.mark.parametrize(
     'sampler_class', [optuna.samplers.RandomSampler, optuna.samplers.TPESampler])

--- a/tests/samplers_tests/tpe_tests/test_parzen_estimator.py
+++ b/tests/samplers_tests/tpe_tests/test_parzen_estimator.py
@@ -1,11 +1,14 @@
 import itertools
 import numpy as np
 import pytest
-from typing import Dict  # NOQA
-from typing import List  # NOQA
 
 from optuna.samplers.tpe.parzen_estimator import ParzenEstimator
 from optuna.samplers.tpe.sampler import default_weights
+from optuna import types
+
+if types.TYPE_CHECKING:
+    from typing import Dict  # NOQA
+    from typing import List  # NOQA
 
 
 class TestParzenEstimator(object):

--- a/tests/storages_tests/rdb_tests/test_storage.py
+++ b/tests/storages_tests/rdb_tests/test_storage.py
@@ -2,7 +2,6 @@ from mock import patch
 import pytest
 import sys
 import tempfile
-from typing import Dict  # NOQA
 
 from optuna.distributions import BaseDistribution  # NOQA
 from optuna.distributions import CategoricalDistribution
@@ -18,7 +17,11 @@ from optuna.structs import StorageInternalError
 from optuna.structs import StudyDirection
 from optuna.structs import StudySummary
 from optuna.structs import TrialState
+from optuna import types
 from optuna import version
+
+if types.TYPE_CHECKING:
+    from typing import Dict  # NOQA
 
 
 def test_init():

--- a/tests/storages_tests/test_storages.py
+++ b/tests/storages_tests/test_storages.py
@@ -2,10 +2,6 @@ from datetime import datetime
 import math
 from mock import patch
 import pytest
-from typing import Any  # NOQA
-from typing import Callable  # NOQA
-from typing import Dict  # NOQA
-from typing import Optional  # NOQA
 
 import optuna
 from optuna.distributions import BaseDistribution  # NOQA
@@ -20,6 +16,13 @@ from optuna.structs import FrozenTrial
 from optuna.structs import StudyDirection
 from optuna.structs import TrialState
 from optuna.testing.storage import StorageSupplier
+from optuna import types
+
+if types.TYPE_CHECKING:
+    from typing import Any  # NOQA
+    from typing import Callable  # NOQA
+    from typing import Dict  # NOQA
+    from typing import Optional  # NOQA
 
 # TODO(Yanase): Remove _number from system_attrs after adding TrialModel.number.
 EXAMPLE_ATTRS = {

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,13 +5,6 @@ import re
 import shutil
 import subprocess
 import tempfile
-from types import TracebackType  # NOQA
-from typing import Any  # NOQA
-from typing import IO  # NOQA
-from typing import List  # NOQA
-from typing import Optional  # NOQA
-from typing import Tuple  # NOQA
-from typing import Type  # NOQA
 
 import optuna
 from optuna.cli import Studies
@@ -19,6 +12,16 @@ from optuna.storages.base import DEFAULT_STUDY_NAME_PREFIX
 from optuna.storages import RDBStorage
 from optuna.structs import CLIUsageError
 from optuna.trial import Trial  # NOQA
+from optuna import types
+
+if types.TYPE_CHECKING:
+    from types import TracebackType  # NOQA
+    from typing import Any  # NOQA
+    from typing import IO  # NOQA
+    from typing import List  # NOQA
+    from typing import Optional  # NOQA
+    from typing import Tuple  # NOQA
+    from typing import Type  # NOQA
 
 TEST_CONFIG_TEMPLATE = 'default_storage: sqlite:///{default_storage}\n'
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,9 +3,12 @@ import os
 import pytest
 import shutil
 import tempfile
-from typing import Optional  # NOQA
 
 import optuna
+from optuna import types
+
+if types.TYPE_CHECKING:
+    from typing import Optional  # NOQA
 
 _dummy_home = None  # type: Optional[str]
 

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -1,9 +1,12 @@
 import json
 import pytest
-from typing import Any  # NOQA
-from typing import Dict  # NOQA
 
 from optuna import distributions
+from optuna import types
+
+if types.TYPE_CHECKING:
+    from typing import Any  # NOQA
+    from typing import Dict  # NOQA
 
 EXAMPLE_DISTRIBUTIONS = {
     'u': distributions.UniformDistribution(low=1., high=2.),

--- a/tests/test_study.py
+++ b/tests/test_study.py
@@ -5,12 +5,15 @@ import pickle
 import pytest
 import threading
 import time
-from typing import Any  # NOQA
-from typing import Dict  # NOQA
-from typing import Optional  # NOQA
 
 import optuna
 from optuna.testing.storage import StorageSupplier
+from optuna import types
+
+if types.TYPE_CHECKING:
+    from typing import Any  # NOQA
+    from typing import Dict  # NOQA
+    from typing import Optional  # NOQA
 
 STORAGE_MODES = [
     'none',  # We give `None` to storage argument, so InMemoryStorage is used.

--- a/tests/test_trial.py
+++ b/tests/test_trial.py
@@ -1,7 +1,6 @@
 from mock import Mock
 from mock import patch
 import pytest
-import typing  # NOQA
 
 from optuna import distributions
 from optuna import samplers
@@ -9,6 +8,10 @@ from optuna import storages
 from optuna.study import create_study
 from optuna.trial import FixedTrial
 from optuna.trial import Trial
+from optuna import types
+
+if types.TYPE_CHECKING:
+    import typing  # NOQA
 
 parametrize_storage = pytest.mark.parametrize(
     'storage_init_func',


### PR DESCRIPTION
`typing` module of Python3.5.0 and Python3.5.1 has not defined some classes that are provided in other Python versions (e.g., `typing.Type` class).
Because of this, in Python3.5.1 (or 3.5.0), `import optuna` fails as follows
```console
$ docker run --rm -it python:3.5.1 /bin/bash
# git clone -b master git://github.com/pfnet/optuna
# cd optuna

$ pip install --upgrade pip
# pip install .
# python -c 'import optuna; print("OK")'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/optuna/optuna/__init__.py", line 2, in <module>
    from optuna import dashboard  # NOQA
  File "/optuna/optuna/dashboard.py", line 26, in <module>
    import optuna.study
  File "/optuna/optuna/study.py", line 17, in <module>
    from typing import Type  # NOQA
ImportError: cannot import name 'Type'
```

However, these missing classes are only needed for type checking by `mypy` and unnecessary for ordinal program executions.
In this PR, I changed to import those classes only when `optuna.types.TYPE_CHECKING` flag is set.
By this modification, `import optuna` became to work well in Python3.5.0 and Python3.5.1.
```console
$ docker run --rm -it python:3.5.1 /bin/bash
# git clone -b fix-import-typing-error git://github.com/pfnet/optuna
# cd optuna

# pip install --upgrade pip
# pip install .
# python -c 'import optuna; print("OK")'
OK
```