### PR TITLE
Make `sample_independent` and `sample_relative` methods return external representations of parameters.

### DIFF
--- a/optuna/integration/skopt.py
+++ b/optuna/integration/skopt.py
@@ -113,7 +113,7 @@ class SkoptSampler(BaseSampler):
         return search_space
 
     def sample_relative(self, study, trial, search_space):
-        # type: (InTrialStudy, FrozenTrial, Dict[str, BaseDistribution]) -> Dict[str, float]
+        # type: (InTrialStudy, FrozenTrial, Dict[str, BaseDistribution]) -> Dict[str, Any]
 
         if len(search_space) == 0:
             return {}
@@ -123,7 +123,7 @@ class SkoptSampler(BaseSampler):
         return optimizer.ask()
 
     def sample_independent(self, study, trial, param_name, param_distribution):
-        # type: (InTrialStudy, FrozenTrial, str, BaseDistribution) -> float
+        # type: (InTrialStudy, FrozenTrial, str, BaseDistribution) -> Any
 
         if self._warn_independent_sampling:
             complete_trials = [t for t in study.trials if t.state == structs.TrialState.COMPLETE]
@@ -196,7 +196,7 @@ class _Optimizer(object):
         self._optimizer.tell(xs, ys)
 
     def ask(self):
-        # type: () -> Dict[str, float]
+        # type: () -> Dict[str, Any]
 
         params = {}
         param_values = self._optimizer.ask()
@@ -204,7 +204,7 @@ class _Optimizer(object):
             if isinstance(distribution, distributions.DiscreteUniformDistribution):
                 value = value * distribution.q + distribution.low
 
-            params[name] = distribution.to_internal_repr(value)
+            params[name] = value
 
         return params
 

--- a/optuna/samplers/base.py
+++ b/optuna/samplers/base.py
@@ -4,6 +4,7 @@ import six
 from optuna import types
 
 if types.TYPE_CHECKING:
+    from typing import Any  # NOQA
     from typing import Dict  # NOQA
 
     from optuna.distributions import BaseDistribution  # NOQA
@@ -38,7 +39,7 @@ class BaseSampler(object):
 
     @abc.abstractmethod
     def sample_relative(self, study, trial, search_space):
-        # type: (InTrialStudy, FrozenTrial, Dict[str, BaseDistribution]) -> Dict[str, float]
+        # type: (InTrialStudy, FrozenTrial, Dict[str, BaseDistribution]) -> Dict[str, Any]
         """Sample parameters based on the previous trials and the given search space.
 
         This method is called once just after each trial has started.
@@ -57,8 +58,7 @@ class BaseSampler(object):
                 :func:`optuna.samplers.BaseSampler.infer_relative_search_space`.
 
         Returns:
-            A dictionary containing the parameter names and the values that are the
-            internal representations of Optuna.
+            A dictionary containing the parameter names and the values.
 
         """
 
@@ -66,7 +66,7 @@ class BaseSampler(object):
 
     @abc.abstractmethod
     def sample_independent(self, study, trial, param_name, param_distribution):
-        # type: (InTrialStudy, FrozenTrial, str, BaseDistribution) -> float
+        # type: (InTrialStudy, FrozenTrial, str, BaseDistribution) -> Any
         """Sample a parameter based on the previous trials and the given distribution.
 
         The method is only called for the parameters that have not been contained in the dictionary
@@ -83,7 +83,7 @@ class BaseSampler(object):
                 Distribution object that specifies a prior and/or scale of the sampling algorithm.
 
         Returns:
-            A float value in the internal representation of Optuna.
+            A parameter value.
 
         """
 

--- a/optuna/samplers/random.py
+++ b/optuna/samplers/random.py
@@ -69,6 +69,6 @@ class RandomSampler(BaseSampler):
             return self.rng.randint(param_distribution.low, param_distribution.high + 1)
         elif isinstance(param_distribution, distributions.CategoricalDistribution):
             choices = param_distribution.choices
