### PR TITLE
Add implementation of maximize.

### DIFF
--- a/examples/pruning/tensorflow_estimator_integration.py
+++ b/examples/pruning/tensorflow_estimator_integration.py
@@ -88,7 +88,6 @@ def objective(trial):
         trial=trial,
         estimator=mnist_classifier,
         metric="accuracy",
-        is_higher_better=True,
         run_every_steps=PRUNING_INTERVAL_STEPS,
     )
 
@@ -105,11 +104,11 @@ def objective(trial):
         input_fn=eval_input_fn, steps=EVAL_STEPS, start_delay_secs=0, throttle_secs=0)
 
     eval_results, _ = tf.estimator.train_and_evaluate(mnist_classifier, train_spec, eval_spec)
-    return 1 - float(eval_results['accuracy'])
+    return float(eval_results['accuracy'])
 
 
 def main(unused_argv):
-    study = optuna.create_study()
+    study = optuna.create_study(direction='maximize')
     study.optimize(objective, n_trials=25)
     pruned_trials = [t for t in study.trials if t.state == optuna.structs.TrialState.PRUNED]
     complete_trials = [t for t in study.trials if t.state == optuna.structs.TrialState.COMPLETE]

--- a/optuna/integration/lightgbm.py
+++ b/optuna/integration/lightgbm.py
@@ -75,6 +75,9 @@ class LightGBMPruningCallback(object):
             if is_higher_better:
                 assert self.trial.storage.get_study_direction(self.trial.study_id) == \
                     optuna.structs.StudyDirection.MAXIMIZE
+            else:
+                assert self.trial.storage.get_study_direction(self.trial.study_id) == \
+                    optuna.structs.StudyDirection.MINIMIZE
 
             self.trial.report(current_score, step=env.iteration)
             if self.trial.should_prune(env.iteration):

--- a/optuna/integration/lightgbm.py
+++ b/optuna/integration/lightgbm.py
@@ -73,11 +73,19 @@ class LightGBMPruningCallback(object):
                 continue
 
             if is_higher_better:
-                assert self.trial.storage.get_study_direction(self.trial.study_id) == \
-                    optuna.structs.StudyDirection.MAXIMIZE
+                if self.trial.storage.get_study_direction(self.trial.study_id) != \
+                        optuna.structs.StudyDirection.MAXIMIZE:
+                    raise ValueError(
+                        "The intermediate values are inconsistent with the objective values in "
+                        "terms of study directions. Please specify a metric to be minimized for "
+                        "LightGBMPruningCallback.")
             else:
-                assert self.trial.storage.get_study_direction(self.trial.study_id) == \
-                    optuna.structs.StudyDirection.MINIMIZE
+                if self.trial.storage.get_study_direction(self.trial.study_id) != \
+                        optuna.structs.StudyDirection.MINIMIZE:
+                    raise ValueError(
+                        "The intermediate values are inconsistent with the objective values in "
+                        "terms of study directions. Please specify a metric to be maximized for "
+                        "LightGBMPruningCallback.")
 
             self.trial.report(current_score, step=env.iteration)
             if self.trial.should_prune(env.iteration):

--- a/optuna/integration/lightgbm.py
+++ b/optuna/integration/lightgbm.py
@@ -72,11 +72,9 @@ class LightGBMPruningCallback(object):
             if valid_name != target_valid_name or metric != self.metric:
                 continue
 
-            # TODO(ohta): Deal with maximize direction
             if is_higher_better:
-                raise ValueError(
-                    'Pruning using metrics to be maximized has not been supported yet '
-                    '(validation_name: {}, metric: {}).'.format(valid_name, metric))
+                assert self.trial.storage.get_study_direction(self.trial.study_id) == \
+                    optuna.structs.StudyDirection.MAXIMIZE
 
             self.trial.report(current_score, step=env.iteration)
             if self.trial.should_prune(env.iteration):

