### PR TITLE
Add reference for distributions.

### DIFF
--- a/docs/source/reference/distributions.rst
+++ b/docs/source/reference/distributions.rst
@@ -1,0 +1,40 @@
+.. module:: optuna.distributions
+
+Distributions
+=============
+
+.. autoclass:: BaseDistribution
+    :members:
+    :inherited-members:
+    :exclude-members: count, index, high, low
+
+.. autoclass:: UniformDistribution
+    :members:
+    :inherited-members:
+    :exclude-members: count, index, high, low
+
+.. autoclass:: LogUniformDistribution
+    :members:
+    :inherited-members:
+    :exclude-members: count, index, high, low
+
+.. autoclass:: DiscreteUniformDistribution
+    :members:
+    :inherited-members:
+    :exclude-members: count, index, high, low, q
+
+.. autoclass:: IntUniformDistribution
+    :members:
+    :inherited-members:
+    :exclude-members: count, index, high, low
+
+.. autoclass:: CategoricalDistribution
+    :members:
+    :inherited-members:
+    :exclude-members: count, index, choices
+
+.. autofunction:: distribution_to_json
+
+.. autofunction:: json_to_distribution
+
+.. autofunction:: check_distribution_compatibility

--- a/docs/source/reference/distributions.rst
+++ b/docs/source/reference/distributions.rst
@@ -3,35 +3,22 @@
 Distributions
 =============
 
-.. autoclass:: BaseDistribution
-    :members:
-    :inherited-members:
-    :exclude-members: count, index, high, low
-
 .. autoclass:: UniformDistribution
     :members:
-    :inherited-members:
-    :exclude-members: count, index, high, low
 
 .. autoclass:: LogUniformDistribution
     :members:
-    :inherited-members:
-    :exclude-members: count, index, high, low
 
 .. autoclass:: DiscreteUniformDistribution
     :members:
-    :inherited-members:
-    :exclude-members: count, index, high, low, q
 
 .. autoclass:: IntUniformDistribution
     :members:
-    :inherited-members:
-    :exclude-members: count, index, high, low
+    :exclude-members: to_external_repr, to_internal_repr
 
 .. autoclass:: CategoricalDistribution
     :members:
-    :inherited-members:
-    :exclude-members: count, index, choices
+    :exclude-members: to_external_repr, to_internal_repr
 
 .. autofunction:: distribution_to_json
 

--- a/docs/source/reference/index.rst
+++ b/docs/source/reference/index.rst
@@ -6,6 +6,7 @@ API Reference
 .. toctree::
     :maxdepth: 2
 
+    distributions
     integration
     logging
     pruners

--- a/optuna/distributions.py
+++ b/optuna/distributions.py
@@ -38,6 +38,8 @@ class BaseDistribution(object):
         # type: (Any) -> float
         """Convert external representation of a parameter value into internal representation.
 
+        Note that :mod:`~optuna.samplers` handle parameter values in the internal representation.
+
         Args:
             param_value_in_external_repr:
                 Optuna's external representation of a parameter value.
@@ -91,6 +93,10 @@ class UniformDistribution(
         BaseDistribution):
     """A uniform distribution in the linear domain.
 
+    This object is instantiated by :func:`~optuna.trial.Trial.suggest_uniform`, and passed to
+    :mod:`~optuna.samplers` in the process of :func:`~optuna.study.Study.optimize`.
+    The internal representation of this object is identical to the external representation.
+
     Attributes:
         low:
             Lower endpoint of the range of the distribution. ``low`` is included in the range.
@@ -117,6 +123,10 @@ class LogUniformDistribution(
         NamedTuple('_BaseLogUniformDistribution', [('low', float), ('high', float)]),
         BaseDistribution):
     """A uniform distribution in the log domain.
+
+    This object is instantiated by :func:`~optuna.trial.Trial.suggest_loguniform`, and passed to
+    :mod:`~optuna.samplers` in the process of :func:`~optuna.study.Study.optimize`.
+    The internal representation of this object is identical to the external representation.
 
     Attributes:
         low:
@@ -145,6 +155,10 @@ class DiscreteUniformDistribution(
                                                         ('q', float)]), BaseDistribution):
     """A discretized uniform distribution in the linear domain.
 
+    This object is instantiated by :func:`~optuna.trial.Trial.suggest_discrete_uniform`, and
+    passed to :mod:`~optuna.samplers` in the process of :func:`~optuna.study.Study.optimize`.
+    The internal representation of this object is identical to the external representation.
+
     Attributes:
         low:
             Lower endpoint of the range of the distribution. ``low`` is included in the range.
@@ -170,6 +184,10 @@ class IntUniformDistribution(
         NamedTuple('_BaseIntUniformDistribution', [('low', int), ('high', int)]),
         BaseDistribution):
     """A uniform distribution on integers.
+
+    This object is instantiated by :func:`~optuna.trial.Trial.suggest_int`, and passed to
+    :mod:`~optuna.samplers` in the process of :func:`~optuna.study.Study.optimize`.
+    Parameter values are cast to integer when they are converted to internal representation.
 
     Attributes:
         low:
@@ -204,6 +222,11 @@ class CategoricalDistribution(
         NamedTuple('_BaseCategoricalDistribution', [('choices', Tuple[Union[float, str], ...])]),
         BaseDistribution):
     """A categorical distribution.
