### PR TITLE
Fix installation failure with Python-3.5.2.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -84,8 +84,11 @@ setup(
     url='https://optuna.org/',
     packages=find_packages(),
     package_data={
-        'optuna':
-        ['storages/rdb/alembic.ini', 'storages/rdb/alembic/*', 'storages/rdb/alembic/versions/*']
+        'optuna': [
+            'storages/rdb/alembic.ini',
+            'storages/rdb/alembic/*.*',
+            'storages/rdb/alembic/versions/*.*'
+        ]
     },
     install_requires=get_install_requires(),
     tests_require=get_extras_require()['testing'],


### PR DESCRIPTION
This PR fixes a problem that it fails to install the latest Optuna in Python-3.5.2 environment.

### Cause and Solution

[setup.py@v0.10.0](https://github.com/pfnet/optuna/blob/v0.10.0/setup.py#L88) uses wildcard string "*" as follows:
```python
    package_data={
        'optuna':
        ['storages/rdb/alembic.ini', 'storages/rdb/alembic/*', 'storages/rdb/alembic/versions/*']
    }
```
Python-3.5.2 cannot handle this properly, so an installation error occurs (see next section).
This PR solves this problem by replacing the wildcard string with "*.*".

### How to Reproduce the Problem

Please execute the following command (it fails):
```console
$ docker run --rm -it python:3.5.2 pip install optuna
...
    creating build/lib/optuna/storages/rdb/alembic
    error: can't copy 'optuna/storages/rdb/alembic/versions': doesn't exist or not a regular file

    ----------------------------------------
Command "/usr/local/bin/python3.5 -u -c "import setuptools, tokenize;__file__='/tmp/pip-build-dmsje_c6/optuna/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" install --reco
rd /tmp/pip-3_d0obq6-record/install-record.txt --single-version-externally-managed --compile" failed with error code 1 in /tmp/pip-build-dmsje_c6/optuna/
```

By referring to this PR branch, the installation will success:
```console
$ docker run --rm -it python:3.5.2 pip install git+https://github.com/pfnet/optuna.git@fix-install-error-on-python3.5.2
...
  Running setup.py install for optuna ... done
Successfully installed Mako-1.0.10 MarkupSafe-1.1.1 PrettyTable-0.7.2 PyYAML-5.1 alembic-1.0.10 attrs-19.1.0 cliff-2.14.1 cmd2-0.9.12 colorama-0.4.1 colorlog-4.0.2 numpy-1.16.3 optuna-0.10.0 pandas-0.24.2 pbr-5.2.0 pyparsing-2.4.0 pyperclip-1.7.0 python-dateutil-2.8.0 python-editor-1.0.4 pytz-2019.1 scipy-1.3.0 six-1.12.0 sqlalchemy-1.3.3 stevedore-1.30.1 typing-3.6.6 wcwidth-0.1.7
```

And this branch also works with other Python versions:
```console
$ docker run --rm -it python:2.7   pip install git+https://github.com/pfnet/optuna.git@fix-install-error-on-python3.5.2
$ docker run --rm -it python:3.5.3 pip install git+https://github.com/pfnet/optuna.git@fix-install-error-on-python3.5.2
$ docker run --rm -it python:3.6   pip install git+https://github.com/pfnet/optuna.git@fix-install-error-on-python3.5.2
$ docker run --rm -it python:3.7   pip install git+https://github.com/pfnet/optuna.git@fix-install-error-on-python3.5.2
```