### PR TITLE
Specify version constraints of `tensorflow` and `typing`.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,8 +31,14 @@ def get_install_requires():
     # type: () -> List[str]
 
     install_requires = [
-        'sqlalchemy>=1.1.0', 'numpy', 'scipy', 'six', 'typing<3.7.0', 'typing-extensions<3.7.0',
-        'cliff', 'colorlog', 'pandas', 'alembic'
+        'sqlalchemy>=1.1.0', 'numpy', 'scipy', 'six',
+        'cliff', 'colorlog', 'pandas', 'alembic',
+
+        # TODO(ohta):
+        # Remove version constraints after `chainer` has supported the latest versions of
+        # `typing` and `typing-extensions` on Python2.7.
+        # (see also: https://github.com/pfnet/optuna/pull/434)
+        'typing<3.7.0', 'typing-extensions<3.7.0'
     ]
     if sys.version_info[0] == 2:
         install_requires.extend(['enum34'])
@@ -46,7 +52,12 @@ def get_extras_require():
         'checking': ['autopep8', 'hacking'],
         'testing': [
             'pytest', 'mock', 'bokeh', 'plotly', 'chainer>=5.0.0', 'xgboost', 'mpi4py', 'lightgbm',
-            'keras', 'tensorflow<1.14.0', 'mxnet'
+            'keras', 'mxnet',
+
+            # TODO(ohta):
+            # Remove version constraint after https://github.com/pfnet/optuna/pull/432
+            # has been merged.
+            'tensorflow<1.14.0'
         ],
         'document': ['sphinx', 'sphinx_rtd_theme'],
         'codecov': ['pytest-cov', 'codecov'],

--- a/setup.py
+++ b/setup.py
@@ -31,8 +31,8 @@ def get_install_requires():
     # type: () -> List[str]
 
     install_requires = [
-        'sqlalchemy>=1.1.0', 'numpy', 'scipy', 'six', 'typing', 'cliff', 'colorlog', 'pandas',
-        'alembic'
+        'sqlalchemy>=1.1.0', 'numpy', 'scipy', 'six', 'typing<3.7.0', 'typing-extensions<3.7.0',
+        'cliff', 'colorlog', 'pandas', 'alembic'
     ]
     if sys.version_info[0] == 2:
         install_requires.extend(['enum34'])
@@ -46,7 +46,7 @@ def get_extras_require():
         'checking': ['autopep8', 'hacking'],
         'testing': [
             'pytest', 'mock', 'bokeh', 'plotly', 'chainer>=5.0.0', 'xgboost', 'mpi4py', 'lightgbm',
-            'keras', 'tensorflow', 'mxnet'
+            'keras', 'tensorflow<1.14.0', 'mxnet'
         ],
         'document': ['sphinx', 'sphinx_rtd_theme'],
         'codecov': ['pytest-cov', 'codecov'],


### PR DESCRIPTION
Because CI fails when using the latest `tensorflow`(v1.14.0) and `typing`(v3.7.4), this PR adds version constraints to setup.py to avoid installing the latest packages.
Once we solved the CI problem, we will remove the constraints.