### PR TITLE
[WIP] Add trial queue.

### DIFF
--- a/optuna/storages/base.py
+++ b/optuna/storages/base.py
@@ -106,7 +106,7 @@ class BaseStorage(object):
 
     @abc.abstractmethod
     def set_trial_state(self, trial_id, state):
-        # type: (int, structs.TrialState) -> None
+        # type: (int, structs.TrialState) -> bool
 
         raise NotImplementedError
 

--- a/optuna/storages/in_memory.py
+++ b/optuna/storages/in_memory.py
@@ -170,15 +170,21 @@ class InMemoryStorage(base.BaseStorage):
             datetime_complete=None)
 
     def set_trial_state(self, trial_id, state):
-        # type: (int, structs.TrialState) -> None
+        # type: (int, structs.TrialState) -> bool
 
         with self._lock:
             self.check_trial_is_updatable(trial_id, self.trials[trial_id].state)
+
+            old_state = self.trials[trial_id].state
+            if state == structs.TrialState.RUNNING and old_state != structs.TrialState.WAITING:
+                return False
 
             self.trials[trial_id] = self.trials[trial_id]._replace(state=state)
             if state.is_finished():
                 self.trials[trial_id] = \
                     self.trials[trial_id]._replace(datetime_complete=datetime.now())
+
+        return True
 
     def set_trial_param(self, trial_id, param_name, param_value_internal, distribution):
         # type: (int, str, float, distributions.BaseDistribution) -> bool

--- a/optuna/structs.py
+++ b/optuna/structs.py
@@ -26,11 +26,12 @@ class TrialState(enum.Enum):
     COMPLETE = 1
     PRUNED = 2
     FAIL = 3
+    WAITING = 4
 
     def is_finished(self):
         # type: () -> bool
 
-        return self != TrialState.RUNNING
+        return self != TrialState.RUNNING and self != TrialState.WAITING
 
 
 class StudyDirection(enum.Enum):

--- a/optuna/study.py
+++ b/optuna/study.py
@@ -378,7 +378,8 @@ class Study(BaseStudy):
         user_attrs = user_attrs or {}
         system_attrs = copy.deepcopy(system_attrs or {})
         system_attrs['_manual_params'] = params
-        self.inject_trial(state=structs.TrialState.WAITING, user_attrs=user_attrs, system_attrs=system_attrs)
+        self.inject_trial(state=structs.TrialState.WAITING,
+                          user_attrs=user_attrs, system_attrs=system_attrs)
 
     def inject_trial(
             self,

--- a/optuna/study.py
+++ b/optuna/study.py
@@ -371,8 +371,13 @@ class Study(BaseStudy):
 
         return pd.DataFrame(records, columns=pd.MultiIndex.from_tuples(columns))
 
-    def enqueue_trial(self, params=None, user_attrs=None, system_attrs=None):
-        # type: (Optional[Dict[str, Any]], Optional[Dict[str, Any]], Optional[Dict[str, Any]]) -> None
+    def enqueue_trial(
+            self,
+            params=None,  # type: Optional[Dict[str, Any]]
+            user_attrs=None,  # type: Optional[Dict[str, Any]]
+            system_attrs=None  # type: Optional[Dict[str, Any]]
+    ):
+        # type: (...) -> None
 
         params = params or {}
         user_attrs = user_attrs or {}

--- a/optuna/trial.py
+++ b/optuna/trial.py
@@ -446,7 +446,9 @@ class Trial(BaseTrial):
     def _suggest(self, name, distribution):
         # type: (str, BaseDistribution) -> Any
 
-        if self._is_relative_param(name, distribution):
+        if self._is_manual_param(name, distribution):
+            param_value = self.system_attrs['_manual_params'][name]
+        elif self._is_relative_param(name, distribution):
             param_value = self.relative_params[name]
         else:
             study = optuna.study.InTrialStudy(self.study)
@@ -467,6 +469,21 @@ class Trial(BaseTrial):
             param_value = distribution.to_external_repr(param_value_in_internal_repr)
 
         return param_value
+
+    def _is_manual_param(self, name, distribution):
+        # type: (str, BaseDistribution) -> bool
+
+        if '_manual_params' not in self.system_attrs:
+            return False
+
+        if name not in self.system_attrs['_manual_params']:
+            return False
+
+        param_value = self.system_attrs['_manual_params'][name]
+        param_value_in_internal_repr = distribution.to_internal_repr(param_value)
+
+        # TODO(ohta): Warn if the following line returns `False`.
+        return distribution._contains(param_value_in_internal_repr)
 
     def _is_relative_param(self, name, distribution):
         # type: (str, BaseDistribution) -> bool


### PR DESCRIPTION
This PR adds `Study.enqueue_trial` method.

```python
import optuna

def objective(trial):
    x = trial.suggest_uniform('x', -100, 100)
    y = trial.suggest_categorical('y', [-1, 0, 1])
    return x**2 + y


if __name__ == '__main__':
    study = optuna.create_study()

    study.enqueue_trial({'x': -99})
    study.enqueue_trial({'x': 99})
    study.enqueue_trial({'x': 0})

    study.optimize(objective, n_trials=10)
    print('Best value: {} (params: {})\n'.format(study.best_value, study.best_params))
```

## TODO

- [ ] Add tests
- [ ] Add migration script (alembic)
- [ ] Change base branch to `master` after #464 is merged