### PR TITLE
Make `TPESampler` pruning aware.

### DIFF
--- a/optuna/samplers/tpe/sampler.py
+++ b/optuna/samplers/tpe/sampler.py
@@ -451,7 +451,7 @@ def _get_observation_pairs(study, param_name):
     """Get observation pairs from the study.
 
        This function collects observation pairs from the trials of the study.
-       The trials that doesn't contain the parameter named ``param_name`` are excluded
+       The trials that don't contain the parameter named ``param_name`` are excluded
        from the result.
 
        An observation pair consists of ``(param_value, (step, value))`` where ``param_value`` is

--- a/optuna/samplers/tpe/sampler.py
+++ b/optuna/samplers/tpe/sampler.py
@@ -454,9 +454,12 @@ def _get_observation_pairs(study, param_name):
        The trials that don't contain the parameter named ``param_name`` are excluded
        from the result.
 
-       An observation pair consists of ``(param_value, (-step, value))`` where ``param_value`` is
-       the value of the parameter ``param_name``, ``step`` is the last step that the trial
-       reached and ``value`` is the reported value at the step.
+       An observation pair fundamentally consists of a parameter value and an objective value.
+       However, due to the pruning mechanism of Optuna, final objective values are not always
+       available. Therefore, this function uses intermediate values in addition to the final
+       ones, and reports the value with its step count as ``(-step, value)``.
+       Consequently, the structure of the observation pair is as follows:
+       ``(param_value, (-step, value))``.
 
        The second element of an observation pair is used to rank observations in
        ``_split_observation_pairs`` method (i.e., observations are sorted lexicographically by

--- a/optuna/samplers/tpe/sampler.py
+++ b/optuna/samplers/tpe/sampler.py
@@ -448,6 +448,20 @@ class TPESampler(base.BaseSampler):
 
 def _get_observation_pairs(study, param_name):
     # type: (InTrialStudy, str) -> List[Tuple[float, Tuple[float, float]]]
+    """Get observation pairs from the study.
+
+       This function collects observation pairs from the trials of the study.
+       The trials that doesn't contain the parameter named ``param_name`` are excluded
+       from the result.
+
+       An observation pair consists of ``(param_value, (step, value))`` where ``param_value`` is
+       the value of the parameter ``param_name``, ``step`` is the last step that the trial
+       reached and ``value`` is the reported value at the step.
+
+       The second element of an observation pair is used to rank observations in
+       ``_split_observation_pairs`` method (i.e., observations are sorted lexicographically by
+       ``(step, value)``).
+    """
 
     sign = 1
     if study.direction == StudyDirection.MAXIMIZE:

--- a/optuna/samplers/tpe/sampler.py
+++ b/optuna/samplers/tpe/sampler.py
@@ -450,17 +450,17 @@ def _get_observation_pairs(study, param_name):
     # type: (InTrialStudy, str) -> List[Tuple[float, Tuple[float, float]]]
     """Get observation pairs from the study.
 
-       This function collects observation pairs from the trials of the study.
+       This function collects observation pairs from the complete or pruned trials of the study.
        The trials that don't contain the parameter named ``param_name`` are excluded
        from the result.
 