--- a/optuna/integration/tensorflow.py
+++ b/optuna/integration/tensorflow.py
@@ -90,9 +90,10 @@ class TensorFlowPruningHook(SessionRunHook):
             if summary_step > self.current_summary_step:
                 # TODO(sano): Remove the following if block after implementing maximize.
                 if self.is_higher_better:
-                    current_score = 1.0 - latest_eval_metrics[self.metric]
-                else:
-                    current_score = latest_eval_metrics[self.metric]
+                    assert self.trial.storage.get_study_direction(self.trial.study_id) == \
+                        optuna.structs.StudyDirection.MAXIMIZE
+
+                current_score = latest_eval_metrics[self.metric]
                 self.trial.report(current_score, step=summary_step)
                 self.current_summary_step = summary_step
             if self.trial.should_prune(self.current_summary_step):

--- a/optuna/integration/tensorflow.py
+++ b/optuna/integration/tensorflow.py
@@ -65,7 +65,7 @@ class TensorFlowPruningHook(SessionRunHook):
         self.timer = tf.train.SecondOrStepTimer(every_secs=None, every_steps=run_every_steps)
 
         if is_higher_better is not None:
-            raise ValueError('Please do not set any values to is_higher_better argument of'
+            raise ValueError('Please do not use is_higher_better argument of'
                              'TensorFlowPruningHook.__init__().')
 
     def begin(self):

--- a/optuna/integration/tensorflow.py
+++ b/optuna/integration/tensorflow.py
@@ -65,8 +65,9 @@ class TensorFlowPruningHook(SessionRunHook):
         self.timer = tf.train.SecondOrStepTimer(every_secs=None, every_steps=run_every_steps)
 
         if is_higher_better is not None:
-            raise ValueError('Please do not use is_higher_better argument of'
-                             'TensorFlowPruningHook.__init__().')
+            raise ValueError('Please do not use is_higher_better argument of '
+                             'TensorFlowPruningHook.__init__(). is_higher_better argument '
+                             'is obsolete since Optuna 0.9.0.')
 
     def begin(self):
         # type: () -> None

--- a/optuna/integration/tensorflow.py
+++ b/optuna/integration/tensorflow.py
@@ -2,6 +2,9 @@ from __future__ import absolute_import
 
 import optuna
 
+if optuna.types.TYPE_CHECKING:
+    from typing import Optional  # NOQA
+
 try:
     import tensorflow as tf
     from tensorflow.train import SessionRunHook
@@ -43,24 +46,27 @@ class TensorFlowPruningHook(SessionRunHook):
             An estimator which you will use.
         metric:
             An evaluation metric for pruning, e.g., ``accuracy`` and ``loss``.
-        is_higher_better:
-           It should be :obj:`True` if you use a metric to be maximize such as ``accuracy``.
         run_every_steps:
            An interval to watch the summary file.
+        is_higher_better:
+           Please do not use this argument because this class refers to
+           :class:`~optuna.structs.StudyDirection` to check whether the current study is
+           ``minimize`` or ``maximize``.
     """
 
-    # TODO(sano): Remove is_higher_better after implementing maximize.
-    # TODO(sano): Get the information from StudyDirection.
-    def __init__(self, trial, estimator, metric, is_higher_better, run_every_steps):
-        # type: (optuna.trial.Trial, tf.estimator.Estimator, str, bool, int) -> None
+    def __init__(self, trial, estimator, metric, run_every_steps, is_higher_better=None):
+        # type: (optuna.trial.Trial, tf.estimator.Estimator, str, int, Optional[bool]) -> None
 
         self.trial = trial
         self.estimator = estimator
         self.current_summary_step = -1
         self.metric = metric
-        self.is_higher_better = is_higher_better
         self.global_step_tensor = None
         self.timer = tf.train.SecondOrStepTimer(every_secs=None, every_steps=run_every_steps)
+
+        if is_higher_better is not None:
+            raise ValueError('Please do not set any values to is_higher_better argument of'
+                             'TensorFlowPruningHook.__init__().')
 
     def begin(self):
         # type: () -> None
@@ -88,11 +94,6 @@ class TensorFlowPruningHook(SessionRunHook):
             latest_eval_metrics = eval_metrics[summary_step]
             # If there exists a new evaluation summary.
             if summary_step > self.current_summary_step:
-                # TODO(sano): Remove the following if block after implementing maximize.
-                if self.is_higher_better:
-                    assert self.trial.storage.get_study_direction(self.trial.study_id) == \
-                        optuna.structs.StudyDirection.MAXIMIZE
-
                 current_score = latest_eval_metrics[self.metric]
                 self.trial.report(current_score, step=summary_step)
                 self.current_summary_step = summary_step

--- a/optuna/pruners/median.py
+++ b/optuna/pruners/median.py
@@ -2,6 +2,7 @@ import math
 
 from optuna.pruners import BasePruner
 from optuna.storages import BaseStorage  # NOQA
+from optuna.structs import StudyDirection
 from optuna.structs import TrialState
 
 
@@ -65,4 +66,6 @@ class MedianPruner(BasePruner):
         if math.isnan(median):
             return False
 
+        if storage.get_study_direction(study_id) == StudyDirection.MAXIMIZE:
+            return best_intermediate_result < median
         return best_intermediate_result > median

--- a/optuna/pruners/successive_halving.py
+++ b/optuna/pruners/successive_halving.py
@@ -134,6 +134,7 @@ class SuccessiveHalvingPruner(BasePruner):
             promotable_idx = 0
 
         if study_direction == StudyDirection.MAXIMIZE:
+            competing_values.reverse()
             return value >= competing_values[promotable_idx]
 
         return value <= competing_values[promotable_idx]

--- a/optuna/samplers/tpe/sampler.py
+++ b/optuna/samplers/tpe/sampler.py
@@ -13,6 +13,7 @@ from optuna.samplers import random  # NOQA
 from optuna.samplers.tpe.parzen_estimator import ParzenEstimator  # NOQA
 from optuna.samplers.tpe.parzen_estimator import ParzenEstimatorParameters  # NOQA
 from optuna.storages.base import BaseStorage  # NOQA
+from optuna.structs import StudyDirection
 
 EPS = 1e-12
 
@@ -67,6 +68,9 @@ class TPESampler(base.BaseSampler):
         # type: (BaseStorage, int, str, BaseDistribution) -> float
 
         observation_pairs = storage.get_trial_param_result_pairs(study_id, param_name)
+        if storage.get_study_direction(study_id) == StudyDirection.MAXIMIZE:
+            observation_pairs = [(p, -v) for p, v in observation_pairs]
+
         n = len(observation_pairs)
 
         if n < self.n_startup_trials:

--- a/optuna/storages/base.py
+++ b/optuna/storages/base.py
@@ -58,6 +58,12 @@ class BaseStorage(object):
         raise NotImplementedError
 
     @abc.abstractmethod
+    def get_study_id_from_trial_id(self, trial_id):
+        # type: (int) -> int
+
+        raise NotImplementedError
+
+    @abc.abstractmethod
     def get_study_name_from_id(self, study_id):
         # type: (int) -> str
 
@@ -172,7 +178,8 @@ class BaseStorage(object):
         if len(all_trials) == 0:
             raise ValueError('No trials are completed yet.')
 
-        # TODO(sano): Deal with maximize direction.
+        if self.get_study_direction(study_id) == structs.StudyDirection.MAXIMIZE:
+            return max(all_trials, key=lambda t: t.value)
         return min(all_trials, key=lambda t: t.value)
 
     def get_trial_params(self, trial_id):
@@ -209,8 +216,12 @@ class BaseStorage(object):
     def get_best_intermediate_result_over_steps(self, trial_id):
         # type: (int) -> float
 
-        return np.nanmin(
-            np.array(list(self.get_trial(trial_id).intermediate_values.values()), np.float))
+        values = np.array(list(self.get_trial(trial_id).intermediate_values.values()), np.float)
+
+        study_id = self.get_study_id_from_trial_id(trial_id)
+        if self.get_study_direction(study_id) == structs.StudyDirection.MAXIMIZE:
+            return np.nanmax(values)
+        return np.nanmin(values)
 
     def get_median_intermediate_result_over_trials(self, study_id, step):
         # type: (int, int) -> float

--- a/optuna/storages/in_memory.py
+++ b/optuna/storages/in_memory.py
@@ -80,6 +80,11 @@ class InMemoryStorage(base.BaseStorage):
 
         return IN_MEMORY_STORAGE_STUDY_ID
 
+    def get_study_id_from_trial_id(self, trial_id):
+        # type: (int) -> int
+
+        return IN_MEMORY_STORAGE_STUDY_ID
+
     def get_study_name_from_id(self, study_id):
         # type: (int) -> str
 

--- a/optuna/storages/rdb/storage.py
+++ b/optuna/storages/rdb/storage.py
@@ -142,6 +142,15 @@ class RDBStorage(BaseStorage):
 
         return study.study_id
 
+    def get_study_id_from_trial_id(self, trial_id):
+        # type: (int) -> int
+
+        session = self.scoped_session()
+
+        trial = models.TrialModel.find_or_raise_by_id(trial_id, session)
+
+        return trial.study_id
+
     def get_study_name_from_id(self, study_id):
         # type: (int) -> str
 
@@ -220,8 +229,10 @@ class RDBStorage(BaseStorage):
             ]
             best_trial = None
             if len(completed_trial_models) > 0:
-                # TODO(sano): Deal with maximize direction.
-                best_trial_model = min(completed_trial_models, key=lambda t: t.value)
+                if study_model.direction == structs.StudyDirection.MAXIMIZE:
+                    best_trial_model = max(completed_trial_models, key=lambda t: t.value)
+                else:
+                    best_trial_model = min(completed_trial_models, key=lambda t: t.value)
 
                 best_param_models = [
                     p for p in param_models if p.trial_id == best_trial_model.trial_id

--- a/optuna/study.py
+++ b/optuna/study.py
@@ -478,7 +478,7 @@ def create_study(
             automatically.
         direction:
             Direction of optimization. Set ``minimize`` for minimization and ``maximize`` for
-            maximization. Note that ``maximize`` is currently unsupported.
+            maximization.
         load_if_exists:
             Flag to control the behavior to handle a conflict of study names.
             In the case where a study named ``study_name`` already exists in the ``storage``,

--- a/optuna/study.py
+++ b/optuna/study.py
@@ -49,9 +49,6 @@ class Study(object):
             A pruner object that decides early stopping of unpromising trials.
             If :obj:`None` is specified, :class:`~optuna.pruners.MedianPruner` is used
             as the default. See also :class:`~optuna.pruners`.
-        direction:
-            Direction of optimization. Set ``minimize`` for minimization and ``maximize`` for
-            maximization. Note that ``maximize`` is currently unsupported.
 
     """
 
@@ -61,7 +58,6 @@ class Study(object):
             storage,  # type: Union[str, storages.BaseStorage]
             sampler=None,  # type: samplers.BaseSampler
             pruner=None,  # type: pruners.BasePruner
-            direction='minimize',  # type: str
     ):
         # type: (...) -> None
 
