### PR TITLE
Fix broken test.

### DIFF
--- a/tests/test_trial.py
+++ b/tests/test_trial.py
@@ -217,6 +217,8 @@ def test_trial_should_prune():
     study_mock.pruner.prune.return_value = True
 
     trial = Trial(study_mock, trial_id)  # type: ignore
+    study_mock.reset_mock()
+
     trial.should_prune()
 
     study_mock.storage.get_trial.assert_called_once_with(trial_id)


### PR DESCRIPTION
After merging #380 and #398, CI became to fail as follows:

```
=================================== FAILURES ===================================
___________________________ test_trial_should_prune ____________________________

    def test_trial_should_prune():
        # type: () -> None
    
        study_id = 1
        trial_id = 1
    
        study_mock = MagicMock()
        study_mock.study_id = study_id
        study_mock.storage.get_trial.return_value.\
            intermediate_values.keys.return_value = [1, 2, 3, 4, 5]
        study_mock.pruner.prune.return_value = True
    
        trial = Trial(study_mock, trial_id)  # type: ignore
        trial.should_prune()
    
>       study_mock.storage.get_trial.assert_called_once_with(trial_id)

tests/test_trial.py:222: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

_mock_self = <MagicMock name='mock.storage.get_trial' id='140341288196192'>
args = (1,), kwargs = {}
self = <MagicMock name='mock.storage.get_trial' id='140341288196192'>
msg = "Expected 'get_trial' to be called once. Called 2 times.\nCalls: [call(1), call(1), call().intermediate_values.keys()]."

    def assert_called_once_with(_mock_self, *args, **kwargs):
        """assert that the mock was called exactly once and that that call was
        with the specified arguments."""
        self = _mock_self
        if not self.call_count == 1:
            msg = ("Expected '%s' to be called once. Called %s times.%s"
                   % (self._mock_name or 'mock',
                      self.call_count,
                      self._calls_repr()))
>           raise AssertionError(msg)
E           AssertionError: Expected 'get_trial' to be called once. Called 2 times.
E           Calls: [call(1), call(1), call().intermediate_values.keys()].

venv/lib/python3.7/site-packages/mock/mock.py:956: AssertionError
```
See https://circleci.com/gh/pfnet/optuna/13734 for the full log messages.

This PR fixes this problem.