### PR TITLE
Escape '%' character in storage URL.

### DIFF
--- a/optuna/storages/rdb/storage.py
+++ b/optuna/storages/rdb/storage.py
@@ -839,10 +839,11 @@ class _VersionManager(object):
     def _create_alembic_config(self):
         # type: () -> alembic.config.Config
 
+        alembic_dir = os.path.join(os.path.dirname(__file__), 'alembic')
+
         config = alembic.config.Config(os.path.join(os.path.dirname(__file__), 'alembic.ini'))
-        config.set_main_option('script_location', os.path.join(
-            os.path.dirname(__file__), 'alembic'))
-        config.set_main_option('sqlalchemy.url', self.url)
+        config.set_main_option('script_location', escape_alembic_config_value(alembic_dir))
+        config.set_main_option('sqlalchemy.url', escape_alembic_config_value(self.url))
         return config
 
 
@@ -881,3 +882,12 @@ class _FinishedTrialsCache(object):
 
         with self._lock:
             return self._finished_trials.get(trial_id)
+
+
+def escape_alembic_config_value(value):
+    # type: (str) -> str
+
+    # We must escape '%' in a value string because the character
+    # is regarded as the trigger of variable expansion.
+    # Please see the documentation of `configparser.BasicInterpolation` for more details.
+    return value.replace('%', '%%')

--- a/tests/storages_tests/rdb_tests/test_storage.py
+++ b/tests/storages_tests/rdb_tests/test_storage.py
@@ -49,6 +49,21 @@ def test_init_url_template():
         assert storage.engine.url.database.endswith(str(SCHEMA_VERSION))
 
 
+def test_init_url_that_contains_percent_character():
+    # type: ()-> None
+
+    # Alembic's ini file regards '%' as the special character for variable expansion.
+    # We checks `RDBStorage` does not raise an error even if a storage url contains the character.
+    with tempfile.NamedTemporaryFile(suffix='%') as tf:
+        RDBStorage('sqlite:///' + tf.name)
+
+    with tempfile.NamedTemporaryFile(suffix='%foo') as tf:
+        RDBStorage('sqlite:///' + tf.name)
+
+    with tempfile.NamedTemporaryFile(suffix='%foo%%bar') as tf:
+        RDBStorage('sqlite:///' + tf.name)
+
+
 def test_init_db_module_import_error():
     # type: () -> None
 


### PR DESCRIPTION
This PR fixes the problem that an error occurs when a storage URL that contains "%" is specified.

The following is an example of this problem:
```python
>>> import optuna
>>> optuna.create_study(study_name='foo', storage='sqlite:///bar%baz.db')
ValueError: invalid interpolation syntax in 'sqlite:///bar%baz.db' at position 13
```
