### PR TITLE
[WIP] feat: Simulated Annealing sampler #346

### DIFF
--- a/optuna/samplers/__init__.py
+++ b/optuna/samplers/__init__.py
@@ -1,4 +1,4 @@
 from optuna.samplers.base import BaseSampler  # NOQA
 from optuna.samplers.random import RandomSampler  # NOQA
-from optuna.samplers.sa import SASampler  # NOQA
 from optuna.samplers.tpe import TPESampler  # NOQA
+from optuna.samplers.sa import SASampler  # NOQA

--- a/optuna/samplers/__init__.py
+++ b/optuna/samplers/__init__.py
@@ -1,3 +1,4 @@
 from optuna.samplers.base import BaseSampler  # NOQA
 from optuna.samplers.random import RandomSampler  # NOQA
 from optuna.samplers.tpe import TPESampler  # NOQA
+from optuna.samplers.sa import SASampler  # NOQA

--- a/optuna/samplers/__init__.py
+++ b/optuna/samplers/__init__.py
@@ -1,4 +1,4 @@
 from optuna.samplers.base import BaseSampler  # NOQA
 from optuna.samplers.random import RandomSampler  # NOQA
-from optuna.samplers.tpe import TPESampler  # NOQA
 from optuna.samplers.sa import SASampler  # NOQA
+from optuna.samplers.tpe import TPESampler  # NOQA

--- a/optuna/samplers/sa/__init__.py
+++ b/optuna/samplers/sa/__init__.py
@@ -1,0 +1,1 @@
+from optuna.samplers.sa.sampler import SASampler  # NOQA

--- a/optuna/samplers/sa/sampler.py
+++ b/optuna/samplers/sa/sampler.py
@@ -1,0 +1,101 @@
+import numpy as np
+
+from optuna import distributions  # NOQA
+from optuna.samplers import base  # NOQA
+from optuna.samplers import random  # NOQA
+from optuna.samplers import TPESampler
+from collections import defaultdict # NOQA
+from optuna.structs import TrialState, StudyDirection # NOQA
+
+
+DEFAULT_START_TEMPERATURE = 1000
+DEFAULT_TEMPERATURE_COEFFICIENT = 0.95
+
+class SASampler(TPESampler):
+    def __init__(
+            self,
+            consider_prior=True,  # type: bool
+            prior_weight=1.0,  # type: Optional[float]
+            consider_magic_clip=True,  # type: bool
+            consider_endpoints=False,  # type: bool
+            n_startup_trials=10,  # type: int
+            n_ei_candidates=24,  # type: int
+            seed=None,  # type: Optional[int]
+            start_temperature = DEFAULT_START_TEMPERATURE,
+            temperature_reduction_coefficient = DEFAULT_TEMPERATURE_COEFFICIENT,
+    ):
+        super().__init__(consider_prior=consider_prior,
+            prior_weight=prior_weight,
+            consider_magic_clip=consider_magic_clip,
+            consider_endpoints=consider_endpoints,
+            n_startup_trials=n_startup_trials,
+            n_ei_candidates=n_ei_candidates,
+            seed=seed)
+
+        self.temperature = start_temperature
+        self.temperature_reduction_coefficient = temperature_reduction_coefficient
+
+        self.rng = np.random.RandomState(seed)
+        self.random_sampler = random.RandomSampler(seed=seed)
+
+
+    def _regen_simulation_pairs(self, observation_pairs):
+        X = []
+        Y = []
+        temperature = self.temperature
+
+        for i, (p, v) in enumerate(observation_pairs):
+            # Append the actual param value to Y
+            Y.append(p)
+
+            # Regenenerate X based on random trial (may not be the exact X, but comes really close)
+            if not X:
+                X.append(p)
+            else:
+                prob = np.exp((observation_pairs[i - 1][1] - v) / temperature)
+                X.append(p if self.rng.uniform() <= prob else observation_pairs[i - 1][0])
+
+            temperature *= self.temperature_reduction_coefficient
+
+        X = np.asarray(X, dtype=float)
+        Y = np.asarray(Y, dtype=float)
+        return X, Y
+
+
+    def sample(self, storage, study_id, param_name, param_distribution):
+        # type: (BaseStorage, int, str, BaseDistribution) -> float
+
+        observation_pairs = storage.get_trial_param_result_pairs(study_id, param_name)
+        if storage.get_study_direction(study_id) == StudyDirection.MAXIMIZE:
+            observation_pairs = [(p, -v) for p, v in observation_pairs]
+
+        n = len(observation_pairs)
+
+        if n < self.n_startup_trials:
+            return self.random_sampler.sample(storage, study_id, param_name, param_distribution)
+
+        Y, X = self._regen_simulation_pairs(observation_pairs)
+
+        if isinstance(param_distribution, distributions.UniformDistribution):
+            return self._sample_uniform(param_distribution, Y, X)
+        elif isinstance(param_distribution, distributions.LogUniformDistribution):
+            return self._sample_loguniform(param_distribution, X, Y)
+        # elif isinstance(param_distribution, distributions.DiscreteUniformDistribution):
+        #     return self._sample_discrete_uniform(param_distribution, below_param_values,
+        #                                          above_param_values)
+        # elif isinstance(param_distribution, distributions.IntUniformDistribution):
+        #     return self._sample_int(param_distribution, below_param_values, above_param_values)
+        # elif isinstance(param_distribution, distributions.CategoricalDistribution):
+        #     return self._sample_categorical(param_distribution, below_param_values,
+        #                                     above_param_values)
+        else:
+            distribution_list = [
+                distributions.UniformDistribution.__name__,
+                distributions.LogUniformDistribution.__name__,
+                # distributions.DiscreteUniformDistribution.__name__,
+                # distributions.IntUniformDistribution.__name__,
+                # distributions.CategoricalDistribution.__name__
+            ]
+            raise NotImplementedError("The distribution {} is not implemented. "
+                                      "The parameter distribution should be one of the {}".format(
+                                          param_distribution, distribution_list))

