### PR TITLE
Support low == high.

### DIFF
--- a/optuna/trial.py
+++ b/optuna/trial.py
@@ -151,7 +151,9 @@ class Trial(BaseTrial):
 
         distribution = distributions.UniformDistribution(low=low, high=high)
         if low == high:
-            return self._inject(name, low, distribution)
+            param_value_in_internal_repr = distribution.to_internal_repr(low)
+            return self._set_new_param_or_get_existing(name, param_value_in_internal_repr,
+                                                       distribution)
 
         return self._suggest(name, distribution)
 
@@ -191,7 +193,9 @@ class Trial(BaseTrial):
 
         distribution = distributions.LogUniformDistribution(low=low, high=high)
         if low == high:
-            return self._inject(name, low, distribution)
+            param_value_in_internal_repr = distribution.to_internal_repr(low)
+            return self._set_new_param_or_get_existing(name, param_value_in_internal_repr,
+                                                       distribution)
 
         return self._suggest(name, distribution)
 
@@ -244,7 +248,9 @@ class Trial(BaseTrial):
 
         distribution = distributions.DiscreteUniformDistribution(low=low, high=high, q=q)
         if low == high:
-            return self._inject(name, low, distribution)
+            param_value_in_internal_repr = distribution.to_internal_repr(low)
+            return self._set_new_param_or_get_existing(name, param_value_in_internal_repr,
+                                                       distribution)
 
         return self._suggest(name, distribution)
 
@@ -281,7 +287,9 @@ class Trial(BaseTrial):
 
         distribution = distributions.IntUniformDistribution(low=low, high=high)
         if low == high:
-            return int(self._inject(name, low, distribution))
+            param_value_in_internal_repr = distribution.to_internal_repr(low)
+            return self._set_new_param_or_get_existing(name, param_value_in_internal_repr,
+                                                       distribution)
 
         return int(self._suggest(name, distribution))
 
@@ -426,18 +434,10 @@ class Trial(BaseTrial):
         param_value_in_internal_repr = self.study.sampler.sample(self.storage, self.study_id, name,
                                                                  distribution)
 
-        return self._save_new_param_or_load_existing(name, param_value_in_internal_repr,
-                                                     distribution)
+        return self._set_new_param_or_get_existing(name, param_value_in_internal_repr,
+                                                   distribution)
 
