### PR TITLE
Update log messages in pruning.rst.

### DIFF
--- a/docs/source/tutorial/pruning.rst
+++ b/docs/source/tutorial/pruning.rst
@@ -55,19 +55,19 @@ Executing the script above:
 .. code-block:: bash
 
     $ python prune.py
-    [I 2018-11-21 17:27:57,836] Finished a trial resulted in value: 0.052631578947368474. Current best value is 0.052631578947368474 with parameters: {'alpha': 0.011428158279113485}.
-    [I 2018-11-21 17:27:57,963] Finished a trial resulted in value: 0.02631578947368418. Current best value is 0.02631578947368418 with parameters: {'alpha': 0.01862693201743629}.
-    [I 2018-11-21 17:27:58,164] Finished a trial resulted in value: 0.21052631578947367. Current best value is 0.02631578947368418 with parameters: {'alpha': 0.01862693201743629}.
-    [I 2018-11-21 17:27:58,333] Finished a trial resulted in value: 0.02631578947368418. Current best value is 0.02631578947368418 with parameters: {'alpha': 0.01862693201743629}.
-    [I 2018-11-21 17:27:58,617] Finished a trial resulted in value: 0.23684210526315785. Current best value is 0.02631578947368418 with parameters: {'alpha': 0.01862693201743629}.
-    [I 2018-11-21 17:27:58,642] Setting trial status as TrialState.PRUNED.
-    [I 2018-11-21 17:27:58,666] Setting trial status as TrialState.PRUNED.
-    [I 2018-11-21 17:27:58,675] Setting trial status as TrialState.PRUNED.
-    [I 2018-11-21 17:27:59,183] Finished a trial resulted in value: 0.39473684210526316. Current best value is 0.02631578947368418 with parameters: {'alpha': 0.01862693201743629}.
-    [I 2018-11-21 17:27:59,202] Setting trial status as TrialState.PRUNED.
+    [I 2018-11-21 17:27:57,836] Finished trial#0 resulted in value: 0.052631578947368474. Current best value is 0.052631578947368474 with parameters: {'alpha': 0.011428158279113485}.
+    [I 2018-11-21 17:27:57,963] Finished trial#1 resulted in value: 0.02631578947368418. Current best value is 0.02631578947368418 with parameters: {'alpha': 0.01862693201743629}.
+    [I 2018-11-21 17:27:58,164] Finished trial#2 resulted in value: 0.21052631578947367. Current best value is 0.02631578947368418 with parameters: {'alpha': 0.01862693201743629}.
+    [I 2018-11-21 17:27:58,333] Finished trial#3 resulted in value: 0.02631578947368418. Current best value is 0.02631578947368418 with parameters: {'alpha': 0.01862693201743629}.
+    [I 2018-11-21 17:27:58,617] Finished trial#4 resulted in value: 0.23684210526315785. Current best value is 0.02631578947368418 with parameters: {'alpha': 0.01862693201743629}.
+    [I 2018-11-21 17:27:58,642] Setting status of trial#5 as TrialState.PRUNED.
+    [I 2018-11-21 17:27:58,666] Setting status of trial#6 as TrialState.PRUNED.
+    [I 2018-11-21 17:27:58,675] Setting status of trial#7 as TrialState.PRUNED.
+    [I 2018-11-21 17:27:59,183] Finished trial#8 resulted in value: 0.39473684210526316. Current best value is 0.02631578947368418 with parameters: {'alpha': 0.01862693201743629}.
+    [I 2018-11-21 17:27:59,202] Setting status of trial#9 as TrialState.PRUNED.
     ...
 
-We can see ``Setting trial status as TrialState.PRUNED`` in the log messages.
+We can see ``Setting status of trial#{} as TrialState.PRUNED`` in the log messages.
 This means several trials are stopped before they finish all iterations.
 
 


### PR DESCRIPTION
This PR updates log messages in `pruning.rst` for reflecting https://github.com/pfnet/optuna/pull/285.

The new generated documentation are shown like the following:
![image](https://user-images.githubusercontent.com/181413/54326471-c8fb9a80-4649-11e9-875f-452fa5006b9e.png)
