### PR TITLE
Add `load_study` function.

### DIFF
--- a/docs/source/reference/study.rst
+++ b/docs/source/reference/study.rst
@@ -8,4 +8,5 @@ Study
     :exclude-members: system_attrs, set_system_attr
 
 .. autofunction:: create_study
+.. autofunction:: load_study
 .. autofunction:: get_all_study_summaries

--- a/optuna/__init__.py
+++ b/optuna/__init__.py
@@ -14,6 +14,7 @@ from optuna import visualization  # NOQA
 
 from optuna.study import create_study  # NOQA
 from optuna.study import get_all_study_summaries  # NOQA
+from optuna.study import load_study  # NOQA
 from optuna.study import Study  # NOQA
 from optuna.trial import Trial  # NOQA
 from optuna.version import __version__  # NOQA

--- a/optuna/study.py
+++ b/optuna/study.py
@@ -30,13 +30,13 @@ ObjectiveFuncType = Callable[[trial_module.Trial], float]
 class Study(object):
     """A study corresponds to an optimization task, i.e., a set of trials.
 
+    Note that the direct use of this constructor is not recommended.
+
     This object provides interfaces to run a new :class:`~optuna.trial.Trial`, access trials'
     history, set/get user-defined attributes of the study itself.
 
     For creating and loading studies, please refer to the documentation of
     :func:`~optuna.study.create_study` and :func:`~optuna.study.load_study` respectively.
-
-    Note that the direct use of this constructor is not recommended.
 
     Args:
         study_name:

--- a/optuna/study.py
+++ b/optuna/study.py
@@ -33,6 +33,11 @@ class Study(object):
     This object provides interfaces to run a new :class:`~optuna.trial.Trial`, access trials'
     history, set/get user-defined attributes of the study itself.
 
+    For creating and loading studies, please refer to the documentation of
+    :func:`~optuna.study.create_study` and :func:`~optuna.study.load_study` respectively.
+
+    Note that the direct use of this constructor is not recommended.
+
     Args:
         study_name:
             Study's name. Each study has a unique name as an identifier.
@@ -51,7 +56,8 @@ class Study(object):
             as the default. See also :class:`~optuna.pruners`.
         direction:
             Direction of optimization. Set ``minimize`` for minimization and ``maximize`` for
-            maximization. Note that ``maximize`` is currently unsupported.
+            maximization. Note that this argument currently has no effect and will be removed
+            in the future.
 
     """
 
@@ -72,20 +78,6 @@ class Study(object):
 
         self.study_id = self.storage.get_study_id_from_name(study_name)
         self.logger = logging.get_logger(__name__)
-
-        if direction == 'minimize':
-            _direction = structs.StudyDirection.MINIMIZE
-        elif direction == 'maximize':
-            _direction = structs.StudyDirection.MAXIMIZE
-        else:
-            raise ValueError('Please set either \'minimize\' or \'maximize\' to direction.')
-
-        # TODO(Yanase): Implement maximization.
-        if _direction == structs.StudyDirection.MAXIMIZE:
-            raise ValueError('Optimization direction of study {} is set to `MAXIMIZE`. '
-                             'Currently, Optuna supports `MINIMIZE` only.'.format(study_name))
-
-        self.storage.set_study_direction(self.study_id, _direction)
 
     def __getstate__(self):
         # type: () -> Dict[Any, Any]
@@ -511,13 +503,59 @@ def create_study(
             raise
 
     study_name = storage.get_study_name_from_id(study_id)
-
-    return Study(
+    study = Study(
         study_name=study_name,
         storage=storage,
         sampler=sampler,
         pruner=pruner,
         direction=direction)
+
+    if direction == 'minimize':
+        _direction = structs.StudyDirection.MINIMIZE
+    elif direction == 'maximize':
+        _direction = structs.StudyDirection.MAXIMIZE
+    else:
+        raise ValueError('Please set either \'minimize\' or \'maximize\' to direction.')
+
+    # TODO(Yanase): Implement maximization.
+    if _direction == structs.StudyDirection.MAXIMIZE:
+        raise ValueError('Optimization direction of study {} is set to `MAXIMIZE`. '
+                         'Currently, Optuna supports `MINIMIZE` only.'.format(study_name))
+
+    study.storage.set_study_direction(study_id, _direction)
+
+    return study
+
+
+def load_study(
+        study_name,  # type: str
+        storage,  # type: Union[str, storages.BaseStorage]
+        sampler=None,  # type: samplers.BaseSampler
+        pruner=None,  # type: pruners.BasePruner
+):
+    # type: (...) -> Study
+    """Load the existing :class:`~optuna.study.Study` that has the specified name.
+
+    Args:
+        study_name:
+            Study's name. Each study has a unique name as an identifier.
+        storage:
+            Database URL such as ``sqlite:///example.db``. Optuna internally uses `SQLAlchemy
+            <https://www.sqlalchemy.org/>`_ to handle databases. Please refer to `SQLAlchemy's
+            document <https://docs.sqlalchemy.org/en/latest/core/engines.html#database-urls>`_ for
+            further details.
+        sampler:
+            A sampler object that implements background algorithm for value suggestion.
+            If :obj:`None` is specified, :class:`~optuna.samplers.TPESampler` is used
+            as the default. See also :class:`~optuna.samplers`.
+        pruner:
+            A pruner object that decides early stopping of unpromising trials.
+            If :obj:`None` is specified, :class:`~optuna.pruners.MedianPruner` is used
+            as the default. See also :class:`~optuna.pruners`.
+
+    """
+
+    return Study(study_name=study_name, storage=storage, sampler=sampler, pruner=pruner)
 
 
 def get_all_study_summaries(storage):

--- a/tests/test_study.py
+++ b/tests/test_study.py
@@ -8,6 +8,7 @@ import time
 from typing import Any  # NOQA
 from typing import Dict  # NOQA
 from typing import Optional  # NOQA
+import uuid
 
 import optuna
 from optuna.testing.storage import StorageSupplier
@@ -485,3 +486,26 @@ def test_create_study(storage_mode):
             with pytest.raises(optuna.structs.DuplicatedStudyError):
                 optuna.create_study(
                     study_name=study.study_name, storage=storage, load_if_exists=False)
+
+
+@pytest.mark.parametrize('storage_mode', STORAGE_MODES)
+def test_load_study(storage_mode):
+    # type: (str) -> None
+
+    with StorageSupplier(storage_mode) as storage:
+        if storage is None:
+            # `InMemoryStorage` can not be used with `load_study` function.
+            return
+
+        study_name = str(uuid.uuid4())
+
+        with pytest.raises(ValueError):
+            # Test loading an unexisting study.
+            optuna.study.load_study(study_name=study_name, storage=storage)
+
+        # Create a new study.
+        created_study = optuna.study.create_study(study_name=study_name, storage=storage)
+
+        # Test loading an existing study.
+        loaded_study = optuna.study.load_study(study_name=study_name, storage=storage)
+        assert created_study.study_id == loaded_study.study_id


### PR DESCRIPTION
Currently, `optuna.study.Study()` constructor can be used to load existing studies. 
However, since this behavior is a bit confusing, this PR adds a more intuitive function `optuna.study.load_study()` for this purpose.

# Generated Documentation

![image](https://user-images.githubusercontent.com/181413/53783375-9fa98300-3f54-11e9-9beb-ae31d8cd9bf5.png)

![image](https://user-images.githubusercontent.com/181413/53782970-1ba2cb80-3f53-11e9-89ac-90ca8502c413.png)
