### PR TITLE
Replace `connect_args` in `RDBStorage` constructor with `engine_kwargs` argument.

### DIFF
--- a/optuna/storages/rdb/storage.py
+++ b/optuna/storages/rdb/storage.py
@@ -41,7 +41,9 @@ class RDBStorage(BaseStorage):
 
     Args:
         url: URL of the storage.
-        connect_args: Arguments that is passed to :func:`sqlalchemy.engine.create_engine`.
+        engine_kwargs:
+           A dictionary of keyword arguments that is passed to
+           :func:`sqlalchemy.engine.create_engine`.
         enable_cache:
             Flag to control whether to enable storage layer caching.
             If this flag is set to :obj:`True` (the default), the finished trials are
@@ -50,15 +52,15 @@ class RDBStorage(BaseStorage):
 
     """
 
-    def __init__(self, url, connect_args=None, enable_cache=True, skip_compatibility_check=False):
+    def __init__(self, url, engine_kwargs=None, enable_cache=True, skip_compatibility_check=False):
         # type: (str, Optional[Dict[str, Any]], bool, bool) -> None
 
-        connect_args = connect_args or {}
+        engine_kwargs = engine_kwargs or {}
 
         url = self._fill_storage_url_template(url)
 
         try:
-            self.engine = create_engine(url, connect_args=connect_args)
+            self.engine = create_engine(url, **engine_kwargs)
         except ImportError as e:
             raise ImportError('Failed to import DB access module for the specified storage URL. '
                               'Please install appropriate one. (The actual import error is: ' +

--- a/optuna/storages/rdb/storage.py
+++ b/optuna/storages/rdb/storage.py
@@ -42,8 +42,8 @@ class RDBStorage(BaseStorage):
     Args:
         url: URL of the storage.
         engine_kwargs:
-           A dictionary of keyword arguments that is passed to
-           :func:`sqlalchemy.engine.create_engine`.
+            A dictionary of keyword arguments that is passed to
+            :func:`sqlalchemy.engine.create_engine`.
         enable_cache:
             Flag to control whether to enable storage layer caching.
             If this flag is set to :obj:`True` (the default), the finished trials are

--- a/optuna/testing/storage.py
+++ b/optuna/testing/storage.py
@@ -34,7 +34,7 @@ class StorageSupplier(object):
             url = 'sqlite:///{}'.format(self.tempfile.name)
             return optuna.storages.RDBStorage(
                 url,
-                connect_args={'timeout': SQLITE3_TIMEOUT},
+                engine_kwargs={'connect_args': {'timeout': SQLITE3_TIMEOUT}},
                 enable_cache=self.enable_cache,
             )
         elif self.storage_specifier == 'common':
@@ -42,7 +42,7 @@ class StorageSupplier(object):
             url = 'sqlite:///{}'.format(self._common_tempfile.name)
             return optuna.storages.RDBStorage(
                 url,
-                connect_args={'timeout': SQLITE3_TIMEOUT},
+                engine_kwargs={'connect_args': {'timeout': SQLITE3_TIMEOUT}},
                 enable_cache=self.enable_cache,
             )
         else:

--- a/tests/storages_tests/rdb_tests/test_storage.py
+++ b/tests/storages_tests/rdb_tests/test_storage.py
@@ -3,7 +3,6 @@ import pytest
 import sys
 import tempfile
 
-from optuna.distributions import BaseDistribution  # NOQA
 from optuna.distributions import CategoricalDistribution
 from optuna.distributions import json_to_distribution
 from optuna.distributions import UniformDistribution
@@ -14,7 +13,6 @@ from optuna.storages.rdb.models import TrialParamModel
 from optuna.storages.rdb.models import VersionInfoModel
 from optuna.storages import RDBStorage
 from optuna.structs import DuplicatedStudyError
-from optuna.structs import FrozenTrial  # NOQA
 from optuna.structs import StorageInternalError
 from optuna.structs import StudyDirection
 from optuna.structs import StudySummary
@@ -23,8 +21,13 @@ from optuna import types
 from optuna import version
 
 if types.TYPE_CHECKING:
+    from typing import Any  # NOQA
     from typing import Dict  # NOQA
     from typing import List  # NOQA
+    from typing import Optional  # NOQA
+
+    from optuna.distributions import BaseDistribution  # NOQA
+    from optuna.structs import FrozenTrial  # NOQA
 
 
 def test_init():
@@ -239,7 +242,9 @@ def test_check_table_schema_compatibility():
 def create_test_storage(enable_cache=True, engine_kwargs=None):
     # type: (bool, Optional[Dict[str, Any]]) -> RDBStorage
 
-    storage = RDBStorage('sqlite:///:memory:', enable_cache=enable_cache, engine_kwargs=engine_kwargs)
+    storage = RDBStorage('sqlite:///:memory:',
+                         enable_cache=enable_cache,
+                         engine_kwargs=engine_kwargs)
     return storage
 
 

--- a/tests/storages_tests/rdb_tests/test_storage.py
+++ b/tests/storages_tests/rdb_tests/test_storage.py
@@ -75,6 +75,15 @@ def test_init_db_module_import_error():
             RDBStorage('postgresql://user:password@host/database')
 
 
+def test_engine_kwargs():
+    # type: () -> None
+
+    create_test_storage(engine_kwargs={'pool_size': 5})
+
+    with pytest.raises(TypeError):
+        create_test_storage(engine_kwargs={'wrong_key': 'wrong_value'})
+
+
 def test_create_new_study_id_multiple_studies():
     # type: () -> None
 
@@ -227,10 +236,10 @@ def test_check_table_schema_compatibility():
     #     storage._check_table_schema_compatibility()
 
 
-def create_test_storage(enable_cache=True):
-    # type: (bool) -> RDBStorage
+def create_test_storage(enable_cache=True, engine_kwargs=None):
+    # type: (bool, Optional[Dict[str, Any]]) -> RDBStorage
 
-    storage = RDBStorage('sqlite:///:memory:', enable_cache=enable_cache)
+    storage = RDBStorage('sqlite:///:memory:', enable_cache=enable_cache, engine_kwargs=engine_kwargs)
     return storage
 
 


### PR DESCRIPTION
This PR replaces `connect_args` argument in `RDBStorage` constructor with more general `engine_kwargs` argument.