--- a/optuna/samplers/sa/sampler.py
+++ b/optuna/samplers/sa/sampler.py
@@ -1,10 +1,16 @@
 import numpy as np
 
 from optuna import distributions  # NOQA
+from optuna.distributions import BaseDistribution  # NOQA
 from optuna.samplers import base  # NOQA
 from optuna.samplers import random  # NOQA
 from optuna.samplers import TPESampler
+from optuna.storages.base import BaseStorage  # NOQA
 from optuna.structs import StudyDirection  # NOQA
+from optuna import types
+
+if types.TYPE_CHECKING:
+    from typing import Optional  # NOQA
 
 
 DEFAULT_START_TEMPERATURE = 1000.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,6 +7,7 @@ max-line-length = 99
 max-line-length = 99
 statistics = True
 exclude = optuna/samplers/_hyperopt.py,venv,build
+ignore = H306
 
 # This section is for yapf.
 [yapf]

--- a/tests/samplers_tests/test_samplers.py
+++ b/tests/samplers_tests/test_samplers.py
@@ -15,7 +15,9 @@ if optuna.types.TYPE_CHECKING:
 
 parametrize_sampler = pytest.mark.parametrize(
     'sampler_class',
-    [optuna.samplers.RandomSampler, lambda: optuna.samplers.TPESampler(n_startup_trials=0)])
+    [optuna.samplers.RandomSampler,
+     lambda: optuna.samplers.TPESampler(n_startup_trials=0),
+     optuna.samplers.SASampler])
 
 
 @parametrize_sampler


### PR DESCRIPTION
Based on Simulated Annealing, the SASampler extends TPESampler. For reference,
visit pdfs.semanticscholar.org/1641/02e1de166a75ca09ae8ae154bca2ce32649e.pdf.
The main difference between TPESampler and SASampler is that instead of using
arbitary splits (lower and upper based on trial scores), we construct a sequence
of states (denoted by X) over actual scores (dentoe by Y) accordint to SA algo.
By constructing a Parzen estiamtes on X and Y sequence and sampling from KDE of
X & ~Y distribution (instead of lower & ~upper in case of TPESampler), we get
the sampling distribution.