### PR TITLE
[WIP] New sampler interface (obsolete).

### DIFF
--- a/optuna/samplers/base.py
+++ b/optuna/samplers/base.py
@@ -20,12 +20,12 @@ class BaseSampler(object):
 
         raise NotImplementedError
 
-    def before(self, trial):
+    def before_trial(self, trial):
         # type: (FrozenTrial) -> None
 
         pass
 
-    def after(self, trial):
+    def after_trial(self, trial):
         # type: (FrozenTrial) -> None
 
         pass

--- a/optuna/samplers/base.py
+++ b/optuna/samplers/base.py
@@ -20,17 +20,15 @@ class BaseSampler(object):
 
         raise NotImplementedError
 
-    @abc.abstractmethod
     def before(self, trial):
         # type: (FrozenTrial) -> None
 
-        raise NotImplementedError
+        pass
 
-    @abc.abstractmethod
     def after(self, trial):
         # type: (FrozenTrial) -> None
 
-        raise NotImplementedError
+        pass
 
     @property
     def study(self):

--- a/optuna/samplers/base.py
+++ b/optuna/samplers/base.py
@@ -17,25 +17,60 @@ class BaseSampler(object):
     @abc.abstractmethod
     def sample(self, trial, param_name, param_distribution):
         # type: (FrozenTrial, str, BaseDistribution) -> float
+        """Sample a parameter based on the previous trials and the given distribution.
+
+        Note that this method is not supposed to be called by library users. Instead,
+        :class:`optuna.trial.Trial` provides user interfaces to sample parameters in an objective
+        function.
+
+        Args:
+            trial:
+                Trial object that contains the information of the target trial.
+            param_name:
+                Name of the sampled parameter.
+            param_distribution:
+                Distribution object that specifies a prior and/or scale of the sampling algorithm.
+
+        Returns:
+            A float value in the internal representation of Optuna.
+
+        """
 
         raise NotImplementedError
 
     def before_trial(self, trial):
         # type: (FrozenTrial) -> None
+        """A callback method that invoked each time before the target objective function is called.
+
+        Args:
+            trial:
+                Trial object that contains the information of the target trial.
+                The state of the trial object always be :obj:`~optuna.structs.TrialState.RUNNING`.
+
+        """
 
         pass
 
     def after_trial(self, trial):
         # type: (FrozenTrial) -> None
+        """A callback method that invoked each time after the target objective function is called.
+
+        Args:
+            trial:
+                Trial object that contains the information of the target trial.
+                The state of the trial object never be :obj:`~optuna.structs.TrialState.RUNNING`.
+
+        """
 
         pass
 
     @property
     def study(self):
         # type: () -> RunningStudy
+        """Return the target study."""
 
         if not hasattr(self, '_study'):
-            raise RuntimeError()
+            raise RuntimeError('`_study` field has not yet been set.')
 
         return self._study
 

--- a/optuna/samplers/random.py
+++ b/optuna/samplers/random.py
@@ -58,13 +58,3 @@ class RandomSampler(BaseSampler):
             return self.rng.randint(len(choices))
         else:
             raise NotImplementedError
-
-    def before(self, trial):
-        # type: (FrozenTrial) -> None
-
-        pass
-
-    def after(self, trial):
-        # type: (FrozenTrial) -> None
-
-        pass

--- a/optuna/samplers/random.py
+++ b/optuna/samplers/random.py
@@ -3,6 +3,7 @@ import numpy
 from optuna import distributions
 from optuna.samplers.base import BaseSampler
 from optuna.storages.base import BaseStorage  # NOQA
+from optuna.structs import FrozenTrial  # NOQA
 from optuna import types
 
 if types.TYPE_CHECKING:
@@ -29,8 +30,8 @@ class RandomSampler(BaseSampler):
         self.seed = seed
         self.rng = numpy.random.RandomState(seed)
 
-    def sample(self, storage, study_id, param_name, param_distribution):
-        # type: (BaseStorage, int, str, distributions.BaseDistribution) -> float
+    def sample(self, trial, param_name, param_distribution):
+        # type: (FrozenTrial, str, distributions.BaseDistribution) -> float
         """Please consult the documentation for :func:`BaseSampler.sample`."""
 
         if isinstance(param_distribution, distributions.UniformDistribution):
@@ -57,3 +58,13 @@ class RandomSampler(BaseSampler):
             return self.rng.randint(len(choices))
         else:
             raise NotImplementedError
+
+    def before(self, trial):
+        # type: (FrozenTrial) -> None
+
+        pass
+
+    def after(self, trial):
+        # type: (FrozenTrial) -> None
+
+        pass

--- a/optuna/samplers/tpe/sampler.py
+++ b/optuna/samplers/tpe/sampler.py
@@ -110,16 +110,6 @@ class TPESampler(base.BaseSampler):
                                       "The parameter distribution should be one of the {}".format(
                                           param_distribution, distribution_list))
 