@@ -72,20 +68,6 @@ class Study(object):
 
         self.study_id = self.storage.get_study_id_from_name(study_name)
         self.logger = logging.get_logger(__name__)
-
-        if direction == 'minimize':
-            _direction = structs.StudyDirection.MINIMIZE
-        elif direction == 'maximize':
-            _direction = structs.StudyDirection.MAXIMIZE
-        else:
-            raise ValueError('Please set either \'minimize\' or \'maximize\' to direction.')
-
-        # TODO(Yanase): Implement maximization.
-        if _direction == structs.StudyDirection.MAXIMIZE:
-            raise ValueError('Optimization direction of study {} is set to `MAXIMIZE`. '
-                             'Currently, Optuna supports `MINIMIZE` only.'.format(study_name))
-
-        self.storage.set_study_direction(self.study_id, _direction)
 
     def __getstate__(self):
         # type: () -> Dict[Any, Any]
@@ -512,12 +494,20 @@ def create_study(
 
     study_name = storage.get_study_name_from_id(study_id)
 
+    if direction == 'minimize':
+        _direction = structs.StudyDirection.MINIMIZE
+    elif direction == 'maximize':
+        _direction = structs.StudyDirection.MAXIMIZE
+    else:
+        raise ValueError('Please set either \'minimize\' or \'maximize\' to direction.')
+
+    storage.set_study_direction(study_id, _direction)
+
     return Study(
         study_name=study_name,
         storage=storage,
         sampler=sampler,
-        pruner=pruner,
-        direction=direction)
+        pruner=pruner)
 
 
 def get_all_study_summaries(storage):

