### PR TITLE
Deprecate `Trial.trial_id` property.

### DIFF
--- a/docs/source/reference/trial.rst
+++ b/docs/source/reference/trial.rst
@@ -6,6 +6,6 @@ Trial
 
 .. autoclass:: Trial
     :members:
-    :exclude-members: system_attrs, set_system_attr
+    :exclude-members: system_attrs, set_system_attr, trial_id
 
 .. autoclass:: FixedTrial

--- a/optuna/integration/chainermn.py
+++ b/optuna/integration/chainermn.py
@@ -48,7 +48,10 @@ class _ChainerMNObjectiveFunc(object):
     def __call__(self, trial):
         # type: (Trial) -> float
 
-        self.comm.mpi_comm.bcast((True, trial.trial_id))
+        # TODO(ohta): Remove the private field access.
+        trial_id = trial._trial_id
+
+        self.comm.mpi_comm.bcast((True, trial_id))
         return self.objective(trial, self.comm)
 
 

--- a/optuna/integration/chainermn.py
+++ b/optuna/integration/chainermn.py
@@ -48,10 +48,7 @@ class _ChainerMNObjectiveFunc(object):
     def __call__(self, trial):
         # type: (Trial) -> float
 
-        # TODO(ohta): Remove the private field access.
-        trial_id = trial._trial_id
-
-        self.comm.mpi_comm.bcast((True, trial_id))
+        self.comm.mpi_comm.bcast((True, trial._trial_id))
         return self.objective(trial, self.comm)
 
 

--- a/optuna/trial.py
+++ b/optuna/trial.py
@@ -1,6 +1,7 @@
 import abc
 import math
 import six
+import warnings
 
 from optuna import distributions
 from optuna import logging
@@ -427,15 +428,19 @@ class Trial(BaseTrial):
         # type: () -> int
         """Return trial ID.
 
-        Note that the use of this property is deprecated.
-        Please use :attr:`~optuna.trial.Trial.number` property instead.
+        Note that the use of this is deprecated.
+        Please use :attr:`~optuna.trial.Trial.number` instead.
 
         Returns:
             A trial ID.
         """
 
-        self.logger.warning('The use of `Trial.trial_id` property is deprecated. '
-                            'Please use `Trial.number` property instead.')
+        warnings.warn(
+            'The use of `Trial.trial_id` is deprecated. '
+            'Please use `Trial.number` instead.', DeprecationWarning)
+
+        self.logger.warning('The use of `Trial.trial_id` is deprecated. '
+                            'Please use `Trial.number` instead.')
 
         return self._trial_id
 

--- a/optuna/trial.py
+++ b/optuna/trial.py
@@ -110,7 +110,7 @@ class Trial(BaseTrial):
         # type: (Study, int) -> None
 
         self.study = study
-        self.trial_id = trial_id
+        self._trial_id = trial_id
 
         self.study_id = self.study.study_id
         self.storage = self.study.storage
@@ -326,9 +326,9 @@ class Trial(BaseTrial):
                 Step of the trial (e.g., Epoch of neural network training).
         """
 
-        self.storage.set_trial_value(self.trial_id, value)
+        self.storage.set_trial_value(self._trial_id, value)
         if step is not None:
-            self.storage.set_trial_intermediate_value(self.trial_id, step, value)
+            self.storage.set_trial_intermediate_value(self._trial_id, step, value)
 
     def should_prune(self, step):
         # type: (int) -> bool
@@ -349,7 +349,7 @@ class Trial(BaseTrial):
 
         # TODO(akiba): remove `step` argument
 
-        return self.study.pruner.prune(self.storage, self.study_id, self.trial_id, step)
+        return self.study.pruner.prune(self.storage, self.study_id, self._trial_id, step)
 
     def set_user_attr(self, key, value):
         # type: (str, Any) -> None
@@ -378,7 +378,7 @@ class Trial(BaseTrial):
                 A value of the attribute. The value should be JSON serializable.
         """
 
-        self.storage.set_trial_user_attr(self.trial_id, key, value)
+        self.storage.set_trial_user_attr(self._trial_id, key, value)
 
     def set_system_attr(self, key, value):
         # type: (str, Any) -> None