-    def before(self, trial):
-        # type: (FrozenTrial) -> None
-
-        pass
-
-    def after(self, trial):
-        # type: (FrozenTrial) -> None
-
-        pass
-
     def _split_observation_pairs(
             self,
             config_idxs,  # type: List[int]

--- a/optuna/study.py
+++ b/optuna/study.py
@@ -396,7 +396,7 @@ class Study(object):
         trial = trial_module.Trial(self, trial_id)
         trial_number = trial.number
 
-        self.sampler.before(self.storage.get_trial(trial_id))
+        self.sampler.before_trial(self.storage.get_trial(trial_id))
         try:
             result = func(trial)
         except structs.TrialPruned as e:
@@ -405,7 +405,7 @@ class Study(object):
                                                                     str(e))
             self.logger.info(message)
             self.storage.set_trial_state(trial_id, structs.TrialState.PRUNED)
-            self.sampler.after(self.storage.get_trial(trial_id))
+            self.sampler.after_trial(self.storage.get_trial(trial_id))
             return trial
         except catch as e:
             message = 'Setting status of trial#{} as {} because of the following error: {}'\
@@ -413,7 +413,7 @@ class Study(object):
             self.logger.warning(message, exc_info=True)
             self.storage.set_trial_state(trial_id, structs.TrialState.FAIL)
             self.storage.set_trial_system_attr(trial_id, 'fail_reason', message)
-            self.sampler.after(self.storage.get_trial(trial_id))
+            self.sampler.after_trial(self.storage.get_trial(trial_id))
             return trial
 
         try:
@@ -428,7 +428,7 @@ class Study(object):
             self.logger.warning(message)
             self.storage.set_trial_state(trial_id, structs.TrialState.FAIL)
             self.storage.set_trial_system_attr(trial_id, 'fail_reason', message)
-            self.sampler.after(self.storage.get_trial(trial_id))
+            self.sampler.after_trial(self.storage.get_trial(trial_id))
             return trial
 
         if math.isnan(result):
@@ -437,14 +437,14 @@ class Study(object):
             self.logger.warning(message)
             self.storage.set_trial_state(trial_id, structs.TrialState.FAIL)
             self.storage.set_trial_system_attr(trial_id, 'fail_reason', message)
-            self.sampler.after(self.storage.get_trial(trial_id))
+            self.sampler.after_trial(self.storage.get_trial(trial_id))
             return trial
 
         trial.report(result)
         self.storage.set_trial_state(trial_id, structs.TrialState.COMPLETE)
         self._log_completed_trial(trial_number, result)
 
-        self.sampler.after(self.storage.get_trial(trial_id))
+        self.sampler.after_trial(self.storage.get_trial(trial_id))
         return trial
 
     def _log_completed_trial(self, trial_number, value):

--- a/optuna/study.py
+++ b/optuna/study.py
@@ -456,6 +456,8 @@ class Study(object):
 
 
 class RunningStudy(object):
+    """TODO: Add documentation after the class name is fixed."""
+
     def __init__(self, study):
         # type: (Study) -> None
 
@@ -466,12 +468,22 @@ class RunningStudy(object):
     @property
     def best_params(self):
         # type: () -> Dict[str, Any]
+        """Return parameters of the best trial in the :class:`~optuna.study.RunningStudy`.
+
+        Returns:
+            A dictionary containing parameters of the best trial.
+        """
 
         return self.best_trial.params
 
     @property
     def best_value(self):
         # type: () -> float
+        """Return the best objective value in the :class:`~optuna.study.RunningStudy`.
+
+        Returns:
+            A float representing the best objective value.
+        """
 
         best_value = self.best_trial.value
         if best_value is None:
@@ -482,29 +494,56 @@ class RunningStudy(object):
     @property
     def best_trial(self):
         # type: () -> structs.FrozenTrial
+        """Return the best trial in the :class:`~optuna.study.RunningStudy`.
+
+        Returns:
+            A :class:`~optuna.structs.FrozenTrial` object of the best trial.
+        """
 
         return self.storage.get_best_trial(self.study_id)
 
     @property
     def direction(self):
         # type: () -> structs.StudyDirection
+        """Return the direction of the :class:`~optuna.study.RunningStudy`.
+
+        Returns:
+            A :class:`~optuna.structs.StudyDirection` object.
+        """
 
         return self.storage.get_study_direction(self.study_id)
 
     @property
     def trials(self):
         # type: () -> List[structs.FrozenTrial]
+        """Return all trials in the :class:`~optuna.study.RunningStudy`.
+
+        Returns:
+            A list of :class:`~optuna.structs.FrozenTrial` objects.
+        """
 
         return self.storage.get_all_trials(self.study_id)
 
     @property
     def system_attrs(self):
         # type: () -> Dict[str, Any]
+        """Return system attributes.
+
+        Returns:
+            A dictionary containing all system attributes.
+        """
 
         return self.storage.get_study_system_attrs(self.study_id)
 
     def set_system_attr(self, key, value):
         # type: (str, Any) -> None
+        """Set a system attribute to the :class:`~optuna.study.RunningStudy`.
+
+        Args:
+            key: A key string of the attribute.
+            value: A value of the attribute. The value should be JSON serializable.
+
+        """
 
         self.storage.set_study_system_attr(self.study_id, key, value)
 