-            return choices[self.rng.randint(len(choices))]
+            return self.rng.choice(choices)
         else:
             raise NotImplementedError

--- a/optuna/samplers/random.py
+++ b/optuna/samplers/random.py
@@ -5,6 +5,7 @@ from optuna.samplers.base import BaseSampler
 from optuna import types
 
 if types.TYPE_CHECKING:
+    from typing import Any  # NOQA
     from typing import Dict  # NOQA
     from typing import Optional  # NOQA
 
@@ -39,12 +40,12 @@ class RandomSampler(BaseSampler):
         return {}
 
     def sample_relative(self, study, trial, search_space):
-        # type: (InTrialStudy, FrozenTrial, Dict[str, BaseDistribution]) -> Dict[str, float]
+        # type: (InTrialStudy, FrozenTrial, Dict[str, BaseDistribution]) -> Dict[str, Any]
 
         return {}
 
     def sample_independent(self, study, trial, param_name, param_distribution):
-        # type: (InTrialStudy, FrozenTrial, str, distributions.BaseDistribution) -> float
+        # type: (InTrialStudy, FrozenTrial, str, distributions.BaseDistribution) -> Any
         """Please consult the documentation for :func:`BaseSampler.sample_independent`."""
 
         if isinstance(param_distribution, distributions.UniformDistribution):
@@ -68,6 +69,6 @@ class RandomSampler(BaseSampler):
             return self.rng.randint(param_distribution.low, param_distribution.high + 1)
         elif isinstance(param_distribution, distributions.CategoricalDistribution):
             choices = param_distribution.choices
-            return self.rng.randint(len(choices))
+            return choices[self.rng.randint(len(choices))]
         else:
             raise NotImplementedError

--- a/optuna/testing/sampler.py
+++ b/optuna/testing/sampler.py
@@ -2,6 +2,7 @@ import optuna
 from optuna import distributions
 
 if optuna.types.TYPE_CHECKING:
+    from typing import Any  # NOQA
     from typing import Dict  # NOQA
     from typing import Union  # NOQA
 
@@ -12,7 +13,7 @@ if optuna.types.TYPE_CHECKING:
 
 class DeterministicRelativeSampler(optuna.samplers.BaseSampler):
     def __init__(self, relative_search_space, relative_params):
-        # type: (Dict[str, BaseDistribution], Dict[str, float]) -> None
+        # type: (Dict[str, BaseDistribution], Dict[str, Any]) -> None
 
         self.relative_search_space = relative_search_space
         self.relative_params = relative_params
@@ -23,12 +24,12 @@ class DeterministicRelativeSampler(optuna.samplers.BaseSampler):
         return self.relative_search_space
 
     def sample_relative(self, study, trial, search_space):
-        # type: (InTrialStudy, FrozenTrial, Dict[str, BaseDistribution]) -> Dict[str, float]
+        # type: (InTrialStudy, FrozenTrial, Dict[str, BaseDistribution]) -> Dict[str, Any]
 
         return self.relative_params
 
     def sample_independent(self, study, trial, param_name, param_distribution):
-        # type: (InTrialStudy, FrozenTrial, str, BaseDistribution) -> float
+        # type: (InTrialStudy, FrozenTrial, str, BaseDistribution) -> Any
 
         if isinstance(param_distribution, distributions.UniformDistribution):
             param_value = param_distribution.low  # type: Union[float, str]
@@ -43,4 +44,4 @@ class DeterministicRelativeSampler(optuna.samplers.BaseSampler):
         else:
             raise NotImplementedError
 
-        return param_distribution.to_internal_repr(param_value)
+        return param_value

--- a/optuna/trial.py
+++ b/optuna/trial.py
@@ -183,9 +183,7 @@ class Trial(BaseTrial):
 
         distribution = distributions.UniformDistribution(low=low, high=high)
         if low == high:
-            param_value_in_internal_repr = distribution.to_internal_repr(low)
-            return self._set_new_param_or_get_existing(name, param_value_in_internal_repr,
-                                                       distribution)
+            return self._set_new_param_or_get_existing(name, low, distribution)
 
         return self._suggest(name, distribution)
 
