### PR TITLE
Add `BaseDistribution.single` methods.

### DIFF
--- a/optuna/distributions.py
+++ b/optuna/distributions.py
@@ -98,7 +98,7 @@ class UniformDistribution(
     def empty(self):
         # type: () -> bool
 
-        return self.low >= self.high
+        return self.low > self.high
 
     def _contains(self, param_value_in_internal_repr):
         # type: (float) -> bool
@@ -125,7 +125,7 @@ class LogUniformDistribution(
     def empty(self):
         # type: () -> bool
 
-        return self.low >= self.high
+        return self.low > self.high
 
     def _contains(self, param_value_in_internal_repr):
         # type: (float) -> bool
@@ -154,7 +154,7 @@ class DiscreteUniformDistribution(
     def empty(self):
         # type: () -> bool
 
-        return self.low >= self.high
+        return self.low > self.high
 
     def _contains(self, param_value_in_internal_repr):
         # type: (float) -> bool
@@ -188,7 +188,7 @@ class IntUniformDistribution(
     def empty(self):
         # type: () -> bool
 
-        return self.low >= self.high
+        return self.low > self.high
 
     def _contains(self, param_value_in_internal_repr):
         # type: (float) -> bool

--- a/optuna/distributions.py
+++ b/optuna/distributions.py
@@ -49,6 +49,18 @@ class BaseDistribution(object):
         return param_value_in_external_repr
 
     @abc.abstractmethod
+    def empty(self):
+        # type: () -> bool
+        """Test whether this distribution represents an empty range.
+
+        Returns:
+            :obj:`True` if this distribution represents an empty range,
+            otherwise :obj:`False`.
+        """
+
+        raise NotImplementedError
+
+    @abc.abstractmethod
     def _contains(self, param_value_in_internal_repr):
         # type: (float) -> bool
         """Test if a parameter value is contained in the range of this distribution.
@@ -83,6 +95,11 @@ class UniformDistribution(
             Upper endpoint of the range of the distribution. ``high`` is excluded from the range.
     """
 
+    def empty(self):
+        # type: () -> bool
+
+        return self.low >= self.high
+
     def _contains(self, param_value_in_internal_repr):
         # type: (float) -> bool
 
@@ -104,6 +121,11 @@ class LogUniformDistribution(
         high:
             Upper endpoint of the range of the distribution. ``high`` is excluded from the range.
     """
+
+    def empty(self):
+        # type: () -> bool
+
+        return self.low >= self.high
 
     def _contains(self, param_value_in_internal_repr):
         # type: (float) -> bool
@@ -128,6 +150,11 @@ class DiscreteUniformDistribution(
         q:
             A discretization step.
     """
+
+    def empty(self):
+        # type: () -> bool
+
+        return self.low >= self.high
 
     def _contains(self, param_value_in_internal_repr):
         # type: (float) -> bool
@@ -158,6 +185,11 @@ class IntUniformDistribution(
 
         return float(param_value_in_external_repr)
 
+    def empty(self):
+        # type: () -> bool
+
+        return self.low >= self.high
+
     def _contains(self, param_value_in_internal_repr):
         # type: (float) -> bool
 
@@ -184,6 +216,11 @@ class CategoricalDistribution(
         # type: (Union[float, str]) -> float
 
         return self.choices.index(param_value_in_external_repr)
+
+    def empty(self):
+        # type: () -> bool
+
+        return len(self.choices) == 0
 
     def _contains(self, param_value_in_internal_repr):
         # type: (float) -> bool

--- a/optuna/distributions.py
+++ b/optuna/distributions.py
@@ -49,21 +49,6 @@ class BaseDistribution(object):
         return param_value_in_external_repr
 
     @abc.abstractmethod
-    def empty(self):
-        # type: () -> bool
-        """Test whether the range of this distribution is empty.
-
-        When this method returns :obj:`True`, :mod:`~optuna.samplers` cannot sample any value
-        from the distribution and raise an error when sampling.
-
-        Returns:
-            :obj:`True` if this distribution represents an empty range,
-            otherwise :obj:`False`.
-        """
-
-        raise NotImplementedError
-
-    @abc.abstractmethod
     def single(self):
         # type: () -> bool
         """Test whether the range of this distribution contains just a single value.
@@ -113,11 +98,6 @@ class UniformDistribution(
             Upper endpoint of the range of the distribution. ``high`` is excluded from the range.
     """
 
-    def empty(self):
-        # type: () -> bool
-
-        return self.low > self.high
-
     def single(self):
         # type: () -> bool
 
@@ -144,11 +124,6 @@ class LogUniformDistribution(
         high:
             Upper endpoint of the range of the distribution. ``high`` is excluded from the range.
     """
-
-    def empty(self):
-        # type: () -> bool
-
-        return self.low > self.high
 
     def single(self):
         # type: () -> bool
@@ -178,11 +153,6 @@ class DiscreteUniformDistribution(
         q:
             A discretization step.
     """
-
-    def empty(self):
-        # type: () -> bool
-
-        return self.low > self.high
 
     def single(self):
         # type: () -> bool
@@ -218,11 +188,6 @@ class IntUniformDistribution(
 
         return float(param_value_in_external_repr)
 
-    def empty(self):
-        # type: () -> bool
-
-        return self.low > self.high
-
     def single(self):
         # type: () -> bool
 
@@ -254,11 +219,6 @@ class CategoricalDistribution(
         # type: (Union[float, str]) -> float
 
         return self.choices.index(param_value_in_external_repr)
-
-    def empty(self):
-        # type: () -> bool
-
-        return len(self.choices) == 0
 
     def single(self):
         # type: () -> bool

--- a/optuna/distributions.py
+++ b/optuna/distributions.py
@@ -53,7 +53,7 @@ class BaseDistribution(object):
         # type: () -> bool
         """Test whether the range of this distribution is empty.
 
-        When this method returns :obj:`True`, samplers cannot sample any value
+        When this method returns :obj:`True`, :mod:`~optuna.samplers` cannot sample any value
         from the distribution and will raise an error when sampling.
 
         Returns:
@@ -68,7 +68,7 @@ class BaseDistribution(object):
         # type: () -> bool
         """Test whether the range of this distribution contains just a single value.
 
-        When this method returns :obj:`True`, samplers will always sample
+        When this method returns :obj:`True`, :mod:`~optuna.samplers` will always sample
         the same value from the distribution.
 
         Returns:

--- a/optuna/distributions.py
+++ b/optuna/distributions.py
@@ -53,7 +53,7 @@ class BaseDistribution(object):
         # type: () -> bool
         """Test whether the range of this distribution is empty.
 
-        If this method returns :obj:`True`, it means that samplers cannot sample any value
+        When this method returns :obj:`True`, samplers cannot sample any value
         from the distribution and will raise an error when sampling.
 
         Returns:
@@ -68,7 +68,7 @@ class BaseDistribution(object):
         # type: () -> bool
         """Test whether the range of this distribution contains just a single value.
 
-        If this method returns :obj:`True`, it means that samplers will always sample
+        When this method returns :obj:`True`, samplers will always sample
         the same value from the distribution.
 
         Returns:

--- a/optuna/distributions.py
+++ b/optuna/distributions.py
@@ -53,6 +53,8 @@ class BaseDistribution(object):
         # type: () -> bool
         """Test whether this distribution represents an empty range.
 
+        If a distribution is empty, samplers given the distribution should raise an error.
+
         Returns:
             :obj:`True` if this distribution represents an empty range,
             otherwise :obj:`False`.

--- a/optuna/distributions.py
+++ b/optuna/distributions.py
@@ -61,6 +61,22 @@ class BaseDistribution(object):
         raise NotImplementedError
 
     @abc.abstractmethod
+    def single(self):
+        # type: () -> bool
+        """Test whether this distribution represents a singleton.
+
+        A singleton means a set that has only one element.
+        If a distribution represents a singleton, samplers given the distribution
+        always suggest the only value.
+
+        Returns:
+            :obj:`True` if this distribution represents a singleton,
+            otherwise :obj:`False`.
+        """
+
+        raise NotImplementedError
+
+    @abc.abstractmethod
     def _contains(self, param_value_in_internal_repr):
         # type: (float) -> bool
         """Test if a parameter value is contained in the range of this distribution.
@@ -100,6 +116,11 @@ class UniformDistribution(
 
         return self.low > self.high
 
+    def single(self):
+        # type: () -> bool
+
+        return self.low == self.high
+
     def _contains(self, param_value_in_internal_repr):
         # type: (float) -> bool
 
@@ -126,6 +147,11 @@ class LogUniformDistribution(
         # type: () -> bool
 
         return self.low > self.high
+
+    def single(self):
+        # type: () -> bool
+
+        return self.low == self.high
 
     def _contains(self, param_value_in_internal_repr):
         # type: (float) -> bool
@@ -155,6 +181,11 @@ class DiscreteUniformDistribution(
         # type: () -> bool
 
         return self.low > self.high
+
+    def single(self):
+        # type: () -> bool
+
+        return self.low == self.high
 
     def _contains(self, param_value_in_internal_repr):
         # type: (float) -> bool
@@ -190,6 +221,11 @@ class IntUniformDistribution(
 
         return self.low > self.high
 
+    def single(self):
+        # type: () -> bool
+
+        return self.low == self.high
+
     def _contains(self, param_value_in_internal_repr):
         # type: (float) -> bool
 
@@ -221,6 +257,11 @@ class CategoricalDistribution(
         # type: () -> bool
 
         return len(self.choices) == 0
+
+    def single(self):
+        # type: () -> bool
+
+        return len(self.choices) == 1
 
     def _contains(self, param_value_in_internal_repr):
         # type: (float) -> bool

--- a/optuna/distributions.py
+++ b/optuna/distributions.py
@@ -51,9 +51,10 @@ class BaseDistribution(object):
     @abc.abstractmethod
     def empty(self):
         # type: () -> bool
-        """Test whether this distribution represents an empty range.
+        """Test whether the range of this distribution is empty.
 
-        If a distribution is empty, samplers given the distribution should raise an error.
+        If this distribution is empty, samplers cannot sample any value from the distribution and
+        will raise an error when sampling.
 
         Returns:
             :obj:`True` if this distribution represents an empty range,
@@ -65,14 +66,13 @@ class BaseDistribution(object):
     @abc.abstractmethod
     def single(self):
         # type: () -> bool
-        """Test whether this distribution represents a singleton.
+        """Test whether the range of this distribution contains just a single element.
 
-        A singleton means a set that has only one element.
-        If a distribution represents a singleton, samplers given the distribution
-        always suggest the only value.
+        If the range contains just a single element,
+        samplers will always sample the value associated with the element from the distribution.
 
         Returns:
-            :obj:`True` if this distribution represents a singleton,
+            :obj:`True` if the range of this distribution contains just a single element,
             otherwise :obj:`False`.
         """
 

--- a/optuna/distributions.py
+++ b/optuna/distributions.py
@@ -54,7 +54,7 @@ class BaseDistribution(object):
         """Test whether the range of this distribution is empty.
 
         When this method returns :obj:`True`, :mod:`~optuna.samplers` cannot sample any value
-        from the distribution and will raise an error when sampling.
+        from the distribution and raise an error when sampling.
 
         Returns:
             :obj:`True` if this distribution represents an empty range,
@@ -68,7 +68,7 @@ class BaseDistribution(object):
         # type: () -> bool
         """Test whether the range of this distribution contains just a single value.
 
-        When this method returns :obj:`True`, :mod:`~optuna.samplers` will always sample
+        When this method returns :obj:`True`, :mod:`~optuna.samplers` always sample
         the same value from the distribution.
 
         Returns:

--- a/optuna/distributions.py
+++ b/optuna/distributions.py
@@ -53,8 +53,8 @@ class BaseDistribution(object):
         # type: () -> bool
         """Test whether the range of this distribution is empty.
 
-        If this distribution is empty, samplers cannot sample any value from the distribution and
-        will raise an error when sampling.
+        If this method returns :obj:`True`, it means that samplers cannot sample any value
+        from the distribution and will raise an error when sampling.
 
         Returns:
             :obj:`True` if this distribution represents an empty range,
@@ -66,13 +66,13 @@ class BaseDistribution(object):
     @abc.abstractmethod
     def single(self):
         # type: () -> bool
-        """Test whether the range of this distribution contains just a single element.
+        """Test whether the range of this distribution contains just a single value.
 
-        If the range contains just a single element,
-        samplers will always sample the value associated with the element from the distribution.
+        If this method returns :obj:`True`, it means that samplers will always sample
+        the same value from the distribution.
 
         Returns:
-            :obj:`True` if the range of this distribution contains just a single element,
+            :obj:`True` if the range of this distribution contains just a single value,
             otherwise :obj:`False`.
         """
 

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -7,6 +7,7 @@ from optuna import types
 if types.TYPE_CHECKING:
     from typing import Any  # NOQA
     from typing import Dict  # NOQA
+    from typing import List  # NOQA
 
 EXAMPLE_DISTRIBUTIONS = {
     'u': distributions.UniformDistribution(low=1., high=2.),
@@ -140,3 +141,31 @@ def test_empty_range_contains():
     assert not iu._contains(0)
     assert iu._contains(1)
     assert not iu._contains(2)
+
+
+def test_empty():
+    # type: () -> None
+
+    empty_distributions = [
+        distributions.UniformDistribution(low=1.0, high=1.0),
+        distributions.UniformDistribution(low=0.0, high=-100.0),
+        distributions.LogUniformDistribution(low=7.3, high=7.3),
+        distributions.LogUniformDistribution(low=7.3, high=7.2),
+        distributions.DiscreteUniformDistribution(low=2.22, high=2.22, q=0.1),
+        distributions.DiscreteUniformDistribution(low=-30, high=-40, q=3),
+        distributions.IntUniformDistribution(low=-123, high=-123),
+        distributions.IntUniformDistribution(low=123, high=100),
+        distributions.CategoricalDistribution(choices=())
+    ]  # type: List[distributions.BaseDistribution]
+    for distribution in empty_distributions:
+        assert distribution.empty()
+
+    nonempty_distributions = [
+        distributions.UniformDistribution(low=1.0, high=1.001),
+        distributions.LogUniformDistribution(low=7.3, high=10),
+        distributions.DiscreteUniformDistribution(low=-30, high=-20, q=2),
+        distributions.IntUniformDistribution(low=-123, high=0),
+        distributions.CategoricalDistribution(choices=('foo', ))
+    ]  # type: List[distributions.BaseDistribution]
+    for distribution in nonempty_distributions:
+        assert not distribution.empty()

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -143,34 +143,6 @@ def test_empty_range_contains():
     assert not iu._contains(2)
 
 
-def test_empty():
-    # type: () -> None
-
-    empty_distributions = [
-        distributions.UniformDistribution(low=0.0, high=-100.0),
-        distributions.LogUniformDistribution(low=7.3, high=7.2),
-        distributions.DiscreteUniformDistribution(low=-30, high=-40, q=3),
-        distributions.IntUniformDistribution(low=123, high=100),
-        distributions.CategoricalDistribution(choices=())
-    ]  # type: List[distributions.BaseDistribution]
-    for distribution in empty_distributions:
-        assert distribution.empty()
-
-    nonempty_distributions = [
-        distributions.UniformDistribution(low=1.0, high=1.0),
-        distributions.UniformDistribution(low=1.0, high=1.001),
-        distributions.LogUniformDistribution(low=7.3, high=7.3),
-        distributions.LogUniformDistribution(low=7.3, high=10),
-        distributions.DiscreteUniformDistribution(low=2.22, high=2.22, q=0.1),
-        distributions.DiscreteUniformDistribution(low=-30, high=-20, q=2),
-        distributions.IntUniformDistribution(low=-123, high=-123),
-        distributions.IntUniformDistribution(low=-123, high=0),
-        distributions.CategoricalDistribution(choices=('foo', ))
-    ]  # type: List[distributions.BaseDistribution]
-    for distribution in nonempty_distributions:
-        assert not distribution.empty()
-
-
 def test_single():
     # type: () -> None
 

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -169,3 +169,32 @@ def test_empty():
     ]  # type: List[distributions.BaseDistribution]
     for distribution in nonempty_distributions:
         assert not distribution.empty()
+
+
+def test_single():
+    # type: () -> None
+
+    single_distributions = [
+        distributions.UniformDistribution(low=1.0, high=1.0),
+        distributions.LogUniformDistribution(low=7.3, high=7.3),
+        distributions.DiscreteUniformDistribution(low=2.22, high=2.22, q=0.1),
+        distributions.IntUniformDistribution(low=-123, high=-123),
+        distributions.CategoricalDistribution(choices=('foo', ))
+    ]  # type: List[distributions.BaseDistribution]
+    for distribution in single_distributions:
+        assert distribution.single()
+
+    nonsingle_distributions = [
+        distributions.UniformDistribution(low=0.0, high=-100.0),
+        distributions.UniformDistribution(low=1.0, high=1.001),
+        distributions.LogUniformDistribution(low=7.3, high=7.2),
+        distributions.LogUniformDistribution(low=7.3, high=10),
+        distributions.DiscreteUniformDistribution(low=-30, high=-40, q=3),
+        distributions.DiscreteUniformDistribution(low=-30, high=-20, q=2),
+        distributions.IntUniformDistribution(low=123, high=100),
+        distributions.IntUniformDistribution(low=-123, high=0),
+        distributions.CategoricalDistribution(choices=()),
+        distributions.CategoricalDistribution(choices=('foo', 'bar'))
+    ]  # type: List[distributions.BaseDistribution]
+    for distribution in nonsingle_distributions:
+        assert not distribution.single()

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -147,13 +147,9 @@ def test_empty():
     # type: () -> None
 
     empty_distributions = [
-        distributions.UniformDistribution(low=1.0, high=1.0),
         distributions.UniformDistribution(low=0.0, high=-100.0),
-        distributions.LogUniformDistribution(low=7.3, high=7.3),
         distributions.LogUniformDistribution(low=7.3, high=7.2),
-        distributions.DiscreteUniformDistribution(low=2.22, high=2.22, q=0.1),
         distributions.DiscreteUniformDistribution(low=-30, high=-40, q=3),
-        distributions.IntUniformDistribution(low=-123, high=-123),
         distributions.IntUniformDistribution(low=123, high=100),
         distributions.CategoricalDistribution(choices=())
     ]  # type: List[distributions.BaseDistribution]
@@ -161,9 +157,13 @@ def test_empty():
         assert distribution.empty()
 
     nonempty_distributions = [
+        distributions.UniformDistribution(low=1.0, high=1.0),
         distributions.UniformDistribution(low=1.0, high=1.001),
+        distributions.LogUniformDistribution(low=7.3, high=7.3),
         distributions.LogUniformDistribution(low=7.3, high=10),
+        distributions.DiscreteUniformDistribution(low=2.22, high=2.22, q=0.1),
         distributions.DiscreteUniformDistribution(low=-30, high=-20, q=2),
+        distributions.IntUniformDistribution(low=-123, high=-123),
         distributions.IntUniformDistribution(low=-123, high=0),
         distributions.CategoricalDistribution(choices=('foo', ))
     ]  # type: List[distributions.BaseDistribution]


### PR DESCRIPTION
This PR adds `BaseDistribution.single` method.
This method is useful when implementing custom samplers.
After this PR is merged, I will use the method in [#399/skopt.py#L90](https://github.com/pfnet/optuna/pull/399/files#diff-665e262286e69f900727d7370b255753R90).