### PR TITLE
Fix daily CI failure (Tensorflow example name confliction).

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -14,7 +14,7 @@ This page contains a list of example codes written with Optuna.
 * [ChainerMN](./chainermn_simple.py)
 * [LighGBM](./lightgbm_simple.py)
 * [XGBoost](./xgboost_simple.py)
-* [Tensorflow](./tensorflow_estimator.py)
+* [Tensorflow](./tensorflow_estimator_simple.py)
 
 ### An example where an objective function uses additional arguments
 

--- a/examples/tensorflow_estimator_simple.py
+++ b/examples/tensorflow_estimator_simple.py
@@ -9,13 +9,13 @@ subset of it.
 We have the following two ways to execute this example:
 
 (1) Execute this code directly.
-    $ python tensorflow_estimator.py
+    $ python tensorflow_estimator_simple.py
 
 
 (2) Execute through CLI.
     $ STUDY_NAME=`optuna create-study --storage sqlite:///example.db`
-    $ optuna study optimize tensorflow_estimator.py objective --n-trials=100 --study $STUDY_NAME \
-      --storage sqlite:///example.db
+    $ optuna study optimize tensorflow_estimator_simple.py objective --n-trials=100 \
+      --study $STUDY_NAME --storage sqlite:///example.db
 
 """
 


### PR DESCRIPTION
The up-to-date `tensorflow` (v1.13.1) includes a new dependent package named `tensorflow_estimator`.
Since the name conflicts with `optuna/examples/tensorflow_estimator.py`, the latest daily CI has failed due to the confliction (e.g., [CircleCI: examples-python37#10208](https://circleci.com/gh/pfnet/optuna/10208)).
For resolving this issue, this PR renames  `examples/tensorflow_estimator.py` to `examples/tensorflow_estimator_simple.py`.