@@ -225,9 +223,7 @@ class Trial(BaseTrial):
 
         distribution = distributions.LogUniformDistribution(low=low, high=high)
         if low == high:
-            param_value_in_internal_repr = distribution.to_internal_repr(low)
-            return self._set_new_param_or_get_existing(name, param_value_in_internal_repr,
-                                                       distribution)
+            return self._set_new_param_or_get_existing(name, low, distribution)
 
         return self._suggest(name, distribution)
 
@@ -274,9 +270,7 @@ class Trial(BaseTrial):
         high = _adjust_discrete_uniform_high(name, low, high, q)
         distribution = distributions.DiscreteUniformDistribution(low=low, high=high, q=q)
         if low == high:
-            param_value_in_internal_repr = distribution.to_internal_repr(low)
-            return self._set_new_param_or_get_existing(name, param_value_in_internal_repr,
-                                                       distribution)
+            return self._set_new_param_or_get_existing(name, low, distribution)
 
         return self._suggest(name, distribution)
 
@@ -313,9 +307,7 @@ class Trial(BaseTrial):
 
         distribution = distributions.IntUniformDistribution(low=low, high=high)
         if low == high:
-            param_value_in_internal_repr = distribution.to_internal_repr(low)
-            return self._set_new_param_or_get_existing(name, param_value_in_internal_repr,
-                                                       distribution)
+            return self._set_new_param_or_get_existing(name, low, distribution)
 
         return int(self._suggest(name, distribution))
 
@@ -462,25 +454,25 @@ class Trial(BaseTrial):
         # type: (str, BaseDistribution) -> Any
 
         if self._is_relative_param(name, distribution):
-            param_value_in_internal_repr = self.relative_params[name]
+            param_value = self.relative_params[name]
         else:
             study = optuna.study.InTrialStudy(self.study)
             trial = self.storage.get_trial(self._trial_id)
-            param_value_in_internal_repr = self.study.sampler.sample_independent(
+            param_value = self.study.sampler.sample_independent(
                 study, trial, name, distribution)
 
-        return self._set_new_param_or_get_existing(name, param_value_in_internal_repr,
-                                                   distribution)
+        return self._set_new_param_or_get_existing(name, param_value, distribution)
 
-    def _set_new_param_or_get_existing(self, name, param_value_in_internal_repr, distribution):
-        # type: (str, float, distributions.BaseDistribution) -> Any
+    def _set_new_param_or_get_existing(self, name, param_value, distribution):
+        # type: (str, Any, distributions.BaseDistribution) -> Any
 
+        param_value_in_internal_repr = distribution.to_internal_repr(param_value)
         set_success = self.storage.set_trial_param(self._trial_id, name,
                                                    param_value_in_internal_repr, distribution)
         if not set_success:
             param_value_in_internal_repr = self.storage.get_trial_param(self._trial_id, name)
+            param_value = distribution.to_external_repr(param_value_in_internal_repr)
 
-        param_value = distribution.to_external_repr(param_value_in_internal_repr)
         return param_value
 
     def _is_relative_param(self, name, distribution):
@@ -497,7 +489,8 @@ class Trial(BaseTrial):
         distributions.check_distribution_compatibility(relative_distribution, distribution)
 
         param_value = self.relative_params[name]
-        return distribution._contains(param_value)
+        param_value_in_internal_repr = distribution.to_internal_repr(param_value)
+        return distribution._contains(param_value_in_internal_repr)
 
     @property
     def number(self):

--- a/tests/integration_tests/test_chainermn.py
+++ b/tests/integration_tests/test_chainermn.py
@@ -258,9 +258,8 @@ class TestChainerMNStudy(object):
             'z': distributions.CategoricalDistribution(choices=(-1.0, 1.0)),
         }
         relative_params = {'x': 1.0, 'y': 25.0, 'z': -1.0}
