### PR TITLE
Fix a bug that `FixedTrial` cannot handle categorical parameters correctly.

### DIFF
--- a/optuna/trial.py
+++ b/optuna/trial.py
@@ -603,7 +603,8 @@ class FixedTrial(BaseTrial):
                              'the construction of the FixedTrial object.'.format(name))
 
         value = self._params[name]
-        if not distribution._contains(value):
+        param_value_in_internal_repr = distribution.to_internal_repr(value)
+        if not distribution._contains(param_value_in_internal_repr):
             raise ValueError("The value {} of the parameter '{}' is out of "
                              "the range of the distribution {}.".format(value, name, distribution))
 

--- a/tests/test_trial.py
+++ b/tests/test_trial.py
@@ -245,11 +245,19 @@ def test_fixed_trial_suggest_int():
 def test_fixed_trial_suggest_categorical():
     # type: () -> None
 
+    # Integer categories.
     trial = FixedTrial({'x': 1})
     assert trial.suggest_categorical('x', [0, 1, 2, 3]) == 1
 
     with pytest.raises(ValueError):
         trial.suggest_categorical('y', [0, 1, 2, 3])
+
+    # String categories.
+    trial = FixedTrial({'x': 'baz'})
+    assert trial.suggest_categorical('x', ['foo', 'bar', 'baz']) == 'baz'
+
+    with pytest.raises(ValueError):
+        trial.suggest_categorical('y', ['foo', 'bar', 'baz'])
 
 
 def test_fixed_trial_user_attrs():


### PR DESCRIPTION
This PR fixes #401.