+
+    This object is instantiated by :func:`~optuna.trial.Trial.suggest_categorical`, and passed to
+    :mod:`~optuna.samplers` in the process of :func:`~optuna.study.Study.optimize`.
+    The index number of `choices` tuple is used as the internal representation for the
+    corresponding parameter value.
 
     Attributes:
         choices:

--- a/optuna/distributions.py
+++ b/optuna/distributions.py
@@ -92,7 +92,7 @@ class UniformDistribution(
     """A uniform distribution in the linear domain.
 
     This object is instantiated by :func:`~optuna.trial.Trial.suggest_uniform`, and passed to
-    :mod:`~optuna.samplers` in the process of :func:`~optuna.study.Study.optimize`.
+    :mod:`~optuna.samplers` in general.
 
     Attributes:
         low:
@@ -122,7 +122,7 @@ class LogUniformDistribution(
     """A uniform distribution in the log domain.
 
     This object is instantiated by :func:`~optuna.trial.Trial.suggest_loguniform`, and passed to
-    :mod:`~optuna.samplers` in the process of :func:`~optuna.study.Study.optimize`.
+    :mod:`~optuna.samplers` in general.
 
     Attributes:
         low:
@@ -151,8 +151,8 @@ class DiscreteUniformDistribution(
                                                         ('q', float)]), BaseDistribution):
     """A discretized uniform distribution in the linear domain.
 
-    This object is instantiated by :func:`~optuna.trial.Trial.suggest_discrete_uniform`, and
-    passed to :mod:`~optuna.samplers` in the process of :func:`~optuna.study.Study.optimize`.
+    This object is instantiated by :func:`~optuna.trial.Trial.suggest_discrete_uniform`, and passed
+    to :mod:`~optuna.samplers` in general.
 
     Attributes:
         low:
@@ -181,7 +181,7 @@ class IntUniformDistribution(
     """A uniform distribution on integers.
 
     This object is instantiated by :func:`~optuna.trial.Trial.suggest_int`, and passed to
-    :mod:`~optuna.samplers` in the process of :func:`~optuna.study.Study.optimize`.
+    :mod:`~optuna.samplers` in general.
 
     Attributes:
         low:
@@ -217,8 +217,8 @@ class CategoricalDistribution(
         BaseDistribution):
     """A categorical distribution.
 
-    This object is instantiated by :func:`~optuna.trial.Trial.suggest_categorical`, and passed to
-    :mod:`~optuna.samplers` in the process of :func:`~optuna.study.Study.optimize`.
+    This object is instantiated by :func:`~optuna.trial.Trial.suggest_categorical`, and
+    passed to :mod:`~optuna.samplers` in general.
 
     Attributes:
         choices:

--- a/optuna/distributions.py
+++ b/optuna/distributions.py
@@ -38,8 +38,6 @@ class BaseDistribution(object):
         # type: (Any) -> float
         """Convert external representation of a parameter value into internal representation.
 
-        Note that :mod:`~optuna.samplers` handle parameter values in the internal representation.
-
         Args:
             param_value_in_external_repr:
                 Optuna's external representation of a parameter value.
@@ -95,7 +93,6 @@ class UniformDistribution(
 
     This object is instantiated by :func:`~optuna.trial.Trial.suggest_uniform`, and passed to
     :mod:`~optuna.samplers` in the process of :func:`~optuna.study.Study.optimize`.
-    The internal representation of this object is identical to the external representation.
 
     Attributes:
         low:
@@ -126,7 +123,6 @@ class LogUniformDistribution(
 
     This object is instantiated by :func:`~optuna.trial.Trial.suggest_loguniform`, and passed to
     :mod:`~optuna.samplers` in the process of :func:`~optuna.study.Study.optimize`.
-    The internal representation of this object is identical to the external representation.
 
     Attributes:
         low:
@@ -157,7 +153,6 @@ class DiscreteUniformDistribution(
 
     This object is instantiated by :func:`~optuna.trial.Trial.suggest_discrete_uniform`, and
     passed to :mod:`~optuna.samplers` in the process of :func:`~optuna.study.Study.optimize`.
-    The internal representation of this object is identical to the external representation.
 
     Attributes:
         low:
@@ -187,7 +182,6 @@ class IntUniformDistribution(
 
     This object is instantiated by :func:`~optuna.trial.Trial.suggest_int`, and passed to
     :mod:`~optuna.samplers` in the process of :func:`~optuna.study.Study.optimize`.
-    Parameter values are cast to integer when they are converted to internal representation.
 
     Attributes:
         low:
@@ -225,8 +219,6 @@ class CategoricalDistribution(
 
     This object is instantiated by :func:`~optuna.trial.Trial.suggest_categorical`, and passed to
     :mod:`~optuna.samplers` in the process of :func:`~optuna.study.Study.optimize`.
-    The index number of `choices` tuple is used as the internal representation for the
-    corresponding parameter value.
 
     Attributes:
         choices:


### PR DESCRIPTION
This PR adds documentation for distributions.  Currently, `optuna.samplers` users the distributions as their input and output, but the documentation is not opened to users/developers.
This PR provides information about distributions mainly for developers of `optuna.samplers`. 