### PR TITLE
Enable tensorflow in Python 3.7.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,12 +128,6 @@ jobs:
     steps:
       - checkout
       - run: *install
-      # TODO(higumachan): remove this "run" section after Tensorflow supports Python 3.7 officially.
-      - run: &keras-install
-          name: install-keras
-          command: |
-            . venv/bin/activate
-            pip install .[keras]
       - run: *tests
       - run: *tests-mn
 
@@ -141,13 +135,13 @@ jobs:
     docker:
       - image: circleci/python:3.5
     steps:
-      [checkout, run: *install, run: *keras-install, run: *tests, run: *tests-mn]
+      [checkout, run: *install, run: *tests, run: *tests-mn]
 
   tests-python27:
     docker:
       - image: circleci/python:2.7
     steps:
-      [checkout, run: *install, run: *keras-install, run: *tests, run: *tests-mn]
+      [checkout, run: *install, run: *tests, run: *tests-mn]
 
   codecov:
     docker:
@@ -156,8 +150,6 @@ jobs:
       - checkout
 
       - run: *install
-
-      - run: *keras-install
 
       - run:
           name: install-codecov

--- a/setup.py
+++ b/setup.py
@@ -43,10 +43,10 @@ def get_extras_require():
 
     extras_require = {
         'checking': ['autopep8', 'hacking'],
-        'testing':
-        ['pytest', 'mock', 'bokeh', 'plotly', 'chainer>=5.0.0', 'xgboost', 'mpi4py', 'lightgbm'],
-        # TODO(higumachan): merge 'keras' to 'testing' after Tensorflow supports Python 3.7.
-        'keras': ['keras', 'tensorflow'],
+        'testing': [
+            'pytest', 'mock', 'bokeh', 'plotly', 'chainer>=5.0.0', 'xgboost', 'mpi4py', 'lightgbm',
+            'keras', 'tensorflow'
+        ],
         'document': ['sphinx', 'sphinx_rtd_theme'],
         'codecov': ['pytest-cov', 'codecov'],
     }

--- a/tests/integration_tests/test_keras.py
+++ b/tests/integration_tests/test_keras.py
@@ -1,14 +1,7 @@
+from keras.layers import Dense
+from keras import Sequential
 import numpy as np
-
 import pytest
-
-# TODO(higumachan): remove this "try-except" section after Tensorflow supports Python 3.7.
-try:
-    from keras.layers import Dense
-    from keras import Sequential
-    _available = True
-except ImportError:
-    _available = False
 
 import optuna
 from optuna.integration import KerasPruningCallback
@@ -17,11 +10,6 @@ from optuna.testing.integration import DeterministicPruner
 
 def test_keras_pruning_callback():
     # type: () -> None
-
-    # TODO(higumachan): remove this "if" section after Tensorflow supports Python 3.7.
-    if not _available:
-        pytest.skip('This test requires keras '
-                    'but this version can not install keras(tensorflow) with pip.')
 
     def objective(trial):
         # type: (optuna.trial.Trial) -> float
@@ -51,11 +39,6 @@ def test_keras_pruning_callback():
 
 def test_keras_pruning_callback_observation_isnan():
     # type: () -> None
-
-    # TODO(higumachan): remove this "if" section after Tensorflow supports Python 3.7.
-    if not _available:
-        pytest.skip('This test requires keras '
-                    'but this version can not install keras(tensorflow) with pip.')
 
     study = optuna.create_study(pruner=DeterministicPruner(True))
     trial = study._run_trial(func=lambda _: 1.0, catch=(Exception, ))

--- a/tests/integration_tests/test_tensorflow.py
+++ b/tests/integration_tests/test_tensorflow.py
@@ -1,12 +1,6 @@
 import numpy as np
-
 import pytest
-
-try:
-    import tensorflow as tf
-    _available = True
-except ImportError:
-    _available = False
+import tensorflow as tf
 
 import optuna
 from optuna.integration import TensorFlowPruningHook
@@ -31,11 +25,6 @@ def fixed_value_input_fn():
 
 def test_tensorflow_pruning_hook():
     # type: () -> None
-
-    # TODO(sfujiwara): remove this "if" section after TensorFlow supports Python 3.7.
-    if not _available:
-        pytest.skip('This test requires TensorFlow '
-                    'but this version can not install TensorFlow with pip.')
 
     def objective(trial):
         # type: (optuna.trial.Trial) -> float
@@ -72,11 +61,6 @@ def test_tensorflow_pruning_hook():
 @pytest.mark.parametrize('is_higher_better', [True, False])
 def test_init_with_is_higher_better(is_higher_better):
     # type: (bool) -> None
-
-    # TODO(Yanase): remove this "if" section after TensorFlow supports Python 3.7.
-    if not _available:
-        pytest.skip('This test requires TensorFlow '
-                    'but this version can not install TensorFlow with pip.')
 
     clf = tf.estimator.DNNClassifier(
         hidden_units=[],


### PR DESCRIPTION
This PR enables test cases which require tensorflow in Python 3.7 environment. Tensorflow added support for Python 3.7 at version 1.13.1 as shown in [this release note](https://github.com/tensorflow/tensorflow/releases/tag/v1.13.1).