### PR TITLE
SuccessiveHalvingPruner too aggressively pruned promising configurations.

### DIFF
--- a/optuna/pruners/successive_halving.py
+++ b/optuna/pruners/successive_halving.py
@@ -131,13 +131,10 @@ class SuccessiveHalvingPruner(BasePruner):
         competing_values.append(value)
         competing_values.sort()
 
-        promotable_idx = (len(competing_values) // self.reduction_factor) - 1
-        if promotable_idx == -1:
-            # Optuna does not support to suspend/resume ongoing trials.
-            #
-            # For the first `eta - 1` trials, this implementation promotes a trial if its
-            # intermediate value is the smallest one among the trials that have completed the rung.
-            promotable_idx = 0
+        # Optuna does not support to suspend/resume ongoing trials.
+        # For the first `eta - 1` trials, this implementation promotes a trial if its
+        # intermediate value is the smallest one among the trials that have completed the rung.
+        promotable_idx = (len(competing_values) // self.reduction_factor)
 
         if study_direction == StudyDirection.MAXIMIZE:
             competing_values.reverse()


### PR DESCRIPTION
This PR proposes to change the behavior of SuccessiveHalvingPrunner.

## Current behavior

To check the current behavior, I inserted print statements like following:

```diff
$ git diff
diff --git a/optuna/pruners/successive_halving.py b/optuna/pruners/successive_halving.py
index fc9c963..2019306 100644
--- a/optuna/pruners/successive_halving.py
+++ b/optuna/pruners/successive_halving.py
@@ -117,6 +117,7 @@ class SuccessiveHalvingPruner(BasePruner):
                 all_trials = storage.get_all_trials(study_id)
 
             storage.set_trial_system_attr(trial_id, _completed_rung_key(rung), value)
+            print("SuccessiveHulvingPrunner", trial_id, rung, value)
             direction = storage.get_study_direction(study_id)
             if not self._is_promotable(rung, value, all_trials, direction):
                 return True
```

After that I executed [this notebook](https://github.com/pfnet/optuna/blob/master/examples/visualization/plot_intermediate_values.ipynb), then got following results:

```
SuccessiveHulvingPrunner 0 0 0.08868571428571426   # It happened to be a good result.
SuccessiveHulvingPrunner 0 1 0.056571428571428606
SuccessiveHulvingPrunner 0 2 0.03531428571428574
SuccessiveHulvingPrunner 0 3 0.02771428571428569  #  The first configuration (trial_id=0) wasn't be pruned because Optuna cannot suspend/resume the training.
SuccessiveHulvingPrunner 1 0 0.4951428571428571
SuccessiveHulvingPrunner 2 0 0.12205714285714286
SuccessiveHulvingPrunner 3 0 0.15028571428571424
SuccessiveHulvingPrunner 4 0 0.7889142857142857
SuccessiveHulvingPrunner 5 0 0.09319999999999995   # This should not be pruned because the reduction factor is 4 and this configurations performs well.
SuccessiveHulvingPrunner 6 0 0.1151428571428571
SuccessiveHulvingPrunner 7 0 0.23874285714285715
SuccessiveHulvingPrunner 8 0 0.1068
SuccessiveHulvingPrunner 9 0 0.19565714285714286
SuccessiveHulvingPrunner 10 0 0.7490285714285714
SuccessiveHulvingPrunner 11 0 0.8316
SuccessiveHulvingPrunner 12 0 0.14565714285714282
SuccessiveHulvingPrunner 13 0 0.9128571428571428
SuccessiveHulvingPrunner 14 0 0.1074857142857143
SuccessiveHulvingPrunner 15 0 0.16920000000000002
SuccessiveHulvingPrunner 16 0 0.4868571428571429
SuccessiveHulvingPrunner 17 0 0.4296
SuccessiveHulvingPrunner 18 0 0.10148571428571429   # The second configuration which is not pruned in rung=0
SuccessiveHulvingPrunner 18 1 0.05834285714285714
SuccessiveHulvingPrunner 19 0 0.1435428571428572
SuccessiveHulvingPrunner 20 0 0.8167428571428571
SuccessiveHulvingPrunner 21 0 0.8064571428571429
SuccessiveHulvingPrunner 22 0 0.5657714285714286
SuccessiveHulvingPrunner 23 0 0.16759999999999997
SuccessiveHulvingPrunner 24 0 0.08857142857142852
SuccessiveHulvingPrunner 24 1 0.06348571428571426
```

Because `n_jobs` is 1, the actual behavior is not Asynchronous. Since optuna cannot suspend/resume the training, the first configuration (`trial_id=0`) wasn't be pruned. But `SuccessiveHalvingPruner` pruned all the configurations(trials) until `trial_id=17` in `rung=0`. 

Especially it seems that the configuration at `trial_id=5` is promising because it's configuration got second-best score on the whole. From the perspective of reduction factor is 4, I think it should not be pruned.

`SuccessiveHavingPruner` pruned more configurations than I expected. It's so aggressive that the reduction factor value is not very reliable.

## Solution

As a premise, Optuna cannot achieve exactly the same behavior as the [Asynchronous Successive Halving Algorithm](https://arxiv.org/abs/1810.05934) because it couldn't provides the method to  suspend/resume training. However, the current implementation has the problem that more promising configurations are pruned than the original SuccessiveHalving algorithm (I know it requires trade-off with the cost.).

The reason why the configuration of `trial_id=5` is pruned in `rung=0` although reduction factor is 4 is decrementing `promotable_idx`. I guess the purpose of decrementation is to fit the index number of array. But it looks the bug which causes this problem.

If I misunderstood, please point it out 🙇 

## TODO

* [ ] Fix tests
* [ ] Add test cases.