### PR TITLE
Add `KerasPruningCallback` and `TensorFlowPruningHook` to document.

### DIFF
--- a/docs/source/reference/integration.rst
+++ b/docs/source/reference/integration.rst
@@ -9,7 +9,13 @@ Integration
 .. autoclass:: ChainerMNStudy
     :members:
 
+.. autoclass:: KerasPruningCallback
+    :members:
+
 .. autoclass:: LightGBMPruningCallback
+    :members:
+
+.. autoclass:: TensorFlowPruningHook
     :members:
 
 .. autoclass:: XGBoostPruningCallback


### PR DESCRIPTION
This PR adds the documents of `KerasPruningCallback` and `TensorFlowPruningHook` to https://optuna.readthedocs.io/en/stable/reference/integration.html.