@@ -395,7 +395,7 @@ class Trial(BaseTrial):
                 A value of the attribute. The value should be JSON serializable.
         """
 
-        self.storage.set_trial_system_attr(self.trial_id, key, value)
+        self.storage.set_trial_system_attr(self._trial_id, key, value)
 
     def _suggest(self, name, distribution):
         # type: (str, distributions.BaseDistribution) -> Any
@@ -403,10 +403,10 @@ class Trial(BaseTrial):
         param_value_in_internal_repr = self.study.sampler.sample(self.storage, self.study_id, name,
                                                                  distribution)
 
-        set_success = self.storage.set_trial_param(self.trial_id, name,
+        set_success = self.storage.set_trial_param(self._trial_id, name,
                                                    param_value_in_internal_repr, distribution)
         if not set_success:
-            param_value_in_internal_repr = self.storage.get_trial_param(self.trial_id, name)
+            param_value_in_internal_repr = self.storage.get_trial_param(self._trial_id, name)
 
         param_value = distribution.to_external_repr(param_value_in_internal_repr)
         return param_value
@@ -420,7 +420,24 @@ class Trial(BaseTrial):
             A trial number.
         """
 
-        return self.storage.get_trial_number_from_id(self.trial_id)
+        return self.storage.get_trial_number_from_id(self._trial_id)
+
+    @property
+    def trial_id(self):
+        # type: () -> int
+        """Return trial ID.
+
+        Note that the use of this property is deprecated.
+        Please use :attr:`~optuna.trial.Trial.number` property instead.
+
+        Returns:
+            A trial ID.
+        """
+
+        self.logger.warning('The use of `Trial.trial_id` property is deprecated. '
+                            'Please use `Trial.number` property instead.')
+
+        return self._trial_id
 
     @property
     def params(self):
@@ -431,7 +448,7 @@ class Trial(BaseTrial):
             A dictionary containing all parameters.
         """
 
-        return self.storage.get_trial_params(self.trial_id)
+        return self.storage.get_trial_params(self._trial_id)
 
     @property
     def user_attrs(self):
@@ -442,7 +459,7 @@ class Trial(BaseTrial):
             A dictionary containing all user attributes.
         """
 
-        return self.storage.get_trial_user_attrs(self.trial_id)
+        return self.storage.get_trial_user_attrs(self._trial_id)
 
     @property
     def system_attrs(self):