--- a/tests/integration_tests/test_lightgbm.py
+++ b/tests/integration_tests/test_lightgbm.py
@@ -92,6 +92,16 @@ def test_lightgbm_pruning_callback_errors(cv):
                 n_trials=1,
                 catch=())
 
+    # Check consistency of study direction.
+    study = optuna.create_study(pruner=DeterministicPruner(False))
+    with pytest.raises(ValueError):
+        study.optimize(lambda trial: objective(trial, metric='auc', cv=cv), n_trials=1, catch=())
+
+    study = optuna.create_study(pruner=DeterministicPruner(False), direction='maximize')
+    with pytest.raises(ValueError):
+        study.optimize(
+            lambda trial: objective(trial, metric='binary_error', cv=cv), n_trials=1, catch=())
+
 
 def objective(trial,
               metric='binary_error',

--- a/tests/integration_tests/test_lightgbm.py
+++ b/tests/integration_tests/test_lightgbm.py
@@ -61,15 +61,20 @@ def test_lightgbm_pruning_callback(cv):
     assert study.trials[0].state == optuna.structs.TrialState.COMPLETE
     assert study.trials[0].value == 1.
 
+    # Check "maximize" direction.
+    study = optuna.create_study(pruner=DeterministicPruner(True), direction='maximize')
+    study.optimize(lambda trial: objective(trial, metric='auc', cv=cv), n_trials=1, catch=())
+    assert study.trials[0].state == optuna.structs.TrialState.PRUNED
+
+    study = optuna.create_study(pruner=DeterministicPruner(False), direction='maximize')
+    study.optimize(lambda trial: objective(trial, metric='auc', cv=cv), n_trials=1, catch=())
+    assert study.trials[0].state == optuna.structs.TrialState.COMPLETE
+    assert study.trials[0].value == 1.
+
 
 @pytest.mark.parametrize('cv', CV_FLAGS)
 def test_lightgbm_pruning_callback_errors(cv):
     # type: (bool) -> None
-
-    # "maximize" direction isn't supported yet.
-    study = optuna.create_study(pruner=DeterministicPruner(False))
-    with pytest.raises(ValueError):
-        study.optimize(lambda trial: objective(trial, metric='auc', cv=cv), n_trials=1, catch=())
 
     # Unknown metric
     study = optuna.create_study(pruner=DeterministicPruner(False))

--- a/tests/integration_tests/test_tensorflow.py
+++ b/tests/integration_tests/test_tensorflow.py
@@ -67,3 +67,24 @@ def test_tensorflow_pruning_hook():
     study.optimize(objective, n_trials=1)
     assert study.trials[0].state == optuna.structs.TrialState.COMPLETE
     assert study.trials[0].value == 1.0
+
+
+@pytest.mark.parametrize('is_higher_better', [True, False])
+def test_init_with_is_higher_better(is_higher_better):
+    # type: (bool) -> None
+
+    clf = tf.estimator.DNNClassifier(
+        hidden_units=[],
+        feature_columns=[tf.feature_column.numeric_column(key="x", shape=[20])],
+        model_dir=None,
+        n_classes=2,
+        config=tf.estimator.RunConfig(save_summary_steps=10, save_checkpoints_steps=10),
+    )
+
+    with pytest.raises(ValueError):
+        TensorFlowPruningHook(
+            trial=optuna.trial.Trial(optuna.create_study(), 0),
+            estimator=clf,
+            metric="accuracy",
+            run_every_steps=5,
+            is_higher_better=is_higher_better)

--- a/tests/integration_tests/test_tensorflow.py
+++ b/tests/integration_tests/test_tensorflow.py
@@ -51,7 +51,6 @@ def test_tensorflow_pruning_hook():
             trial=trial,
             estimator=clf,
             metric="accuracy",
-            is_higher_better=True,
             run_every_steps=5,
         )
         train_spec = tf.estimator.TrainSpec(

--- a/tests/integration_tests/test_tensorflow.py
+++ b/tests/integration_tests/test_tensorflow.py
@@ -57,11 +57,11 @@ def test_tensorflow_pruning_hook():
         tf.estimator.train_and_evaluate(estimator=clf, train_spec=train_spec, eval_spec=eval_spec)
         return 1.0
 
-    study = optuna.create_study(pruner=DeterministicPruner(True))
+    study = optuna.create_study(pruner=DeterministicPruner(True), direction='maximize')
     study.optimize(objective, n_trials=1)
     assert study.trials[0].state == optuna.structs.TrialState.PRUNED
 
-    study = optuna.create_study(pruner=DeterministicPruner(False))
+    study = optuna.create_study(pruner=DeterministicPruner(False), direction='maximize')
     study.optimize(objective, n_trials=1)
     assert study.trials[0].state == optuna.structs.TrialState.COMPLETE
     assert study.trials[0].value == 1.0

--- a/tests/integration_tests/test_tensorflow.py
+++ b/tests/integration_tests/test_tensorflow.py
@@ -73,6 +73,11 @@ def test_tensorflow_pruning_hook():
 def test_init_with_is_higher_better(is_higher_better):
     # type: (bool) -> None
 
+    # TODO(Yanase): remove this "if" section after TensorFlow supports Python 3.7.
+    if not _available:
+        pytest.skip('This test requires TensorFlow '
+                    'but this version can not install TensorFlow with pip.')
+
     clf = tf.estimator.DNNClassifier(
         hidden_units=[],
         feature_columns=[tf.feature_column.numeric_column(key="x", shape=[20])],

--- a/tests/pruners_tests/test_median.py
+++ b/tests/pruners_tests/test_median.py
@@ -1,5 +1,11 @@
+import pytest
+
 import optuna
 from optuna.structs import TrialState
+from optuna import types
+
+if types.TYPE_CHECKING:
+    from typing import Tuple  # NOQA
 
 
 def test_median_pruner_with_one_trial():
@@ -15,11 +21,13 @@ def test_median_pruner_with_one_trial():
         storage=study.storage, study_id=study.study_id, trial_id=trial.trial_id, step=1)
 
 
-def test_median_pruner_intermediate_values():
-    # type: () -> None
+@pytest.mark.parametrize('direction_value', [('minimize', 2), ('maximize', 0.5)])
+def test_median_pruner_intermediate_values(direction_value):
+    # type: (Tuple[str, float]) -> None
 
+    direction, intermediate_value = direction_value
     pruner = optuna.pruners.MedianPruner(0, 0)
-    study = optuna.study.create_study()
+    study = optuna.study.create_study(direction=direction)
 
     trial = optuna.trial.Trial(study, study.storage.create_new_trial_id(study.study_id))
     trial.report(1, 1)
@@ -30,7 +38,7 @@ def test_median_pruner_intermediate_values():
     assert not pruner.prune(
         storage=study.storage, study_id=study.study_id, trial_id=trial.trial_id, step=1)
 
-    trial.report(2, 1)
+    trial.report(intermediate_value, 1)
     # A pruner is activated if a trial has an intermediate value.
     assert pruner.prune(
         storage=study.storage, study_id=study.study_id, trial_id=trial.trial_id, step=1)

--- a/tests/pruners_tests/test_successive_halving.py
+++ b/tests/pruners_tests/test_successive_halving.py
@@ -1,14 +1,20 @@
 import pytest
 
 import optuna
+from optuna import types
+
+if types.TYPE_CHECKING:
+    from typing import Tuple  # NOQA
 
 
-def test_successive_halving_pruner_intermediate_values():
-    # type: () -> None
+@pytest.mark.parametrize('direction_value', [('minimize', 2), ('maximize', 0.5)])
+def test_successive_halving_pruner_intermediate_values(direction_value):
+    # type: (Tuple[str, float]) -> None
 
+    direction, intermediate_value = direction_value
     pruner = optuna.pruners.SuccessiveHalvingPruner(
         min_resource=1, reduction_factor=2, min_early_stopping_rate=0)
-    study = optuna.study.create_study()
+    study = optuna.study.create_study(direction=direction)
 
     trial = optuna.trial.Trial(study, study.storage.create_new_trial_id(study.study_id))
     trial.report(1, 1)
@@ -20,7 +26,7 @@ def test_successive_halving_pruner_intermediate_values():
     # A pruner is not activated if a trial has no intermediate values.
     assert not pruner.prune(study.storage, study.study_id, trial.trial_id, step=1)
 
-    trial.report(2, 1)
+    trial.report(intermediate_value, 1)
     # A pruner is activated if a trial has an intermediate value.
     assert pruner.prune(study.storage, study.study_id, trial.trial_id, step=1)
 

--- a/tests/storages_tests/rdb_tests/test_storage.py
+++ b/tests/storages_tests/rdb_tests/test_storage.py
@@ -128,12 +128,14 @@ def test_get_all_study_summaries_with_multiple_studies():
     study_id_2 = storage.create_new_study_id()
     storage.set_study_direction(study_id_2, StudyDirection.MAXIMIZE)
 
-    # TODO(sano): Add more trials after implementing maximize.
     trial_id_2_1 = storage.create_new_trial_id(study_id_2)
+    trial_id_2_2 = storage.create_new_trial_id(study_id_2)
 
     storage.set_trial_value(trial_id_2_1, -100)
+    storage.set_trial_value(trial_id_2_2, -200)
 
     storage.set_trial_state(trial_id_2_1, TrialState.COMPLETE)
+    storage.set_trial_state(trial_id_2_2, TrialState.COMPLETE)
 
     # Set up an empty study.
     study_id_3 = storage.create_new_study_id()
@@ -158,7 +160,7 @@ def test_get_all_study_summaries_with_multiple_studies():
         user_attrs={},
         system_attrs={},
         best_trial=summaries[1].best_trial,  # This always passes.
-        n_trials=1,
+        n_trials=2,
         datetime_start=summaries[1].datetime_start  # This always passes.
     )
     expected_summary_3 = StudySummary(

--- a/tests/storages_tests/test_storages.py
+++ b/tests/storages_tests/test_storages.py
@@ -164,6 +164,22 @@ def test_get_study_id_from_name_and_get_study_name_from_id(storage_mode):
             storage.get_study_name_from_id(-1)
 
 
+@pytest.mark.parametrize('storage_mode', STORAGE_MODES)
+def test_get_study_id_from_trial_id(storage_mode):
+    # type: (str) -> None
+
+    with StorageSupplier(storage_mode) as storage:
+
+        # Generate unique study_name from the current function name and storage_mode.
+        storage = optuna.storages.get_storage(storage)
+
+        # Check if trial_number starts from 0.
+        study_id = storage.create_new_study_id()
+
+        trial_id = storage.create_new_trial_id(study_id)
+        assert storage.get_study_id_from_trial_id(trial_id) == study_id
+
+
 @parametrize_storage
 def test_set_and_get_study_direction(storage_init_func):
     # type: (Callable[[], BaseStorage]) -> None

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -126,10 +126,9 @@ def test_create_study_command_with_direction():
         assert storage.get_study_direction(study_id) == optuna.structs.StudyDirection.MINIMIZE
 
         command = ['optuna', 'create-study', '--storage', storage_url, '--direction', 'maximize']
-
-        # Currently, 'maximize' is not implemented.
-        with pytest.raises(subprocess.CalledProcessError):
-            subprocess.check_call(command)
+        study_name = str(subprocess.check_output(command).decode().strip())
+        study_id = storage.get_study_id_from_name(study_name)
+        assert storage.get_study_direction(study_id) == optuna.structs.StudyDirection.MAXIMIZE
 
         command = ['optuna', 'create-study', '--storage', storage_url, '--direction', 'test']
 

--- a/tests/test_study.py
+++ b/tests/test_study.py
@@ -140,12 +140,10 @@ def test_optimize_with_direction():
     assert study.direction == optuna.structs.StudyDirection.MINIMIZE
     check_study(study)
 
-    # Currently, maximization is not implemented.
-    with pytest.raises(ValueError):
-        study = optuna.create_study(direction='maximize')
-        study.optimize(func, n_trials=10)
-        assert study.direction == optuna.structs.StudyDirection.MAXIMIZE
-        check_study(study)
+    study = optuna.create_study(direction='maximize')
+    study.optimize(func, n_trials=10)
+    assert study.direction == optuna.structs.StudyDirection.MAXIMIZE
+    check_study(study)
 
     with pytest.raises(ValueError):
         optuna.create_study(direction='test')


### PR DESCRIPTION
This PR adds logic to support maximization. With this PR, users can write maximization simply as follows:

```python
import sklearn.datasets
import sklearn.model_selection
import sklearn.svm

def objective(trial):
    iris = sklearn.datasets.load_iris()
    x, y = iris.data, iris.target

    svc_c = trial.suggest_loguniform('svc_c', 1e-10, 1e10)
    classifier_obj = sklearn.svm.SVC(C=svc_c)
    score = sklearn.model_selection.cross_val_score(classifier_obj, x, y, n_jobs=-1, cv=3)
    accuracy = score.mean()
    return accuracy  # Directly use accuracy as an objective value.


if __name__ == '__main__':
    import optuna
    study = optuna.create_study(direction='maximize')  # Set study direction to maximize.
    study.optimize(objective, n_trials=100)
    print(study.best_trial)
```

I have two concerns.

1) This implementation assumes that users use the same direction both for samplers and pruners. This assumption makes implementation simple, but it will suppress flexibility. For instance, [this example](https://github.com/pfnet/optuna/blob/master/examples/pruning/tensorflow_estimator_integration.py) in current master uses validation accuracy for the pruner and validation error for the sampler. On the other hand, validation accuracy is used for both the pruner and the sampler in this PR.

2) Also, this PR contains an API change.  `is_higher_better` argument of TensorFlowPruningHook.__init__() was disabled [here](https://github.com/pfnet/optuna/pull/331/files#diff-6777d6b27690da66a18f118b10e4a1dcR57) to ensure that both samplers and pruners use the same study direction.
