### PR TITLE
Fix occasional failure of a ChainerMNStudy test.

### DIFF
--- a/tests/integration_tests/test_chainermn.py
+++ b/tests/integration_tests/test_chainermn.py
@@ -228,6 +228,9 @@ class TestChainerMNStudy(object):
             failed_trials = [t for t in mn_study.trials if t.state == TrialState.FAIL]
             assert len(failed_trials) == n_trials
 
+            # Synchronize nodes before executing the next optimization.
+            comm.mpi_comm.barrier()
+
             # Invoke optimize in which no exceptions are accepted.
             with pytest.raises(ValueError):
                 mn_study.optimize(objective, n_trials=n_trials, catch=())


### PR DESCRIPTION
This PR fixes a problem where `chainermn_test.py::TestChainerMNStudy::test_failure` fails occasionally depending on the execution timing.

The problem can be reproduced by applying a patch to `master` branch and executing the test command as follows:
```console
$ cat patch
diff --git a/tests/integration_tests/test_chainermn.py b/tests/integration_tests/test_chainermn.py
index 8ba9863..c282e90 100644
--- a/tests/integration_tests/test_chainermn.py
+++ b/tests/integration_tests/test_chainermn.py
@@ -221,6 +221,10 @@ class TestChainerMNStudy(object):
             n_trials = 20
             mn_study.optimize(objective, n_trials=n_trials, catch=(ValueError, ))
 
+            if comm.rank != 0:
+                import time
+                time.sleep(1)
+
             # Assert trial count.
             assert len(mn_study.trials) == n_trials

$ patch -p1 < patch

$ mpirun -n 2 -- pytest -v tests/integration_tests/test_chainermn.py::TestChainerMNStudy::test_failure
collected 4 items                                              

tests/integration_tests/test_chainermn.py::TestChainerMNStudy::test_failure[True-new] PASSED [ 25%]
tests/integration_tests/test_chainermn.py::TestChainerMNStudy::test_failure[True-common] FAILED [ 50%]

=================================== FAILURES ===================================
__________________ TestChainerMNStudy.test_failure[False-new] __________________

storage_mode = 'new', cache_mode = False
comm = <chainermn.communicators.naive_communicator.NaiveCommunicator object at 0x7f4424e8b160>

    @staticmethod
    @pytest.mark.parametrize('storage_mode', STORAGE_MODES)
    @pytest.mark.parametrize('cache_mode', CACHE_MODES)
    def test_failure(storage_mode, cache_mode, comm):
        # type: (str, bool, CommunicatorBase) -> None

        with MultiNodeStorageSupplier(storage_mode, cache_mode, comm) as storage:
            study = TestChainerMNStudy._create_shared_study(storage, comm)
            mn_study = ChainerMNStudy(study, comm)

            def objective(_trial, _comm):
                # type: (Trial, bool) -> float

                raise ValueError  # Always fails.

            # Invoke optimize in which `ValueError` is accepted.
            n_trials = 20
            mn_study.optimize(objective, n_trials=n_trials, catch=(ValueError, ))

            # Assert trial count.
>           assert len(mn_study.trials) == n_trials
E           assert 21 == 20
E             -21
E             +20

tests/integration_tests/test_chainermn.py:225: AssertionError
```