### PR TITLE
Replace trial_id with trial.number in rdb.rst.

### DIFF
--- a/docs/source/tutorial/rdb.rst
+++ b/docs/source/tutorial/rdb.rst
@@ -61,14 +61,14 @@ The method :func:`~optuna.study.Study.trials_dataframe` returns a pandas datafra
 
 .. code-block:: bash
 
-    trial_id                state       value             datetime_start          datetime_complete    params
-                                                                                                            x
-           1  TrialState.COMPLETE   46.904095 2018-10-31 16:06:28.264950 2018-10-31 16:06:28.296937  8.848656
-           2  TrialState.COMPLETE   25.416075 2018-10-31 16:06:28.310073 2018-10-31 16:06:28.333799 -3.041436
-           3  TrialState.COMPLETE   50.302101 2018-10-31 16:06:28.344672 2018-10-31 16:06:28.364514  9.092397
-           4  TrialState.COMPLETE   53.415845 2018-10-31 16:06:28.380938 2018-10-31 16:06:28.400815 -5.308614
-           5  TrialState.COMPLETE   29.780800 2018-10-31 16:06:28.415496 2018-10-31 16:06:28.449833  7.457179
-           6  TrialState.COMPLETE    6.950141 2018-10-31 16:06:28.466843 2018-10-31 16:06:28.484284  4.636312
+    number                state       value             datetime_start          datetime_complete    params system_attrs
+                                                                                                          x      _number
+         0  TrialState.COMPLETE   25.301959 2019-03-14 10:57:27.716141 2019-03-14 10:57:27.746354 -3.030105            0
+         1  TrialState.COMPLETE    1.406223 2019-03-14 10:57:27.774461 2019-03-14 10:57:27.835520  0.814157            1
+         2  TrialState.COMPLETE   44.010366 2019-03-14 10:57:27.871365 2019-03-14 10:57:27.926247 -4.634031            2
+         3  TrialState.COMPLETE   55.872181 2019-03-14 10:59:00.845565 2019-03-14 10:59:00.899305  9.474770            3
+         4  TrialState.COMPLETE  113.039223 2019-03-14 10:59:00.921534 2019-03-14 10:59:00.947233 -8.631991            4
+         5  TrialState.COMPLETE   57.319570 2019-03-14 10:59:00.985909 2019-03-14 10:59:01.028819  9.570969            5
 
 A :class:`~optuna.study.Study` object also provides properties such as :attr:`~optuna.study.Study.trials`, :attr:`~optuna.study.Study.best_value`, :attr:`~optuna.study.Study.best_params` (see also :ref:`firstopt`).
 


### PR DESCRIPTION
Since `study.trials_dataframe()` format changed with #285, where `trial_id` has been replaced with `number`, this PR fixes output log of `rdb.rst`.