### PR TITLE
Fix the error that occurs when using a study that contains old trials.

### DIFF
--- a/optuna/storages/rdb/storage.py
+++ b/optuna/storages/rdb/storage.py
@@ -442,6 +442,8 @@ class RDBStorage(BaseStorage):
             # This happens if the trial was created before v0.9.0,
             # where a trial didn't have `_number` attribute.
             # In this case, `check_trial_is_updatable` is skipped to avoid the `RuntimeError`.
+            #
+            # TODO(ohta): Remove this workaround when `number` field is added to `TrialModel`.
             pass
         else:
             self.check_trial_is_updatable(trial_id, trial.state)

--- a/optuna/storages/rdb/storage.py
+++ b/optuna/storages/rdb/storage.py
@@ -437,7 +437,13 @@ class RDBStorage(BaseStorage):
         session = self.scoped_session()
 
         trial = models.TrialModel.find_or_raise_by_id(trial_id, session)
-        self.check_trial_is_updatable(trial_id, trial.state)
+        if key == '_number':
+            # If this trial was created before v0.9.0, it doesn't have `_number` attribute.
+            # We want to set the attribute regardless the trial state,
+            # so we skip the invocation of `check_trial_is_updatable()` method in this case.
+            pass
+        else:
+            self.check_trial_is_updatable(trial_id, trial.state)
 
         attribute = models.TrialSystemAttributeModel.find_by_trial_and_key(trial, key, session)
         if attribute is None:

--- a/optuna/storages/rdb/storage.py
+++ b/optuna/storages/rdb/storage.py
@@ -438,9 +438,10 @@ class RDBStorage(BaseStorage):
 
         trial = models.TrialModel.find_or_raise_by_id(trial_id, session)
         if key == '_number':
-            # If this trial was created before v0.9.0, it doesn't have `_number` attribute.
-            # We want to set the attribute regardless the trial state,
-            # so we skip the invocation of `check_trial_is_updatable()` method in this case.
+            # `_number` attribute may be set even after a trial is finished.
+            # This happens if the trial was created before v0.9.0,
+            # where a trial didn't have `_number` attribute.
+            # In this case, `check_trial_is_updatable` is skipped to avoid the `RuntimeError`.
             pass
         else:
             self.check_trial_is_updatable(trial_id, trial.state)


### PR DESCRIPTION
This PR fixes the problem that the up-to-date optuna cannot handle studies that contain the trials created before v0.9.0.

## How to reproduce this problem and confirm that this PR fixes it

```console
//
// (1) Install Optuna before v0.9.0
//
$ pip install optuna==0.8.0

//
// (2) Create a study and executes it
//
$ optuna create-study --study foo --storage sqlite:///example.db
[I 2019-06-03 17:16:18,417] A new study created with name: foo

$ optuna study optimize examples/quadratic_simple.py objective --n-trials=1 --study foo --storage sqlite:///example.db
[I 2019-06-03 17:17:14,429] Finished a trial resulted in value: 2926.8920645504154. Current best value is 2926.8920645504154 with parameters: {'y': -1, 'x': 54.10999967243038}.

//
// (3) Upgrade Optuna to the latest version
//
$ pip install optuna==0.11.0

//
// (4) Continue optimization from the existing study
//      => Failed!
$ optuna study optimize examples/quadratic_simple.py objective --n-trials=1 --study foo --storage sqlite:///example.db 2>&1 | head
[W 2019-06-03 17:20:06,661] Setting status of trial#1 as TrialState.FAIL because of the following error: RecursionError('maximum recursion depth exceeded while calling a Python object',)
Traceback (most recent call last):
  File "/home/ohta/.local/lib/python3.5/site-packages/optuna/study.py", line 399, in _run_trial
    result = func(trial)
  File "examples/quadratic_simple.py", line 25, in objective
    x = trial.suggest_uniform('x', -100, 100)
  File "/home/ohta/.local/lib/python3.5/site-packages/optuna/trial.py", line 165, in suggest_uniform
    return self._suggest(name, distribution)
  File "/home/ohta/.local/lib/python3.5/site-packages/optuna/trial.py", line 436, in _suggest
    distribution)

//
// (5) Re-install the patched version of Optuna
//
$ pip install -U git+http://github.com/pfnet/optuna.git@support-old-trials

//
// (6) Continue optimization from the existing study
//      => Succeeded!
$ optuna study optimize examples/quadratic_simple.py objective --n-trials=1 --study foo --storage sqlite:///example.db
[I 2019-06-03 17:23:44,630] Finished trial#2 resulted in value: 1.476264522273886. Current best value is 1.476264522273886 with parameters: {'y': 1, 'x': -0.6901192087414216}.
```