### PR TITLE
Remove print calls for logging from PyTorch example.

### DIFF
--- a/examples/pytorch_simple.py
+++ b/examples/pytorch_simple.py
@@ -127,15 +127,8 @@ def objective(trial):
             # Updating the weights.
             optimizer.step()
 
-            # Printing statistics.
-            if batch_idx % LOG_INTERVAL == 0:
-                print('Train Epoch: {} [{}/{} ({:.0f}%)]\tLoss: {:.6f}'.format(
-                    epoch, batch_idx * len(data), N_TRAIN_EXAMPLES,
-                    100. * batch_idx * BATCHSIZE / N_TRAIN_EXAMPLES, loss.item()))
-
     # Validation of the model.
     model.eval()
-    test_loss = 0
     correct = 0
     with torch.no_grad():
         for batch_idx, (data, target) in enumerate(test_loader):
@@ -144,16 +137,10 @@ def objective(trial):
                 break
             data, target = data.to(DEVICE), target.to(DEVICE)
             output = model(data)
-            test_loss += F.nll_loss(output, target, reduction='sum').item()  # Sum up batch losses.
             pred = output.argmax(dim=1, keepdim=True)  # Get the index of the max log-probability.
             correct += pred.eq(target.view_as(pred)).sum().item()
 
-    test_loss /= N_TEST_EXAMPLES
     accuracy = 100. * correct / N_TEST_EXAMPLES
-
-    print('\nTest set: Average loss: {:.4f}, Accuracy: {}/{} ({:.0f}%)\n'.format(
-        test_loss, correct, N_TEST_EXAMPLES, accuracy))
-
     return accuracy
 
 

--- a/examples/pytorch_simple.py
+++ b/examples/pytorch_simple.py
@@ -90,7 +90,7 @@ def get_mnist():
                                               batch_size=BATCHSIZE,
                                               shuffle=True)
 
-    return (train_loader, test_loader)
+    return train_loader, test_loader
 
 
 def objective(trial):

--- a/examples/pytorch_simple.py
+++ b/examples/pytorch_simple.py
@@ -19,6 +19,7 @@ We have the following two ways to execute this example:
 
 """
 
+from __future__ import division
 from __future__ import print_function
 
 import os
@@ -140,7 +141,7 @@ def objective(trial):
             pred = output.argmax(dim=1, keepdim=True)  # Get the index of the max log-probability.
             correct += pred.eq(target.view_as(pred)).sum().item()
 
-    accuracy = 100. * correct / N_TEST_EXAMPLES
+    accuracy = correct / N_TEST_EXAMPLES
     return accuracy
 
 

--- a/examples/pytorch_simple.py
+++ b/examples/pytorch_simple.py
@@ -59,11 +59,11 @@ class Net(nn.Module):
 
         self.layers.append(nn.Linear(input_dim, CLASSES))
 
-        # assinging the layers as class variables (PyTorch requirement).
+        # Assigning the layers as class variables (PyTorch requirement).
         for idx, layer in enumerate(self.layers):
             setattr(self, 'fc{}'.format(idx), layer)
 
-        # assinging the dropouts as class variables (PyTorch requirement).
+        # Assigning the dropouts as class variables (PyTorch requirement).
         for idx, dropout in enumerate(self.dropouts):
             setattr(self, 'drop{}'.format(idx), dropout)
 


### PR DESCRIPTION
This is a followup PR to #366.