-        relative_params_in_internal_repr = {'x': 1.0, 'y': 25.0, 'z': 0.0}
         sampler = DeterministicRelativeSampler(relative_search_space,  # type: ignore
-                                               relative_params_in_internal_repr)
+                                               relative_params)
 
         with MultiNodeStorageSupplier(storage_mode, cache_mode, comm) as storage:
             study = TestChainerMNStudy._create_shared_study(storage, comm, sampler=sampler)

--- a/tests/integration_tests/test_skopt.py
+++ b/tests/integration_tests/test_skopt.py
@@ -95,7 +95,7 @@ def test_sample_independent():
         return p0 + p1 + p2 + p3 + int(p4)
 
     with patch.object(sampler, 'sample_independent') as mock_object:
-        mock_object.side_effect = [1, 2, 3, 3, 0]
+        mock_object.side_effect = [1, 2, 3, 3, '10']
 
         study.optimize(objective0, n_trials=1)
 

--- a/tests/samplers_tests/test_samplers.py
+++ b/tests/samplers_tests/test_samplers.py
@@ -127,7 +127,7 @@ def test_categorical(sampler_class, choices):
     in_trial_study = InTrialStudy(study)
 
     def sample():
-        # type: () -> int
+        # type: () -> float
 
         trial = _create_new_trial(study)
         param_value = study.sampler.sample_independent(in_trial_study, trial, 'x', distribution)

--- a/tests/samplers_tests/test_samplers.py
+++ b/tests/samplers_tests/test_samplers.py
@@ -127,7 +127,7 @@ def test_categorical(sampler_class, choices):
     in_trial_study = InTrialStudy(study)
 
     def sample():
-        # type: () -> Any
+        # type: () -> int
 
         trial = _create_new_trial(study)
         param_value = study.sampler.sample_independent(in_trial_study, trial, 'x', distribution)

--- a/tests/samplers_tests/test_samplers.py
+++ b/tests/samplers_tests/test_samplers.py
@@ -12,6 +12,7 @@ from optuna.study import InTrialStudy
 
 if optuna.types.TYPE_CHECKING:
     import typing  # NOQA
+    from typing import Any  # NOQA
     from typing import Dict  # NOQA
 
     from optuna.distributions import BaseDistribution  # NOQA
@@ -124,10 +125,16 @@ def test_categorical(sampler_class, choices):
 
     study = optuna.study.create_study(sampler=sampler_class())
     in_trial_study = InTrialStudy(study)
-    points = np.array([
-        study.sampler.sample_independent(in_trial_study, _create_new_trial(study), 'x',
-                                         distribution) for _ in range(100)
-    ])
+
+    def sample():
+        # type: () -> Any
+
+        trial = _create_new_trial(study)
+        param_value = study.sampler.sample_independent(in_trial_study, trial, 'x', distribution)
+        return distribution.to_internal_repr(param_value)
+
+    points = np.array([sample() for _ in range(100)])
+
     # 'x' value is corresponding to an index of distribution.choices.
     assert np.all(points >= 0)
     assert np.all(points <= len(distribution.choices) - 1)
@@ -176,7 +183,7 @@ def test_sample_relative():
     }
     relative_params = {
         'a': 3.2,
-        'b': 2,
+        'b': 'baz',
     }
     unknown_param_value = 30
 

--- a/tests/samplers_tests/test_samplers.py
+++ b/tests/samplers_tests/test_samplers.py
@@ -12,7 +12,6 @@ from optuna.study import InTrialStudy
 
 if optuna.types.TYPE_CHECKING:
     import typing  # NOQA
-    from typing import Any  # NOQA
     from typing import Dict  # NOQA
 
     from optuna.distributions import BaseDistribution  # NOQA


### PR DESCRIPTION
This PR changes the types of return values of `BaseSampler.sample_independent` and `BaseSampler.sample_relative` methods.
In `master` branch, the methods return the internal representations of parameters (i.e., `float` type). After merging this PR, those methods will return the external representations of parameters (i.e., `Any` type).
The aim is to hide the notion of "parameter internal representation" from users.