### PR TITLE
Apply lazy import in `optuna.integration` for Python 3.x.

### DIFF
--- a/optuna/integration/__init__.py
+++ b/optuna/integration/__init__.py
@@ -38,6 +38,7 @@ else:
         imports all submodules and their dependencies (e.g., chainer, keras, lightgbm) all at once.
         """
 
+        __file__ = globals()['__file__']
         __path__ = [os.path.dirname(__file__)]
 
         _modules = {

--- a/optuna/integration/__init__.py
+++ b/optuna/integration/__init__.py
@@ -48,13 +48,15 @@ else:
             # type: (str) -> Any
 
             if name in self._modules:
-                return self._get_module(name)
+                value = self._get_module(name)
             elif name in self._class_to_module.keys():
                 module = self._get_module(self._class_to_module[name])
-                return getattr(module, name)
+                value = getattr(module, name)
+            else:
+                raise AttributeError('module {} has no attribute {}'.format(self.__name__, name))
 
-            raise AttributeError(
-                'module {} has no attribute {}'.format(self.__name__, name))
+            setattr(self, name, value)
+            return value
 
         def _get_module(self, module_name):
             # type: (str) -> ModuleType

--- a/optuna/integration/__init__.py
+++ b/optuna/integration/__init__.py
@@ -1,6 +1,71 @@
-from optuna.integration.chainer import ChainerPruningExtension  # NOQA
-from optuna.integration.chainermn import ChainerMNStudy  # NOQA
-from optuna.integration.keras import KerasPruningCallback  # NOQA
-from optuna.integration.lightgbm import LightGBMPruningCallback  # NOQA
-from optuna.integration.tensorflow import TensorFlowPruningHook  # NOQA
-from optuna.integration.xgboost import XGBoostPruningCallback  # NOQA
+import os
+import sys
+from types import ModuleType
+from typing import Any  # NOQA
+
+
+__all__ = [
+    'chainer',
+    'chainermn'
+    'keras',
+    'lightgbm',
+    'tensorflow',
+    'xgboost',
+    'ChainerMNStudy'
+    'ChainerPruningExtension',
+    'KerasPruningCallback',
+    'LightGBMPruningCallback',
+    'TensorFlowPruningHook',
+    'XGBoostPruningCallback',
+]
+
+
+class _IntegrationModule(ModuleType):
+
+    __path__ = [os.path.dirname(__file__)]
+
+    _modules = {
+        'chainer',
+        'chainermn',
+        'keras',
+        'lightgbm',
+        'tensorflow',
+        'xgboost',
+    }
+
+    _class_to_module = {
+        'ChainerMNStudy': 'chainermn',
+        'ChainerPruningExtension': 'chainer',
+        'KerasPruningCallback': 'keras',
+        'LightGBMPruningCallback': 'lightgbm',
+        'TensorFlowPruningHook': 'tensorflow',
+        'XGBoostPruningCallback': 'xgboost',
+    }
+
+    def __getattr__(self, name):
+        # type: (str) -> Any
+
+        if name in self._modules:
+            return self._get_module(name)
+        elif name in self._class_to_module.keys():
+            module = self._get_module(self._class_to_module[name])
+            return getattr(module, name)
+
+        raise AttributeError('module {} has no attribute {}'.format(self.__name__, name))
+
+    if sys.version_info[0] == 2:
+        def _get_module(self, module_name):
+            # type: (str) -> ModuleType
+
+            import imp
+            file, path_name, description = imp.find_module(module_name, self.__path__)
+            return imp.load_module(module_name, file, path_name, description)
+    else:
+        def _get_module(self, module_name):
+            # type: (str) -> ModuleType
+
+            import importlib
+            return importlib.import_module('.' + module_name, self.__name__)
+
+
+sys.modules[__name__] = _IntegrationModule(__name__)

--- a/optuna/integration/__init__.py
+++ b/optuna/integration/__init__.py
@@ -31,6 +31,12 @@ if sys.version_info[0] == 2 or TYPE_CHECKING:
     from optuna.integration.xgboost import XGBoostPruningCallback  # NOQA
 else:
     class _IntegrationModule(ModuleType):
+        """Module class that implements `optuna.integration` package.
+
+        This class applies lazy import under `optuna.integration`, where submodules are imported
+        when they are actually accessed. Otherwise, `import optuna` becomes much slower because it
+        imports all submodules and their dependencies (e.g., chainer, keras, lightgbm) all at once.
+        """
 
         __path__ = [os.path.dirname(__file__)]
 

--- a/optuna/integration/__init__.py
+++ b/optuna/integration/__init__.py
@@ -6,20 +6,17 @@ from typing import Any  # NOQA
 from optuna.types import TYPE_CHECKING
 
 
-__all__ = [
-    'chainer',
-    'chainermn'
-    'keras',
-    'lightgbm',
-    'tensorflow',
-    'xgboost',
-    'ChainerMNStudy'
-    'ChainerPruningExtension',
-    'KerasPruningCallback',
-    'LightGBMPruningCallback',
-    'TensorFlowPruningHook',
-    'XGBoostPruningCallback',
-]
+_import_structure = {
+    'chainer': ['ChainerPruningExtension'],
+    'chainermn': ['ChainerMNStudy'],
+    'keras': ['KerasPruningCallback'],
+    'lightgbm': ['LightGBMPruningCallback'],
+    'tensorflow': ['TensorFlowPruningHook'],
+    'xgboost': ['XGBoostPruningCallback'],
+}
+
+
+__all__ = list(_import_structure.keys()) + sum(_import_structure.values(), [])
 
 
 if sys.version_info[0] == 2 or TYPE_CHECKING:
@@ -41,23 +38,11 @@ else:
         __file__ = globals()['__file__']
         __path__ = [os.path.dirname(__file__)]
 
-        _modules = {
-            'chainer',
-            'chainermn',
-            'keras',
-            'lightgbm',
-            'tensorflow',
-            'xgboost',
-        }
-
-        _class_to_module = {
-            'ChainerMNStudy': 'chainermn',
-            'ChainerPruningExtension': 'chainer',
-            'KerasPruningCallback': 'keras',
-            'LightGBMPruningCallback': 'lightgbm',
-            'TensorFlowPruningHook': 'tensorflow',
-            'XGBoostPruningCallback': 'xgboost',
-        }
+        _modules = set(_import_structure.keys())
+        _class_to_module = {}
+        for key, values in _import_structure.items():
+            for value in values:
+                _class_to_module[value] = key
 
         def __getattr__(self, name):
             # type: (str) -> Any

--- a/optuna/integration/__init__.py
+++ b/optuna/integration/__init__.py
@@ -3,6 +3,8 @@ import sys
 from types import ModuleType
 from typing import Any  # NOQA
 
+from optuna.types import TYPE_CHECKING
+
 
 __all__ = [
     'chainer',
@@ -20,52 +22,52 @@ __all__ = [
 ]
 
 
-class _IntegrationModule(ModuleType):
+if sys.version_info[0] == 2 or TYPE_CHECKING:
+    from optuna.integration.chainer import ChainerPruningExtension  # NOQA
+    from optuna.integration.chainermn import ChainerMNStudy  # NOQA
+    from optuna.integration.keras import KerasPruningCallback  # NOQA
+    from optuna.integration.lightgbm import LightGBMPruningCallback  # NOQA
+    from optuna.integration.tensorflow import TensorFlowPruningHook  # NOQA
+    from optuna.integration.xgboost import XGBoostPruningCallback  # NOQA
+else:
+    class _IntegrationModule(ModuleType):
 
-    __path__ = [os.path.dirname(__file__)]
+        __path__ = [os.path.dirname(__file__)]
 
-    _modules = {
-        'chainer',
-        'chainermn',
-        'keras',
-        'lightgbm',
-        'tensorflow',
-        'xgboost',
-    }
+        _modules = {
+            'chainer',
+            'chainermn',
+            'keras',
+            'lightgbm',
+            'tensorflow',
+            'xgboost',
+        }
 
-    _class_to_module = {
-        'ChainerMNStudy': 'chainermn',
-        'ChainerPruningExtension': 'chainer',
-        'KerasPruningCallback': 'keras',
-        'LightGBMPruningCallback': 'lightgbm',
-        'TensorFlowPruningHook': 'tensorflow',
-        'XGBoostPruningCallback': 'xgboost',
-    }
+        _class_to_module = {
+            'ChainerMNStudy': 'chainermn',
+            'ChainerPruningExtension': 'chainer',
+            'KerasPruningCallback': 'keras',
+            'LightGBMPruningCallback': 'lightgbm',
+            'TensorFlowPruningHook': 'tensorflow',
+            'XGBoostPruningCallback': 'xgboost',
+        }
 
-    def __getattr__(self, name):
-        # type: (str) -> Any
+        def __getattr__(self, name):
+            # type: (str) -> Any
 
-        if name in self._modules:
-            return self._get_module(name)
-        elif name in self._class_to_module.keys():
-            module = self._get_module(self._class_to_module[name])
-            return getattr(module, name)
+            if name in self._modules:
+                return self._get_module(name)
+            elif name in self._class_to_module.keys():
+                module = self._get_module(self._class_to_module[name])
+                return getattr(module, name)
 
-        raise AttributeError('module {} has no attribute {}'.format(self.__name__, name))
+            raise AttributeError(
+                'module {} has no attribute {}'.format(self.__name__, name))
 
-    if sys.version_info[0] == 2:
-        def _get_module(self, module_name):
-            # type: (str) -> ModuleType
-
-            import imp
-            file, path_name, description = imp.find_module(module_name, self.__path__)
-            return imp.load_module(module_name, file, path_name, description)
-    else:
         def _get_module(self, module_name):
             # type: (str) -> ModuleType
 
             import importlib
             return importlib.import_module('.' + module_name, self.__name__)
 
-
-sys.modules[__name__] = _IntegrationModule(__name__)
+    sys.modules[__name__] = _IntegrationModule(__name__)

--- a/tests/integration_tests/test_integration.py
+++ b/tests/integration_tests/test_integration.py
@@ -1,5 +1,4 @@
 import pytest
-import sys
 
 
 def test_import():
@@ -20,7 +19,7 @@ def test_import():
     from optuna.integration import XGBoostPruningCallback  # NOQA
 
     with pytest.raises(ImportError):
-        from optuna.integration import unknown_module  # NOQA
+        from optuna.integration import unknown_module  # type: ignore # NOQA
 
 
 def test_module_attributes():
@@ -42,4 +41,4 @@ def test_module_attributes():
     assert hasattr(optuna.integration, 'XGBoostPruningCallback')
 
     with pytest.raises(AttributeError):
-        optuna.integration.unknown_attribute
+        optuna.integration.unknown_attribute  # type: ignore

--- a/tests/integration_tests/test_integration.py
+++ b/tests/integration_tests/test_integration.py
@@ -1,0 +1,45 @@
+import pytest
+import sys
+
+
+def test_import():
+    # type: () -> None
+
+    from optuna.integration import chainer  # NOQA
+    from optuna.integration import chainermn  # NOQA
+    from optuna.integration import keras  # NOQA
+    from optuna.integration import lightgbm  # NOQA
+    from optuna.integration import tensorflow  # NOQA
+    from optuna.integration import xgboost  # NOQA
+
+    from optuna.integration import ChainerMNStudy  # NOQA
+    from optuna.integration import ChainerPruningExtension  # NOQA
+    from optuna.integration import KerasPruningCallback  # NOQA
+    from optuna.integration import LightGBMPruningCallback  # NOQA
+    from optuna.integration import TensorFlowPruningHook  # NOQA
+    from optuna.integration import XGBoostPruningCallback  # NOQA
+
+    with pytest.raises(ImportError):
+        from optuna.integration import unknown_module  # NOQA
+
+
+def test_module_attributes():
+    # type: () -> None
+
+    import optuna
+
+    assert hasattr(optuna.integration, 'chainer')
+    assert hasattr(optuna.integration, 'chainermn')
+    assert hasattr(optuna.integration, 'keras')
+    assert hasattr(optuna.integration, 'lightgbm')
+    assert hasattr(optuna.integration, 'tensorflow')
+    assert hasattr(optuna.integration, 'xgboost')
+    assert hasattr(optuna.integration, 'ChainerMNStudy')
+    assert hasattr(optuna.integration, 'ChainerPruningExtension')
+    assert hasattr(optuna.integration, 'KerasPruningCallback')
+    assert hasattr(optuna.integration, 'LightGBMPruningCallback')
+    assert hasattr(optuna.integration, 'TensorFlowPruningHook')
+    assert hasattr(optuna.integration, 'XGBoostPruningCallback')
+
+    with pytest.raises(AttributeError):
+        optuna.integration.unknown_attribute


### PR DESCRIPTION
Since `import optuna` has been getting much slower due to dependencies under `optuna.integration`, this PR applies lazy import in the `integration` modules.