-    def _inject(self, name, param_value, distribution):
-        # type: (str, Any, distributions.BaseDistribution) -> Any
-
-        param_value_in_internal_repr = distribution.to_internal_repr(param_value)
-
-        return self._save_new_param_or_load_existing(name, param_value_in_internal_repr,
-                                                     distribution)
-
-    def _save_new_param_or_load_existing(self, name, param_value_in_internal_repr, distribution):
+    def _set_new_param_or_get_existing(self, name, param_value_in_internal_repr, distribution):
         # type: (str, float, distributions.BaseDistribution) -> Any
 
         set_success = self.storage.set_trial_param(self._trial_id, name,

--- a/optuna/trial.py
+++ b/optuna/trial.py
@@ -424,18 +424,19 @@ class Trial(BaseTrial):
         param_value_in_internal_repr = self.study.sampler.sample(self.storage, self.study_id, name,
                                                                  distribution)
 
-        set_success = self.storage.set_trial_param(self._trial_id, name,
-                                                   param_value_in_internal_repr, distribution)
-        if not set_success:
-            param_value_in_internal_repr = self.storage.get_trial_param(self._trial_id, name)
-
-        param_value = distribution.to_external_repr(param_value_in_internal_repr)
-        return param_value
+        return self._save_new_param_or_load_existing(name, param_value_in_internal_repr,
+                                                     distribution)
 
     def _inject(self, name, param_value, distribution):
         # type: (str, Any, distributions.BaseDistribution) -> Any
 
         param_value_in_internal_repr = distribution.to_internal_repr(param_value)
+
+        return self._save_new_param_or_load_existing(name, param_value_in_internal_repr,
+                                                     distribution)
+
+    def _save_new_param_or_load_existing(self, name, param_value_in_internal_repr, distribution):
+        # type: (str, float, distributions.BaseDistribution) -> Any
 
         set_success = self.storage.set_trial_param(self._trial_id, name,
                                                    param_value_in_internal_repr, distribution)

--- a/optuna/trial.py
+++ b/optuna/trial.py
@@ -122,7 +122,8 @@ class Trial(BaseTrial):
         """Suggest a value for the continuous parameter.
 
         The value is sampled from the range :math:`[\\mathsf{low}, \\mathsf{high})`
-        in the linear domain.
+        in the linear domain. When :math:`\\mathsf{low} = \\mathsf{high}`, the value of
+        :math:`\\mathsf{low}` will be returned.
 
         Example:
 
@@ -159,7 +160,8 @@ class Trial(BaseTrial):
         """Suggest a value for the continuous parameter.
 
         The value is sampled from the range :math:`[\\mathsf{low}, \\mathsf{high})`
-        in the log domain.
+        in the log domain. When :math:`\\mathsf{low} = \\mathsf{high}`, the value of
+        :math:`\\mathsf{low}` will be returned.
 
         Example:
 

--- a/tests/test_trial.py
+++ b/tests/test_trial.py
@@ -65,19 +65,21 @@ def test_suggest_low_equals_high(storage_init_func):
 
     study = create_study(storage_init_func(), sampler=samplers.TPESampler(n_startup_trials=0))
     trial = Trial(study, study.storage.create_new_trial_id(study.study_id))
-    with patch.object(trial, '_inject', wraps=trial._inject) as mock_object:
+
+    # Parameter values are determined without suggestion when low == high.
+    with patch.object(trial, '_suggest', wraps=trial._suggest) as mock_object:
         assert trial.suggest_uniform('a', 1., 1.) == 1.  # Suggesting a param.
         assert trial.suggest_uniform('a', 1., 1.) == 1.  # Suggesting the same param.
-        assert mock_object.call_count == 2
+        assert mock_object.call_count == 0
         assert trial.suggest_loguniform('b', 1., 1.) == 1.  # Suggesting a param.
         assert trial.suggest_loguniform('b', 1., 1.) == 1.  # Suggesting the same param.
-        assert mock_object.call_count == 4
+        assert mock_object.call_count == 0
         assert trial.suggest_discrete_uniform('c', 1., 1., 1.) == 1.  # Suggesting a param.
         assert trial.suggest_discrete_uniform('c', 1., 1., 1.) == 1.  # Suggesting the same param.
-        assert mock_object.call_count == 6
+        assert mock_object.call_count == 0
         assert trial.suggest_int('d', 1, 1) == 1  # Suggesting a param.
         assert trial.suggest_int('d', 1, 1) == 1  # Suggesting the same param.
-        assert mock_object.call_count == 8
+        assert mock_object.call_count == 0
 
 
 @parametrize_storage

--- a/tests/test_trial.py
+++ b/tests/test_trial.py
@@ -66,17 +66,17 @@ def test_suggest_low_equals_high(storage_init_func):
     study = create_study(storage_init_func(), sampler=samplers.TPESampler(n_startup_trials=0))
     trial = Trial(study, study.storage.create_new_trial_id(study.study_id))
     with patch.object(trial, '_inject', wraps=trial._inject) as mock_object:
-        assert trial.suggest_uniform('x', 1., 1.) == 1.  # Suggesting a param.
-        assert trial.suggest_uniform('x', 1., 1.) == 1.  # Suggesting the same param.
+        assert trial.suggest_uniform('a', 1., 1.) == 1.  # Suggesting a param.
+        assert trial.suggest_uniform('a', 1., 1.) == 1.  # Suggesting the same param.
         assert mock_object.call_count == 2
-        assert trial.suggest_loguniform('y', 1., 1.) == 1.  # Suggesting a param.
-        assert trial.suggest_loguniform('y', 1., 1.) == 1.  # Suggesting the same param.
+        assert trial.suggest_loguniform('b', 1., 1.) == 1.  # Suggesting a param.
+        assert trial.suggest_loguniform('b', 1., 1.) == 1.  # Suggesting the same param.
         assert mock_object.call_count == 4
-        assert trial.suggest_discrete_uniform('z', 1., 1., 1.) == 1.  # Suggesting a param.
-        assert trial.suggest_discrete_uniform('z', 1., 1., 1.) == 1.  # Suggesting the same param.
+        assert trial.suggest_discrete_uniform('c', 1., 1., 1.) == 1.  # Suggesting a param.
+        assert trial.suggest_discrete_uniform('c', 1., 1., 1.) == 1.  # Suggesting the same param.
         assert mock_object.call_count == 6
-        assert trial.suggest_int('a', 1, 1) == 1  # Suggesting a param.
-        assert trial.suggest_int('a', 1, 1) == 1  # Suggesting the same param.
+        assert trial.suggest_int('d', 1, 1) == 1  # Suggesting a param.
+        assert trial.suggest_int('d', 1, 1) == 1  # Suggesting the same param.
         assert mock_object.call_count == 8
 
 

--- a/tests/test_trial.py
+++ b/tests/test_trial.py
@@ -60,6 +60,27 @@ def test_suggest_discrete_uniform(storage_init_func):
 
 
 @parametrize_storage
+def test_suggest_low_equals_high(storage_init_func):
+    # type: (typing.Callable[[], storages.BaseStorage]) -> None
+
+    study = create_study(storage_init_func(), sampler=samplers.TPESampler(n_startup_trials=0))
+    trial = Trial(study, study.storage.create_new_trial_id(study.study_id))
+    with patch.object(trial, '_inject', wraps=trial._inject) as mock_object:
+        assert trial.suggest_uniform('x', 1., 1.) == 1.  # Suggesting a param.
+        assert trial.suggest_uniform('x', 1., 1.) == 1.  # Suggesting the same param.
+        assert mock_object.call_count == 2
+        assert trial.suggest_loguniform('y', 1., 1.) == 1.  # Suggesting a param.
+        assert trial.suggest_loguniform('y', 1., 1.) == 1.  # Suggesting the same param.
+        assert mock_object.call_count == 4
+        assert trial.suggest_discrete_uniform('z', 1., 1., 1.) == 1.  # Suggesting a param.
+        assert trial.suggest_discrete_uniform('z', 1., 1., 1.) == 1.  # Suggesting the same param.
+        assert mock_object.call_count == 6
+        assert trial.suggest_int('a', 1, 1) == 1  # Suggesting a param.
+        assert trial.suggest_int('a', 1, 1) == 1  # Suggesting the same param.
+        assert mock_object.call_count == 8
+
+
+@parametrize_storage
 @pytest.mark.parametrize(
     'range_config',
     [


### PR DESCRIPTION
This PR adds support for suggestion ranges whose endpoints take the same value.
For example, we can optimize the following objective function without any errors.

```python
def objective(trial):
    a = trial.suggest_uniform('a', 1, 1)
    b = trial.suggest_loguniform('b', 1, 1)
    c = trial.suggest_int('c', 1, 1)
    d = trial.suggest_discrete_uniform('d', 1, 1, 1)
    return a + b + c + d
```