### PR TITLE
Minor refactoring of TensorFlow eager execution example.

### DIFF
--- a/examples/tensorflow_eager_simple.py
+++ b/examples/tensorflow_eager_simple.py
@@ -38,11 +38,12 @@ def model_fn(trial):
     model.add(tf.keras.layers.Flatten())
     for i in range(n_layers):
         num_hidden = int(trial.suggest_loguniform('n_units_l{}'.format(i), 4, 128))
-        model.add(tf.keras.layers.Dense(num_hidden,
-                                        activation='relu',
-                                        kernel_regularizer=tf.keras.regularizers.l2(weight_decay)))
-    model.add(tf.keras.layers.Dense(CLASSES,
-                                    kernel_regularizer=tf.keras.regularizers.l2(weight_decay)))
+        model.add(
+            tf.keras.layers.Dense(num_hidden,
+                                  activation='relu',
+                                  kernel_regularizer=tf.keras.regularizers.l2(weight_decay)))
+    model.add(
+        tf.keras.layers.Dense(CLASSES, kernel_regularizer=tf.keras.regularizers.l2(weight_decay)))
     return model
 
 
@@ -88,8 +89,8 @@ def learn(model, optimizer, dataset, mode='eval'):
 def get_mnist():
     # Load the data, split between train and test sets.
     (x_train, y_train), (x_test, y_test) = mnist.load_data()
-    x_train = x_train.astype('float32')/255
-    x_test = x_test.astype('float32')/255
+    x_train = x_train.astype('float32') / 255
+    x_test = x_test.astype('float32') / 255
 
     y_train = y_train.astype('int32')
     y_test = y_test.astype('int32')
@@ -126,7 +127,6 @@ def objective(trial):
 
 if __name__ == '__main__':
     import optuna
-    optuna.logging.set_verbosity(optuna.logging.INFO)
 
     study = optuna.create_study(direction='maximize')
     study.optimize(objective, n_trials=100)

--- a/examples/tensorflow_eager_simple.py
+++ b/examples/tensorflow_eager_simple.py
@@ -33,7 +33,7 @@ tf.enable_eager_execution()
 def create_model(trial):
     # We optimize the numbers of layers, their units and weight decay parameter.
     n_layers = trial.suggest_int('n_layers', 1, 3)
-    weight_decay = trial.suggest_uniform('weight_decay', 1e-10, 1e-3)
+    weight_decay = trial.suggest_loguniform('weight_decay', 1e-10, 1e-3)
     model = tf.keras.Sequential()
     model.add(tf.keras.layers.Flatten())
     for i in range(n_layers):
@@ -53,14 +53,14 @@ def create_optimizer(trial):
     optimizer_options = ['RMSPropOptimizer', 'AdamOptimizer', 'MomentumOptimizer']
     optimizer_selected = trial.suggest_categorical('optimizer', optimizer_options)
     if optimizer_selected == 'RMSPropOptimizer':
-        kwargs['learning_rate'] = trial.suggest_uniform('rmsprop_learning_rate', 1e-5, 1e-1)
+        kwargs['learning_rate'] = trial.suggest_loguniform('rmsprop_learning_rate', 1e-5, 1e-1)
         kwargs['decay'] = trial.suggest_uniform('rmsprop_decay', 0.85, 0.99)
-        kwargs['momentum'] = trial.suggest_uniform('rmsprop_momentum', 1e-5, 1e-1)
+        kwargs['momentum'] = trial.suggest_loguniform('rmsprop_momentum', 1e-5, 1e-1)
     elif optimizer_selected == 'AdamOptimizer':
-        kwargs['learning_rate'] = trial.suggest_uniform('adam_learning_rate', 1e-5, 1e-1)
+        kwargs['learning_rate'] = trial.suggest_loguniform('adam_learning_rate', 1e-5, 1e-1)
     elif optimizer_selected == 'MomentumOptimizer':
