### PR TITLE
Rename MxnetPruningCallback to MXNetPruningCallback.

### DIFF
--- a/docs/source/reference/integration.rst
+++ b/docs/source/reference/integration.rst
@@ -15,7 +15,7 @@ Integration
 .. autoclass:: LightGBMPruningCallback
     :members:
 
-.. autoclass:: MxnetPruningCallback
+.. autoclass:: MXNetPruningCallback
     :members:
 
 .. autoclass:: TensorFlowPruningHook

--- a/docs/source/tutorial/pruning.rst
+++ b/docs/source/tutorial/pruning.rst
@@ -80,7 +80,7 @@ To implement pruning mechanism in much simpler forms, Optuna provides integratio
 - Chainer: :class:`optuna.integration.ChainerPruningExtension`
 - Keras: :class:`optuna.integration.KerasPruningCallback`
 - TensorFlow :class:`optuna.integration.TensorFlowPruningHook`
-- MXNet :class:`optuna.integration.MxnetPruningCallback`
+- MXNet :class:`optuna.integration.MXNetPruningCallback`
 
 For example, :class:`~optuna.integration.XGBoostPruningCallback` introduces pruning without directly changing the logic of training iteration.
 (See also `example <https://github.com/pfnet/optuna/blob/master/examples/pruning/xgboost_integration.py>`_ for the entire script.)

--- a/optuna/integration/__init__.py
+++ b/optuna/integration/__init__.py
@@ -11,7 +11,7 @@ _import_structure = {
     'chainermn': ['ChainerMNStudy'],
     'keras': ['KerasPruningCallback'],
     'lightgbm': ['LightGBMPruningCallback'],
-    'mxnet': ['MxnetPruningCallback'],
+    'mxnet': ['MXNetPruningCallback'],
     'tensorflow': ['TensorFlowPruningHook'],
     'xgboost': ['XGBoostPruningCallback'],
 }
@@ -25,7 +25,7 @@ if sys.version_info[0] == 2 or TYPE_CHECKING:
     from optuna.integration.chainermn import ChainerMNStudy  # NOQA
     from optuna.integration.keras import KerasPruningCallback  # NOQA
     from optuna.integration.lightgbm import LightGBMPruningCallback  # NOQA
-    from optuna.integration.mxnet import MxnetPruningCallback  # NOQA
+    from optuna.integration.mxnet import MXNetPruningCallback  # NOQA
     from optuna.integration.tensorflow import TensorFlowPruningHook  # NOQA
     from optuna.integration.xgboost import XGBoostPruningCallback  # NOQA
 else:

--- a/optuna/integration/mxnet.py
+++ b/optuna/integration/mxnet.py
@@ -20,7 +20,7 @@ class MXNetPruningCallback(object):
         .. code::
 
             model.fit(train_data=X, eval_data=Y,
-                      eval_end_callback=MxnetPruningCallback(trial, eval_metric='accuracy'))
+                      eval_end_callback=MXNetPruningCallback(trial, eval_metric='accuracy'))
 
     Args:
         trial:

--- a/optuna/integration/mxnet.py
+++ b/optuna/integration/mxnet.py
@@ -10,7 +10,7 @@ except ImportError as e:
     _available = False
 
 
-class MxnetPruningCallback(object):
+class MXNetPruningCallback(object):
     """MXNet callback to prune unpromising trials.
 
     Example:
@@ -30,7 +30,7 @@ class MxnetPruningCallback(object):
             An evaluation metric name for pruning, e.g., ``cross-entropy`` and
             ``accuracy``. If using default metrics like mxnet.metrics.Accuracy, use it's
             default metric name. For custom metrics, use the metric_name provided to
-             constructor. Please refer to `mxnet.metrics reference
+            constructor. Please refer to `mxnet.metrics reference
             <https://mxnet.apache.org/api/python/metric/metric.html>`_ for further details.
     """
 

--- a/tests/integration_tests/test_integration.py
+++ b/tests/integration_tests/test_integration.py
@@ -8,6 +8,7 @@ def test_import():
     from optuna.integration import chainermn  # NOQA
     from optuna.integration import keras  # NOQA
     from optuna.integration import lightgbm  # NOQA
+    from optuna.integration import mxnet  # NOQA
     from optuna.integration import tensorflow  # NOQA
     from optuna.integration import xgboost  # NOQA
 
@@ -15,6 +16,7 @@ def test_import():
     from optuna.integration import ChainerPruningExtension  # NOQA
     from optuna.integration import KerasPruningCallback  # NOQA
     from optuna.integration import LightGBMPruningCallback  # NOQA
+    from optuna.integration import MXNetPruningCallback  # NOQA
     from optuna.integration import TensorFlowPruningHook  # NOQA
     from optuna.integration import XGBoostPruningCallback  # NOQA
 
@@ -31,12 +33,14 @@ def test_module_attributes():
     assert hasattr(optuna.integration, 'chainermn')
     assert hasattr(optuna.integration, 'keras')
     assert hasattr(optuna.integration, 'lightgbm')
+    assert hasattr(optuna.integration, 'mxnet')
     assert hasattr(optuna.integration, 'tensorflow')
     assert hasattr(optuna.integration, 'xgboost')
     assert hasattr(optuna.integration, 'ChainerMNStudy')
     assert hasattr(optuna.integration, 'ChainerPruningExtension')
     assert hasattr(optuna.integration, 'KerasPruningCallback')
     assert hasattr(optuna.integration, 'LightGBMPruningCallback')
+    assert hasattr(optuna.integration, 'MXNetPruningCallback')
     assert hasattr(optuna.integration, 'TensorFlowPruningHook')
     assert hasattr(optuna.integration, 'XGBoostPruningCallback')
 

--- a/tests/integration_tests/test_mxnet.py
+++ b/tests/integration_tests/test_mxnet.py
@@ -3,7 +3,7 @@ import numpy as np
 import pytest
 
 import optuna
-from optuna.integration.mxnet import MxnetPruningCallback
+from optuna.integration.mxnet import MXNetPruningCallback
 from optuna.testing.integration import DeterministicPruner
 from optuna import types
 
@@ -43,7 +43,7 @@ def test_mxnet_pruning_callback():
                   eval_metric=eval_metric,
                   optimizer=optimizer,
                   num_epoch=1,
-                  eval_end_callback=MxnetPruningCallback(trial, 'accuracy'))
+                  eval_end_callback=MXNetPruningCallback(trial, 'accuracy'))
         return 1.0
 
     study = optuna.create_study(pruner=DeterministicPruner(True))


### PR DESCRIPTION
This is a followup PR to #363
- rename `MxnetPruningCallBack` to `MXNetPruningCallback`, and
- add test cases for integration import.