--- a/optuna/trial.py
+++ b/optuna/trial.py
@@ -406,8 +406,8 @@ class Trial(BaseTrial):
     def _suggest(self, name, distribution):
         # type: (str, distributions.BaseDistribution) -> Any
 
-        param_value_in_internal_repr = self.study.sampler.sample(self.storage, self.study_id, name,
-                                                                 distribution)
+        trial = self.storage.get_trial(self._trial_id)
+        param_value_in_internal_repr = self.study.sampler.sample(trial, name, distribution)
 
         set_success = self.storage.set_trial_param(self._trial_id, name,
                                                    param_value_in_internal_repr, distribution)

--- a/tests/test_study.py
+++ b/tests/test_study.py
@@ -1,4 +1,6 @@
 import itertools
+from mock import Mock
+from mock import patch
 import multiprocessing
 import pandas as pd
 import pickle
@@ -8,6 +10,8 @@ import time
 import uuid
 
 import optuna
+from optuna.samplers import RandomSampler
+from optuna.struts import TrialState
 from optuna.testing.storage import StorageSupplier
 from optuna import types
 
@@ -510,3 +514,57 @@ def test_load_study(storage_mode):
         # Test loading an existing study.
         loaded_study = optuna.study.load_study(study_name=study_name, storage=storage)
         assert created_study.study_id == loaded_study.study_id
+
+
+def test_sampler_before_trial():
+    # type: () -> None
+
+    sampler = RandomSampler()
+    study = optuna.create_study(sampler=sampler)
+
+    def objective(mock, trial):
+        # type: (Mock, optuna.trial.Trial) -> float
+
+        assert mock.call_count == 1
+        return 1.0
+
+    def check_trial_state(trial):
+        # type: (optuna.structs.FrozenTrial) -> None
+
+        assert trial.state == TrialState.RUNNING
+
+    mock = Mock(return_value=None, side_effect=check_trial_state)
+    with patch.object(RandomSampler, 'before_trial', mock) as mock:
+        assert mock.call_count == 0
+        study.optimize(lambda trial: objective(mock, trial), n_trials=1)
+        assert mock.call_count == 1
+
+
+def test_sampler_after_trial():
+    # type: () -> None
+
+    sampler = RandomSampler()
+    study = optuna.create_study(sampler=sampler)
+
+    for expected_state in [TrialState.COMPLETE, TrialState.PRUNED, TrialState.FAIL]:
+        def objective(mock, trial):
+            # type: (Mock, optuna.trial.Trial) -> float
+
+            assert mock.call_count == 0
+            if expected_state is TrialState.COMPLETE:
+                return 1.0
+            elif expected_state is TrialState.PRUNED:
+                raise optuna.structs.TrialPruned()
+            else:
+                raise RuntimeError()
+
+        def check_trial_state(trial):
+            # type: (optuna.structs.FrozenTrial) -> None
+
+            assert trial.state == expected_state
+
+        mock = Mock(return_value=None, side_effect=check_trial_state)
+        with patch.object(RandomSampler, 'after_trial', mock) as mock:
+            assert mock.call_count == 0
+            study.optimize(lambda trial: objective(mock, trial), n_trials=1)
+            assert mock.call_count == 1

--- a/tests/test_study.py
+++ b/tests/test_study.py
@@ -11,7 +11,7 @@ import uuid
 
 import optuna
 from optuna.samplers import RandomSampler
-from optuna.struts import TrialState
+from optuna.structs import TrialState
 from optuna.testing.storage import StorageSupplier
 from optuna import types
 

--- a/tests/test_trial.py
+++ b/tests/test_trial.py
@@ -109,7 +109,7 @@ def test_suggest_discrete_uniform_range(storage_init_func, range_config):
 
     # Check upper endpoints.
     mock = Mock()
-    mock.side_effect = lambda storage, study_id, param_name, distribution: distribution.high
+    mock.side_effect = lambda trial, param_name, distribution: distribution.high
     with patch.object(sampler, 'sample', mock) as mock_object:
         study = create_study(storage_init_func(), sampler=sampler)
         trial = Trial(study, study.storage.create_new_trial_id(study.study_id))
@@ -121,7 +121,7 @@ def test_suggest_discrete_uniform_range(storage_init_func, range_config):
 
     # Check lower endpoints.
     mock = Mock()
-    mock.side_effect = lambda storage, study_id, param_name, distribution: distribution.low
+    mock.side_effect = lambda trial, param_name, distribution: distribution.low
     with patch.object(sampler, 'sample', mock) as mock_object:
         study = create_study(storage_init_func(), sampler=sampler)
         trial = Trial(study, study.storage.create_new_trial_id(study.study_id))


### PR DESCRIPTION
This PR proposes a new `BaseSampler` interface.

The new interface has mainly differed with the current one in the following points:
- (a) Samplers can the current trial information via `trial` argument of `BaseSampler.sample()` method
- (b) Samplers can access the current study via `BaseSampler.study` property
  - The property returns a `RunningStudy` object (note that the class name will change before merging)
- (c) Samplers can implement their own setup and teardown logics in `BaseSampler.before_trial()` and `BaseSampler.after_trial()` methods respectively