-       An observation pair consists of ``(param_value, (step, value))`` where ``param_value`` is
+       An observation pair consists of ``(param_value, (-step, value))`` where ``param_value`` is
        the value of the parameter ``param_name``, ``step`` is the last step that the trial
        reached and ``value`` is the reported value at the step.
 
        The second element of an observation pair is used to rank observations in
        ``_split_observation_pairs`` method (i.e., observations are sorted lexicographically by
-       ``(step, value)``).
+       ``(-step, value)``).
     """
 
     sign = 1

--- a/optuna/storages/base.py
+++ b/optuna/storages/base.py
@@ -11,7 +11,6 @@ if types.TYPE_CHECKING:
     from typing import Dict  # NOQA
     from typing import List  # NOQA
     from typing import Optional  # NOQA
-    from typing import Tuple  # NOQA
 
 DEFAULT_STUDY_NAME_PREFIX = 'no-name-'
 

--- a/optuna/storages/base.py
+++ b/optuna/storages/base.py
@@ -200,20 +200,6 @@ class BaseStorage(object):
 
         return self.get_trial(trial_id).system_attrs
 
-    # Methods for the TPE sampler
-
-    def get_trial_param_result_pairs(self, study_id, param_name):
-        # type: (int, str) -> List[Tuple[float, float]]
-
-        # Be careful: this method returns param values in internal representation
-        all_trials = self.get_all_trials(study_id)
-
-        return [(t.params_in_internal_repr[param_name], t.value) for t in all_trials
-                if (t.value is not None and param_name in t.params
-                    and t.state is structs.TrialState.COMPLETE)
-                # TODO(Akiba): We also want to use pruned results
-                ]
-
     # Methods for PercentilePruner and MedianPruner
 
     def get_best_intermediate_result_over_steps(self, trial_id):

--- a/tests/samplers_tests/tpe_tests/test_sampler.py
+++ b/tests/samplers_tests/tpe_tests/test_sampler.py
@@ -3,6 +3,9 @@ from optuna.samplers import tpe
 from optuna.structs import TrialPruned
 from optuna.study import InTrialStudy
 
+if optuna.typing.TYPE_CHECKING:
+    from optuna.trial import Trial  # NOQA
+
 
 def test_get_observation_pairs():
     # type: () -> None

--- a/tests/samplers_tests/tpe_tests/test_sampler.py
+++ b/tests/samplers_tests/tpe_tests/test_sampler.py
@@ -3,7 +3,7 @@ from optuna.samplers import tpe
 from optuna.structs import TrialPruned
 from optuna.study import InTrialStudy
 
-if optuna.typing.TYPE_CHECKING:
+if optuna.types.TYPE_CHECKING:
     from optuna.trial import Trial  # NOQA
 
 

--- a/tests/samplers_tests/tpe_tests/test_sampler.py
+++ b/tests/samplers_tests/tpe_tests/test_sampler.py
@@ -1,7 +1,3 @@
-import itertools
-import numpy as np
-import pytest
-
 import optuna
 from optuna.samplers import tpe
 from optuna.structs import TrialPruned

--- a/tests/samplers_tests/tpe_tests/test_sampler.py
+++ b/tests/samplers_tests/tpe_tests/test_sampler.py
@@ -1,0 +1,55 @@
+import itertools
+import numpy as np
+import pytest
+
+import optuna
+from optuna.samplers import tpe
+from optuna.structs import TrialPruned
+from optuna.study import InTrialStudy
+
+
+def test_get_observation_pairs():
+    # type: () -> None
+
+    def objective(trial):
+        # type: (Trial) -> float
+
+        x = trial.suggest_int('x', 5, 5)
+        if trial.number == 0:
+            return x
+        elif trial.number == 1:
+            trial.report(1, 4)
+            trial.report(2, 7)
+            raise TrialPruned()
+        elif trial.number == 2:
+            raise TrialPruned()
+        else:
+            raise RuntimeError()
+
+    # direction=minimize.
+    study = optuna.create_study(direction='minimize')
+    study.optimize(objective, n_trials=4)
+    study.storage.create_new_trial_id(study.study_id)  # Create a running trial.
+
+    in_trial_study = InTrialStudy(study)
+
+    assert tpe.sampler._get_observation_pairs(in_trial_study, 'x') == [
+        (5.0, (-float('inf'), 5.0)),  # COMPLETE
+        (5.0, (-7, 2)),  # PRUNED (with intermediate values)
+        (5.0, (float('inf'), 0.0))  # PRUNED (without intermediate values)
+    ]
+    assert tpe.sampler._get_observation_pairs(in_trial_study, 'y') == []
+
+    # direction=maximize.
+    study = optuna.create_study(direction='maximize')
+    study.optimize(objective, n_trials=4)
+    study.storage.create_new_trial_id(study.study_id)  # Create a running trial.
+
+    in_trial_study = InTrialStudy(study)
+
+    assert tpe.sampler._get_observation_pairs(in_trial_study, 'x') == [
+        (5.0, (-float('inf'), -5.0)),  # COMPLETE
+        (5.0, (-7, -2)),  # PRUNED (with intermediate values)
+        (5.0, (float('inf'), 0.0))  # PRUNED (without intermediate values)
+    ]
+    assert tpe.sampler._get_observation_pairs(in_trial_study, 'y') == []


### PR DESCRIPTION
This PR makes `TPESampler` pruning aware.
More specifically, this PR changes `TPESampler` to account for the pruned steps and intermediate values of pruned trials in addition to complete ones.

The following benchmark results show that this modification can dramatically improve optimization performance when `TPESampler` is used with pruning.

## (1) Benchmark Results

Please refer to [Tabular Benchmarks for Joint Architecture and Hyperparameter Optimization](https://arxiv.org/abs/1905.04970) for the datasets and search space used by this benchmarking.

### (1-1) Pruning Benchmark

<img alt="result0" src="https://user-images.githubusercontent.com/181413/60312841-e30e7e00-9997-11e9-8004-acc4c6651658.png" width="48%"> <img alt="result1" src="https://user-images.githubusercontent.com/181413/60312992-5ca66c00-9998-11e9-91a2-43690304fa9e.png" width="48%">

<img alt="result2" src="https://user-images.githubusercontent.com/181413/60313165-04bc3500-9999-11e9-861f-17b830bf7d34.png" width="48%" ><img alt="result3" src="https://user-images.githubusercontent.com/181413/60313272-6aa8bc80-9999-11e9-8823-1d119c2dfe61.png" width="48%" >

#### Ranking

`$ cat *.json | grep -v noprune | kurobako stats ranking`

| Sampler                                       | Borda | Firsts |
|:---------------------------------------------|------:|-------:|
| (a) optuna#master:minimize:asha              |     4 |      0 |
| (b) optuna#master:minimize:median            |     0 |      0 |
| (c) optuna#pruning-aware-tpe:minimize:asha   |     9 |      4 |
| (d) optuna#pruning-aware-tpe:minimize:median |     8 |      3 |

### (1-2) No Pruning Benchmark

#### Ranking

<img alt="noprune-0" src="https://user-images.githubusercontent.com/181413/60313911-beb4a080-999b-11e9-8f5a-3fb4a63ed8be.png" width="48%" ><img alt="noprune-1" src="https://user-images.githubusercontent.com/181413/60313943-d68c2480-999b-11e9-929e-48f46d29e62d.png" width="48%" >

<img alt="noprune-2" src="https://user-images.githubusercontent.com/181413/60313999-0509ff80-999c-11e9-9766-d7816e649b83.png" width="48%" /> <img alt="noprune-3" src="https://user-images.githubusercontent.com/181413/60314303-228b9900-999d-11e9-9be7-eb337b1102ce.png" width="48%" >

`$ cat *.json | grep noprune | kurobako stats ranking`

| Samplers                                       | Borda | Firsts |
|:----------------------------------------------|------:|-------:|
| (a) optuna#master:maximize:noprune            |     0 |      4 |
| (b) optuna#master:minimize:noprune            |     0 |      3 |
| (c) optuna#pruning-aware-tpe:maximize:noprune |     1 |      4 |
| (d) optuna#pruning-aware-tpe:minimize:noprune |     0 |      4 |

In no pruning cases, there are no statistically significant performance degradations by this modification.

## (2) Benchmark Commands

```console
// Install packages
$ cargo install kurobako
$ kurobako --version
kurobako 0.0.14

$ pip install git+http://github.com/sile/kurobako-py.git
$ pip install git+http://github.com/pfnet/optuna.git@pruning-aware-tpe2

// Download datasets
$ wget http://ml4aad.org/wp-content/uploads/2019/01/fcnet_tabular_benchmarks.tar.gz
$ tar xf fcnet_tabular_benchmarks.tar.gz

// Run benchmarks
$ kurobako benchmark --problems $(kurobako problem-suite fc-net fcnet_tabular_benchmarks) --solvers $(kurobako solver --tag pruning-aware-tpe:minimize:asha optuna --pruner asha --asha-min-resource 3 --asha-reduction-factor 3) --budget 50 --iterations 40 --evaluation-points 3 9 27 81 100 | kurobako run > pruning-aware-tpe-minimize-asha.json
$ kurobako benchmark --problems $(kurobako problem-suite fc-net fcnet_tabular_benchmarks) --solvers $(kurobako solver --tag master:minimize:median optuna) --budget 50 --iterations 40 --evaluation-points 10 20 30 40 50 60 70 80 90 100 | kurobako run > master-minimize-median.json
$ kurobako benchmark --problems $(kurobako problem-suite fc-net fcnet_tabular_benchmarks) --solvers $(kurobako solver --tag pruning-aware-tpe:maximize:noprune optuna --maximize) --budget 50 --iterations 40 --evaluation-points 100 | kurobako run > pruning-aware-tpe-maximize-noprune.json
$ kurobako benchmark --problems $(kurobako problem-suite fc-net fcnet_tabular_benchmarks) --solvers $(kurobako solver --tag pruning-aware-tpe:maximize:noprune optuna) --budget 50 --iterations 40 --evaluation-points 100 | kurobako run > pruning-aware-tpe-minimize-noprune.json

// Plot results
$ cat *.json | grep -v noprune | kurobako select --problems fcnet_slice_localization_data | kurobako plot -o /tmp/plot-result/ --ymin 0.0 --ymax 0.002
$ cat *.json | grep -v noprune | kurobako select --problems fcnet_protein_structure_data | kurobako plot -o /tmp/plot-result/ --ymin 0.2 --ymax 0.4
$ cat *.json | grep -v noprune | kurobako select --problems fcnet_parkinsons_telemonitoring_data | kurobako plot -o /tmp/plot-result/ --ymin 0 --ymax 0.05
$ cat *.json | grep -v noprune | kurobako select --problems fcnet_naval_propulsion_data | kurobako plot -o /tmp/plot-result/ --ymin 0 --ymax 0.002
```