@@ -453,7 +470,7 @@ class Trial(BaseTrial):
             A dictionary containing all system attributes.
         """
 
-        return self.storage.get_trial_system_attrs(self.trial_id)
+        return self.storage.get_trial_system_attrs(self._trial_id)
 
 
 class FixedTrial(BaseTrial):

--- a/tests/integration_tests/test_chainermn.py
+++ b/tests/integration_tests/test_chainermn.py
@@ -59,10 +59,10 @@ class Func(object):
         y = trial.suggest_loguniform('y', 20, 30)
         z = trial.suggest_categorical('z', (-1.0, 1.0))
 
-        self.suggested_values[trial.trial_id] = {}
-        self.suggested_values[trial.trial_id]['x'] = x
-        self.suggested_values[trial.trial_id]['y'] = y
-        self.suggested_values[trial.trial_id]['z'] = z
+        self.suggested_values[trial._trial_id] = {}
+        self.suggested_values[trial._trial_id]['x'] = x
+        self.suggested_values[trial._trial_id]['y'] = y
+        self.suggested_values[trial._trial_id]['z'] = z
 
         return (x - 2)**2 + (y - 25)**2 + z
 
@@ -166,7 +166,7 @@ class TestChainerMNStudy(object):
 
             # Assert the same parameters have been suggested among all nodes.
             for trial in mn_study.trials:
-                assert trial.params == func.suggested_values[trial.trial_id]
+                assert trial.params == func.suggested_values[trial._trial_id]
 
     @staticmethod
     @pytest.mark.parametrize('storage_mode', STORAGE_MODES)

--- a/tests/integration_tests/test_chainermn.py
+++ b/tests/integration_tests/test_chainermn.py
@@ -166,7 +166,7 @@ class TestChainerMNStudy(object):
 
             # Assert the same parameters have been suggested among all nodes.
             for trial in mn_study.trials:
-                assert trial.params == func.suggested_values[trial._trial_id]
+                assert trial.params == func.suggested_values[trial.trial_id]
 
     @staticmethod
     @pytest.mark.parametrize('storage_mode', STORAGE_MODES)

--- a/tests/pruners_tests/test_median.py
+++ b/tests/pruners_tests/test_median.py
@@ -18,7 +18,7 @@ def test_median_pruner_with_one_trial():
 
     # A pruner is not activated at a first trial.
     assert not pruner.prune(
-        storage=study.storage, study_id=study.study_id, trial_id=trial.trial_id, step=1)
+        storage=study.storage, study_id=study.study_id, trial_id=trial._trial_id, step=1)
 
 
 @pytest.mark.parametrize('direction_value', [('minimize', 2), ('maximize', 0.5)])
@@ -31,17 +31,17 @@ def test_median_pruner_intermediate_values(direction_value):
 
     trial = optuna.trial.Trial(study, study.storage.create_new_trial_id(study.study_id))
     trial.report(1, 1)
-    study.storage.set_trial_state(trial.trial_id, TrialState.COMPLETE)
+    study.storage.set_trial_state(trial._trial_id, TrialState.COMPLETE)
 
     trial = optuna.trial.Trial(study, study.storage.create_new_trial_id(study.study_id))
     # A pruner is not activated if a trial has no intermediate values.
     assert not pruner.prune(
-        storage=study.storage, study_id=study.study_id, trial_id=trial.trial_id, step=1)
+        storage=study.storage, study_id=study.study_id, trial_id=trial._trial_id, step=1)
 
     trial.report(intermediate_value, 1)
     # A pruner is activated if a trial has an intermediate value.
     assert pruner.prune(
-        storage=study.storage, study_id=study.study_id, trial_id=trial.trial_id, step=1)
+        storage=study.storage, study_id=study.study_id, trial_id=trial._trial_id, step=1)
 
 
 def test_median_pruner_intermediate_values_nan():
@@ -54,21 +54,21 @@ def test_median_pruner_intermediate_values_nan():
     trial.report(float('nan'), 1)
     # A pruner is not activated if the study does not have any previous trials.
     assert not pruner.prune(
-        storage=study.storage, study_id=study.study_id, trial_id=trial.trial_id, step=1)
-    study.storage.set_trial_state(trial.trial_id, TrialState.COMPLETE)
+        storage=study.storage, study_id=study.study_id, trial_id=trial._trial_id, step=1)
+    study.storage.set_trial_state(trial._trial_id, TrialState.COMPLETE)
 
     trial = optuna.trial.Trial(study, study.storage.create_new_trial_id(study.study_id))
     trial.report(float('nan'), 1)
     # A pruner is activated if the best intermediate value of this trial is NaN.
     assert pruner.prune(
-        storage=study.storage, study_id=study.study_id, trial_id=trial.trial_id, step=1)
-    study.storage.set_trial_state(trial.trial_id, TrialState.COMPLETE)
+        storage=study.storage, study_id=study.study_id, trial_id=trial._trial_id, step=1)
+    study.storage.set_trial_state(trial._trial_id, TrialState.COMPLETE)
 
     trial = optuna.trial.Trial(study, study.storage.create_new_trial_id(study.study_id))
     trial.report(1, 1)
     # A pruner is not activated if the median intermediate value is NaN.
     assert not pruner.prune(
-        storage=study.storage, study_id=study.study_id, trial_id=trial.trial_id, step=1)
+        storage=study.storage, study_id=study.study_id, trial_id=trial._trial_id, step=1)
 
 
 def test_median_pruner_n_startup_trials():
@@ -79,20 +79,20 @@ def test_median_pruner_n_startup_trials():
 
     trial = optuna.trial.Trial(study, study.storage.create_new_trial_id(study.study_id))
     trial.report(1, 1)
-    study.storage.set_trial_state(trial.trial_id, TrialState.COMPLETE)
+    study.storage.set_trial_state(trial._trial_id, TrialState.COMPLETE)
 
     trial = optuna.trial.Trial(study, study.storage.create_new_trial_id(study.study_id))
     trial.report(2, 1)
     # A pruner is not activated during startup trials.
     assert not pruner.prune(
-        storage=study.storage, study_id=study.study_id, trial_id=trial.trial_id, step=1)
-    study.storage.set_trial_state(trial.trial_id, TrialState.COMPLETE)
+        storage=study.storage, study_id=study.study_id, trial_id=trial._trial_id, step=1)
+    study.storage.set_trial_state(trial._trial_id, TrialState.COMPLETE)
 
     trial = optuna.trial.Trial(study, study.storage.create_new_trial_id(study.study_id))
     trial.report(3, 1)
     # A pruner is activated after startup trials.
     assert pruner.prune(
-        storage=study.storage, study_id=study.study_id, trial_id=trial.trial_id, step=1)
+        storage=study.storage, study_id=study.study_id, trial_id=trial._trial_id, step=1)
 
 
 def test_median_pruner_n_warmup_steps():
@@ -104,15 +104,15 @@ def test_median_pruner_n_warmup_steps():
     trial = optuna.trial.Trial(study, study.storage.create_new_trial_id(study.study_id))
     trial.report(1, 1)
     trial.report(1, 2)
-    study.storage.set_trial_state(trial.trial_id, TrialState.COMPLETE)
+    study.storage.set_trial_state(trial._trial_id, TrialState.COMPLETE)
 
     trial = optuna.trial.Trial(study, study.storage.create_new_trial_id(study.study_id))
     trial.report(2, 1)
     # A pruner is not activated during warm-up steps.
     assert not pruner.prune(
-        storage=study.storage, study_id=study.study_id, trial_id=trial.trial_id, step=1)
+        storage=study.storage, study_id=study.study_id, trial_id=trial._trial_id, step=1)
 
     trial.report(2, 2)
     # A pruner is activated after warm-up steps.
     assert pruner.prune(
-        storage=study.storage, study_id=study.study_id, trial_id=trial.trial_id, step=2)
+        storage=study.storage, study_id=study.study_id, trial_id=trial._trial_id, step=2)

--- a/tests/pruners_tests/test_successive_halving.py
+++ b/tests/pruners_tests/test_successive_halving.py
@@ -20,15 +20,15 @@ def test_successive_halving_pruner_intermediate_values(direction_value):
     trial.report(1, 1)
 
     # A pruner is not activated at a first trial.
-    assert not pruner.prune(study.storage, study.study_id, trial.trial_id, step=1)
+    assert not pruner.prune(study.storage, study.study_id, trial._trial_id, step=1)
 
     trial = optuna.trial.Trial(study, study.storage.create_new_trial_id(study.study_id))
     # A pruner is not activated if a trial has no intermediate values.
-    assert not pruner.prune(study.storage, study.study_id, trial.trial_id, step=1)
+    assert not pruner.prune(study.storage, study.study_id, trial._trial_id, step=1)
 
     trial.report(intermediate_value, 1)
     # A pruner is activated if a trial has an intermediate value.
-    assert pruner.prune(study.storage, study.study_id, trial.trial_id, step=1)
+    assert pruner.prune(study.storage, study.study_id, trial._trial_id, step=1)
 
 
 def test_successive_halving_pruner_rung_check():
@@ -42,26 +42,26 @@ def test_successive_halving_pruner_rung_check():
     for i in range(7):
         trial = optuna.trial.Trial(study, study.storage.create_new_trial_id(study.study_id))
         trial.report(0.1 * (i + 1), step=7)
-        pruner.prune(study.storage, study.study_id, trial.trial_id, step=7)
+        pruner.prune(study.storage, study.study_id, trial._trial_id, step=7)
 
     # Report a trial that has the 7-th value from bottom.
     trial = optuna.trial.Trial(study, study.storage.create_new_trial_id(study.study_id))
     trial.report(0.75, step=7)
-    pruner.prune(study.storage, study.study_id, trial.trial_id, step=7)
+    pruner.prune(study.storage, study.study_id, trial._trial_id, step=7)
     assert 'completed_rung_0' in trial.system_attrs
     assert 'completed_rung_1' not in trial.system_attrs
 
     # Report a trial that has the third value from bottom.
     trial = optuna.trial.Trial(study, study.storage.create_new_trial_id(study.study_id))
     trial.report(0.25, step=7)
-    pruner.prune(study.storage, study.study_id, trial.trial_id, step=7)
+    pruner.prune(study.storage, study.study_id, trial._trial_id, step=7)
     assert 'completed_rung_1' in trial.system_attrs
     assert 'completed_rung_2' not in trial.system_attrs
 
     # Report a trial that has the lowest value.
     trial = optuna.trial.Trial(study, study.storage.create_new_trial_id(study.study_id))
     trial.report(0.05, step=7)
-    pruner.prune(study.storage, study.study_id, trial.trial_id, step=7)
+    pruner.prune(study.storage, study.study_id, trial._trial_id, step=7)
     assert 'completed_rung_2' in trial.system_attrs
     assert 'completed_rung_3' not in trial.system_attrs
 
@@ -78,7 +78,7 @@ def test_successive_halving_pruner_first_trial_is_not_pruned():
         trial.report(1, step=i)
 
         # The first trial is not pruned.
-        assert not pruner.prune(study.storage, study.study_id, trial.trial_id, step=i)
+        assert not pruner.prune(study.storage, study.study_id, trial._trial_id, step=i)
 
     # The trial completed until rung 3.
     assert 'completed_rung_0' in trial.system_attrs
@@ -99,12 +99,12 @@ def test_successive_halving_pruner_with_nan():
 
     # A pruner is not activated if the step is not a rung completion point.
     trial.report(float('nan'), step=1)
-    assert not pruner.prune(study.storage, study.study_id, trial.trial_id, step=1)
+    assert not pruner.prune(study.storage, study.study_id, trial._trial_id, step=1)
 
     # A pruner is activated if the step is a rung completion point and
     # the intermediate value is NaN.
     trial.report(float('nan'), step=2)
-    assert pruner.prune(study.storage, study.study_id, trial.trial_id, step=2)
+    assert pruner.prune(study.storage, study.study_id, trial._trial_id, step=2)
 
 
 def test_successive_halving_pruner_min_resource_parameter():
@@ -123,7 +123,7 @@ def test_successive_halving_pruner_min_resource_parameter():
     trial = optuna.trial.Trial(study, study.storage.create_new_trial_id(study.study_id))
 
     trial.report(1, step=1)
-    assert not pruner.prune(study.storage, study.study_id, trial.trial_id, step=1)
+    assert not pruner.prune(study.storage, study.study_id, trial._trial_id, step=1)
     assert 'completed_rung_0' in trial.system_attrs
     assert 'completed_rung_1' not in trial.system_attrs
 
@@ -133,11 +133,11 @@ def test_successive_halving_pruner_min_resource_parameter():
     trial = optuna.trial.Trial(study, study.storage.create_new_trial_id(study.study_id))
 
     trial.report(1, step=1)
-    assert not pruner.prune(study.storage, study.study_id, trial.trial_id, step=1)
+    assert not pruner.prune(study.storage, study.study_id, trial._trial_id, step=1)
     assert 'completed_rung_0' not in trial.system_attrs
 
     trial.report(1, step=2)
-    assert not pruner.prune(study.storage, study.study_id, trial.trial_id, step=2)
+    assert not pruner.prune(study.storage, study.study_id, trial._trial_id, step=2)
     assert 'completed_rung_0' in trial.system_attrs
     assert 'completed_rung_1' not in trial.system_attrs
 
@@ -158,7 +158,7 @@ def test_successive_halving_pruner_reduction_factor_parameter():
     trial = optuna.trial.Trial(study, study.storage.create_new_trial_id(study.study_id))
 
     trial.report(1, step=1)
-    assert not pruner.prune(study.storage, study.study_id, trial.trial_id, step=1)
+    assert not pruner.prune(study.storage, study.study_id, trial._trial_id, step=1)
     assert 'completed_rung_0' in trial.system_attrs
     assert 'completed_rung_1' not in trial.system_attrs
 
@@ -168,16 +168,16 @@ def test_successive_halving_pruner_reduction_factor_parameter():
     trial = optuna.trial.Trial(study, study.storage.create_new_trial_id(study.study_id))
 
     trial.report(1, step=1)
-    assert not pruner.prune(study.storage, study.study_id, trial.trial_id, step=1)
+    assert not pruner.prune(study.storage, study.study_id, trial._trial_id, step=1)
     assert 'completed_rung_0' in trial.system_attrs
     assert 'completed_rung_1' not in trial.system_attrs
 
     trial.report(1, step=2)
-    assert not pruner.prune(study.storage, study.study_id, trial.trial_id, step=2)
+    assert not pruner.prune(study.storage, study.study_id, trial._trial_id, step=2)
     assert 'completed_rung_1' not in trial.system_attrs
 
     trial.report(1, step=3)
-    assert not pruner.prune(study.storage, study.study_id, trial.trial_id, step=3)
+    assert not pruner.prune(study.storage, study.study_id, trial._trial_id, step=3)
     assert 'completed_rung_1' in trial.system_attrs
     assert 'completed_rung_2' not in trial.system_attrs
 
@@ -198,7 +198,7 @@ def test_successive_halving_pruner_min_early_stopping_rate_parameter():
     trial = optuna.trial.Trial(study, study.storage.create_new_trial_id(study.study_id))
 
     trial.report(1, step=1)
-    assert not pruner.prune(study.storage, study.study_id, trial.trial_id, step=1)
+    assert not pruner.prune(study.storage, study.study_id, trial._trial_id, step=1)
     assert 'completed_rung_0' in trial.system_attrs
 
     # min_early_stopping_rate=1: The rung 0 ends at step 2.
@@ -207,11 +207,11 @@ def test_successive_halving_pruner_min_early_stopping_rate_parameter():
     trial = optuna.trial.Trial(study, study.storage.create_new_trial_id(study.study_id))
 
     trial.report(1, step=1)
-    assert not pruner.prune(study.storage, study.study_id, trial.trial_id, step=1)
+    assert not pruner.prune(study.storage, study.study_id, trial._trial_id, step=1)
     assert 'completed_rung_0' not in trial.system_attrs
     assert 'completed_rung_1' not in trial.system_attrs
 
     trial.report(1, step=2)
-    assert not pruner.prune(study.storage, study.study_id, trial.trial_id, step=2)
+    assert not pruner.prune(study.storage, study.study_id, trial._trial_id, step=2)
     assert 'completed_rung_0' in trial.system_attrs
     assert 'completed_rung_1' not in trial.system_attrs

--- a/tests/test_study.py
+++ b/tests/test_study.py
@@ -329,7 +329,7 @@ def test_run_trial(storage_mode):
             raise ValueError
 
         trial = study._run_trial(func_value_error, catch=(ValueError, ))
-        frozen_trial = study.storage.get_trial(trial.trial_id)
+        frozen_trial = study.storage.get_trial(trial._trial_id)
 
         expected_message = 'Setting status of trial#1 as TrialState.FAIL because of the ' \
                            'following error: ValueError()'
@@ -347,7 +347,7 @@ def test_run_trial(storage_mode):
             return None  # type: ignore
 
         trial = study._run_trial(func_none, catch=(Exception, ))
-        frozen_trial = study.storage.get_trial(trial.trial_id)
+        frozen_trial = study.storage.get_trial(trial._trial_id)
 
         expected_message = 'Setting status of trial#3 as TrialState.FAIL because the returned ' \
                            'value from the objective function cannot be casted to float. ' \
@@ -362,7 +362,7 @@ def test_run_trial(storage_mode):
             return float('nan')
 
         trial = study._run_trial(func_nan, catch=(Exception, ))
-        frozen_trial = study.storage.get_trial(trial.trial_id)
+        frozen_trial = study.storage.get_trial(trial._trial_id)
 
         expected_message = 'Setting status of trial#4 as TrialState.FAIL because the objective ' \
                            'function returned nan.'


### PR DESCRIPTION
This PR deprecate the access to `Trial.trial_id` property (when the property is accessed, a warning log message is outputted). 
Since the next release of Optuna, `Trial.number` introduced by https://github.com/pfnet/optuna/pull/285 will be recommended.