-        kwargs['learning_rate'] = trial.suggest_uniform('momentum_opt_learning_rate', 1e-5, 1e-1)
-        kwargs['momentum'] = trial.suggest_uniform('momentum_opt_momentum', 1e-5, 1e-1)
+        kwargs['learning_rate'] = trial.suggest_loguniform('momentum_opt_learning_rate', 1e-5, 1e-1)
+        kwargs['momentum'] = trial.suggest_loguniform('momentum_opt_momentum', 1e-5, 1e-1)
 
     optimizer = getattr(tf.train, optimizer_selected)(**kwargs)
     return optimizer

--- a/examples/tensorflow_eager_simple.py
+++ b/examples/tensorflow_eager_simple.py
@@ -59,7 +59,8 @@ def create_optimizer(trial):
     elif optimizer_selected == 'AdamOptimizer':
         kwargs['learning_rate'] = trial.suggest_loguniform('adam_learning_rate', 1e-5, 1e-1)
     elif optimizer_selected == 'MomentumOptimizer':
-        kwargs['learning_rate'] = trial.suggest_loguniform('momentum_opt_learning_rate', 1e-5, 1e-1)
+        kwargs['learning_rate'] = trial.suggest_loguniform('momentum_opt_learning_rate', 1e-5,
+                                                           1e-1)
         kwargs['momentum'] = trial.suggest_loguniform('momentum_opt_momentum', 1e-5, 1e-1)
 
     optimizer = getattr(tf.train, optimizer_selected)(**kwargs)

--- a/examples/tensorflow_eager_simple.py
+++ b/examples/tensorflow_eager_simple.py
@@ -67,7 +67,6 @@ def optimizer_fn(trial):
 
 
 def learn(model, optimizer, dataset, mode='eval'):
-    """Trains model on `dataset` using `optimizer`."""
     accuracy = tfe.metrics.Accuracy('accuracy', dtype=tf.float32)
 
     for batch, (images, labels) in enumerate(dataset):
@@ -99,12 +98,13 @@ def get_mnist():
     train_ds = tf.data.Dataset.from_tensor_slices((x_train, y_train))
     train_ds = train_ds.shuffle(60000).batch(BATCHSIZE).take(N_TRAIN_EXAMPLES)
 
-    # Create the dataset and its associated one-shot iterator.
     test_ds = tf.data.Dataset.from_tensor_slices((x_test, y_test))
     test_ds = test_ds.shuffle(10000).batch(BATCHSIZE).take(N_TEST_EXAMPLES)
     return train_ds, test_ds
 
 
+# FYI: Objective functions can take additional arguments
+# (https://optuna.readthedocs.io/en/stable/faq.html#objective-func-additional-args).
 def objective(trial):
     # Get MNIST data.
     train_ds, test_ds = get_mnist()
@@ -113,13 +113,12 @@ def objective(trial):
     model = model_fn(trial)
     optimizer = optimizer_fn(trial)
 
-    # Training and Validatin cycle.
+    # Training and Validating cycle.
     with tf.device("/cpu:0"):
         for _ in range(EPOCHS):
-            # Train the network.
             learn(model, optimizer, train_ds, 'train')
-            # Perform the validation.
-            accuracy = learn(model, optimizer, test_ds, 'eval')
+
+        accuracy = learn(model, optimizer, test_ds, 'eval')
 
     # Return last validation accuracy.
     return accuracy.result()

--- a/examples/tensorflow_eager_simple.py
+++ b/examples/tensorflow_eager_simple.py
@@ -26,7 +26,7 @@ N_TRAIN_EXAMPLES = 3000
 N_TEST_EXAMPLES = 1000
 BATCHSIZE = 128
 CLASSES = 10
-EPOCHS = 10
+EPOCHS = 1
 tf.enable_eager_execution()
 
 


### PR DESCRIPTION
This is a followup PR to #369:
- Reduces the execution time of each trial from 30 seconds to 3 seconds
- Applies `yapf` 
- Removes unused constants and variables
- Adjusts comments