### PR TITLE
Fix `PercentilePruner` example code.

### DIFF
--- a/optuna/pruners/percentile.py
+++ b/optuna/pruners/percentile.py
@@ -24,7 +24,7 @@ class PercentilePruner(BasePruner):
             >>> def objective(trial):
             >>>     ...
             >>>
-            >>> study = create_study(pruner=PercentilePruner())
+            >>> study = create_study(pruner=PercentilePruner(25.0))
             >>> study.optimize(objective)
 
     Args:


### PR DESCRIPTION
The current example code doesn't work because the mandatory argument of `PercentilePruner()` is missing. This PR adds the argument.