### PR TITLE
Fix type of suggest APIs.

### DIFF
--- a/optuna/samplers/random.py
+++ b/optuna/samplers/random.py
@@ -38,7 +38,7 @@ class RandomSampler(BaseSampler):
         elif isinstance(param_distribution, distributions.LogUniformDistribution):
             log_low = numpy.log(param_distribution.low)
             log_high = numpy.log(param_distribution.high)
-            return numpy.exp(self.rng.uniform(log_low, log_high))
+            return float(numpy.exp(self.rng.uniform(log_low, log_high)))
         elif isinstance(param_distribution, distributions.DiscreteUniformDistribution):
             q = param_distribution.q
             r = param_distribution.high - param_distribution.low
@@ -48,7 +48,7 @@ class RandomSampler(BaseSampler):
             s = self.rng.uniform(low, high)
             v = numpy.round(s / q) * q + param_distribution.low
             # v may slightly exceed range due to round-off errors.
-            return min(max(v, param_distribution.low), param_distribution.high)
+            return float(min(max(v, param_distribution.low), param_distribution.high))
         elif isinstance(param_distribution, distributions.IntUniformDistribution):
             # numpy.random.randint includes low but excludes high.
             return self.rng.randint(param_distribution.low, param_distribution.high + 1)

--- a/optuna/samplers/tpe/sampler.py
+++ b/optuna/samplers/tpe/sampler.py
@@ -212,8 +212,10 @@ class TPESampler(base.BaseSampler):
             q=q,
             is_log=is_log)
 
-        return TPESampler._compare(
-            samples=samples_below, log_l=log_likelihoods_below, log_g=log_likelihoods_above)[0]
+        return float(
+            TPESampler._compare(
+                samples=samples_below, log_l=log_likelihoods_below,
+                log_g=log_likelihoods_above)[0])
 
     def _sample_categorical(self, distribution, below, above):
         # type: (distributions.CategoricalDistribution, np.ndarray, np.ndarray) -> float

--- a/tests/samplers_tests/test_samplers.py
+++ b/tests/samplers_tests/test_samplers.py
@@ -33,6 +33,8 @@ def test_uniform(sampler_class, distribution):
     ])
     assert np.all(points >= distribution.low)
     assert np.all(points < distribution.high)
+    assert not isinstance(
+        study.sampler.sample(study.storage, study.study_id, 'x', distribution), np.floating)
 
 
 @parametrize_sampler
@@ -46,6 +48,8 @@ def test_log_uniform(sampler_class, distribution):
     ])
     assert np.all(points >= distribution.low)
     assert np.all(points < distribution.high)
+    assert not isinstance(
+        study.sampler.sample(study.storage, study.study_id, 'x', distribution), np.floating)
 
 
 @parametrize_sampler
@@ -63,6 +67,8 @@ def test_discrete_uniform(sampler_class, distribution):
     ])
     assert np.all(points >= distribution.low)
     assert np.all(points <= distribution.high)
+    assert not isinstance(
+        study.sampler.sample(study.storage, study.study_id, 'x', distribution), np.floating)
 
     # Check all points are multiples of distribution.q.
     points = points
@@ -87,6 +93,8 @@ def test_int(sampler_class, distribution):
     ])
     assert np.all(points >= distribution.low)
     assert np.all(points <= distribution.high)
+    assert not isinstance(
+        study.sampler.sample(study.storage, study.study_id, 'x', distribution), np.integer)
 
 
 @parametrize_sampler


### PR DESCRIPTION
This PR fixes the type of following suggest APIs:
- `TPESampler.suggest_uniform`,
- `TPESampler.suggest_loguniform`,
- `TPESampler.suggest_discrete_uniform`,
- `RandomSampler.suggest_loguniform`, and
- `RandomSampler.suggest_discrete_uniform`.

The expected type is `float`, but the actual type is `numpy.float64`.
This mismatch causes errors when users use MySQL as reported in https://github.com/pfnet/optuna/issues/392.