### PR TITLE
Restrict data load to worker 0.

### DIFF
--- a/examples/chainermn_simple.py
+++ b/examples/chainermn_simple.py
@@ -55,12 +55,17 @@ def objective(trial, comm):
     optimizer.setup(model)
     optimizer = chainermn.create_multi_node_optimizer(optimizer, comm)
 
-    # Setup dataset and iterator.
-    train, test = chainer.datasets.get_mnist()
-    rng = np.random.RandomState(0)
-    train = chainer.datasets.SubDataset(
-        train, 0, N_TRAIN_EXAMPLES, order=rng.permutation(len(train)))
-    test = chainer.datasets.SubDataset(test, 0, N_TEST_EXAMPLES, order=rng.permutation(len(test)))
+    # Setup dataset and iterator. Only worker 0 loads the whole dataset.
+    # The dataset of worker 0 is evenly split and distributed to all workers.
+    if comm.rank == 0:
+        train, test = chainer.datasets.get_mnist()
+        rng = np.random.RandomState(0)
+        train = chainer.datasets.SubDataset(
+            train, 0, N_TRAIN_EXAMPLES, order=rng.permutation(len(train)))
+        test = chainer.datasets.SubDataset(
+            test, 0, N_TEST_EXAMPLES, order=rng.permutation(len(test)))
+    else:
+        train, test = None, None
 
     train = chainermn.scatter_dataset(train, comm, shuffle=True)
     test = chainermn.scatter_dataset(test, comm)

--- a/examples/pruning/chainermn_integration.py
+++ b/examples/pruning/chainermn_integration.py
@@ -55,12 +55,17 @@ def objective(trial, comm):
     optimizer.setup(model)
     optimizer = chainermn.create_multi_node_optimizer(optimizer, comm)
 
-    # Setup dataset and iterator.
-    train, test = chainer.datasets.get_mnist()
-    rng = np.random.RandomState(0)
-    train = chainer.datasets.SubDataset(
-        train, 0, N_TRAIN_EXAMPLES, order=rng.permutation(len(train)))
-    test = chainer.datasets.SubDataset(test, 0, N_TEST_EXAMPLES, order=rng.permutation(len(test)))
+    # Setup dataset and iterator. Only worker 0 loads the whole dataset.
+    # The dataset of worker 0 is evenly split and distributed to all workers.
+    if comm.rank == 0:
+        train, test = chainer.datasets.get_mnist()
+        rng = np.random.RandomState(0)
+        train = chainer.datasets.SubDataset(
+            train, 0, N_TRAIN_EXAMPLES, order=rng.permutation(len(train)))
+        test = chainer.datasets.SubDataset(
+            test, 0, N_TEST_EXAMPLES, order=rng.permutation(len(test)))
+    else:
+        train, test = None, None
 
     train = chainermn.scatter_dataset(train, comm, shuffle=True)
     test = chainermn.scatter_dataset(test, comm)


### PR DESCRIPTION
This PR changes dataset access in ChainerMN examples. In this change, only the worker 0 loads the dataset and then distributes it to other workers similarly to [this example](https://github.com/chainer/chainer/blob/master/examples/chainermn/mnist/train_mnist.py) in Chainer repository.
