### PR TITLE
Support TensorFlow 1.14.0.

### DIFF
--- a/optuna/integration/tensorflow.py
+++ b/optuna/integration/tensorflow.py
@@ -8,6 +8,7 @@ if optuna.types.TYPE_CHECKING:
 try:
     import tensorflow as tf
     from tensorflow.train import SessionRunHook
+    from tensorflow_estimator.python.estimator.early_stopping import read_eval_metrics
     _available = True
 except ImportError as e:
     _import_error = e
@@ -87,7 +88,7 @@ class TensorFlowPruningHook(SessionRunHook):
         # Get eval metrics every n steps.
         if self.timer.should_trigger_for_step(global_step):
             self.timer.update_last_triggered_step(global_step)
-            eval_metrics = tf.contrib.estimator.read_eval_metrics(self.estimator.eval_dir())
+            eval_metrics = read_eval_metrics(self.estimator.eval_dir())
         else:
             eval_metrics = None
         if eval_metrics:

--- a/setup.py
+++ b/setup.py
@@ -52,12 +52,7 @@ def get_extras_require():
         'checking': ['autopep8', 'hacking'],
         'testing': [
             'pytest', 'mock', 'bokeh', 'plotly', 'chainer>=5.0.0', 'xgboost', 'mpi4py', 'lightgbm',
-            'keras', 'mxnet',
-
-            # TODO(ohta):
-            # Remove version constraint after https://github.com/pfnet/optuna/pull/432
-            # has been merged.
-            'tensorflow<1.14.0'
+            'keras', 'mxnet', 'tensorflow'
         ],
         'document': ['sphinx', 'sphinx_rtd_theme'],
         'codecov': ['pytest-cov', 'codecov'],

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -26,7 +26,7 @@ def test_default_handler(capsys):
     # The following line is added to avoid interference with the TensorFlow's logger.
     # See also: https://github.com/pfnet/optuna/pull/432
     #
-    # TODO(ohta): Remove this line if `optuna.logging` becomes to be able to handle this problem.
+    # TODO(ohta): Remove this line if `optuna.logging` becomes able to handle this problem.
     library_root_logger.propagate = False
 
     example_logger = optuna.logging.get_logger('optuna.bar')

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -19,20 +19,23 @@ def test_default_handler(capsys):
 
     # We need to reconstruct our default handler to properly capture stderr.
     optuna.logging._reset_library_root_logger()
+    optuna.logging.set_verbosity(optuna.logging.INFO)
+
     library_root_logger = optuna.logging._get_library_root_logger()
+    library_root_logger.propagate = False
     example_logger = optuna.logging.get_logger('optuna.bar')
 
     # Default handler enabled
     optuna.logging.enable_default_handler()
     assert library_root_logger.handlers
-    example_logger.warning('hey')
+    example_logger.info('hey')
     _, err = capsys.readouterr()
     assert 'hey' in err
 
     # Default handler disabled
     optuna.logging.disable_default_handler()
     assert not library_root_logger.handlers
-    example_logger.warning('yoyo')
+    example_logger.info('yoyo')
     _, err = capsys.readouterr()
     assert 'yoyo' not in err
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -22,7 +22,13 @@ def test_default_handler(capsys):
     optuna.logging.set_verbosity(optuna.logging.INFO)
 
     library_root_logger = optuna.logging._get_library_root_logger()
+
+    # The following line is added to avoid interference with the TensorFlow's logger.
+    # See also: https://github.com/pfnet/optuna/pull/432
+    #
+    # TODO(ohta): Remove this line if `optuna.logging` becomes to be able to handle this problem.
     library_root_logger.propagate = False
+
     example_logger = optuna.logging.get_logger('optuna.bar')
 
     # Default handler enabled


### PR DESCRIPTION
This PR fixes CI failure due to [tensorflow-v1.14.0] release.

Since [tensorflow-v1.14.0] has dropped `tensorflow.contrib.estimator.read_eval_metrics` function, we use `tensorflow_estimator.python.estimator.early_stopping.read_eval_metrics` instead of it (both are identical except for the path).

[tensorflow-v1.14.0]: https://github.com/tensorflow/tensorflow/tree/v1.14.0