### PR TITLE
Add CMA-ES Sampler.

### DIFF
--- a/docs/source/reference/integration.rst
+++ b/docs/source/reference/integration.rst
@@ -9,6 +9,10 @@ Integration
 .. autoclass:: ChainerMNStudy
     :members:
 
+.. autoclass:: CmaEsSampler
+    :members:
+    :exclude-members: infer_relative_search_space, sample_relative, sample_independent
+
 .. autoclass:: KerasPruningCallback
     :members:
 

--- a/optuna/integration/__init__.py
+++ b/optuna/integration/__init__.py
@@ -9,6 +9,7 @@ from optuna.types import TYPE_CHECKING
 _import_structure = {
     'chainer': ['ChainerPruningExtension'],
     'chainermn': ['ChainerMNStudy'],
+    'cma': ['CmaEsSampler'],
     'keras': ['KerasPruningCallback'],
     'lightgbm': ['LightGBMPruningCallback'],
     'mxnet': ['MXNetPruningCallback'],
@@ -24,6 +25,7 @@ __all__ = list(_import_structure.keys()) + sum(_import_structure.values(), [])
 if sys.version_info[0] == 2 or TYPE_CHECKING:
     from optuna.integration.chainer import ChainerPruningExtension  # NOQA
     from optuna.integration.chainermn import ChainerMNStudy  # NOQA
+    from optuna.integration.cma import CmaEsSampler  # NOQA
     from optuna.integration.keras import KerasPruningCallback  # NOQA
     from optuna.integration.lightgbm import LightGBMPruningCallback  # NOQA
     from optuna.integration.mxnet import MXNetPruningCallback  # NOQA

--- a/optuna/integration/cma.py
+++ b/optuna/integration/cma.py
@@ -170,7 +170,7 @@ class CmaEsSampler(BaseSampler):
 
         if len(search_space) == 1:
             self._logger.info("`CmaEsSampler` does not support optimization of 1-D search space. "
-                              "Use `{}` instead of it.".format(
+                              "`{}` is used instead of `CmaEsSampler`.".format(
                                   self._independent_sampler.__class__.__name__))
             self._warn_independent_sampling = False
             return {}

--- a/optuna/integration/cma.py
+++ b/optuna/integration/cma.py
@@ -35,6 +35,8 @@ if types.TYPE_CHECKING:
     from optuna.samplers.base import InTrialStudy  # NOQA
     from optuna.structs import FrozenTrial  # NOQA
 
+MIN_SIGMA0 = 1e-10  # Minimum value of sigma0 to avoid ZeroDivisionError in cma.CMAEvotionStrategy.
+
 
 class CmaEsSampler(BaseSampler):
     """A Sampler using cma library as the backend.
@@ -194,6 +196,7 @@ class CmaEsSampler(BaseSampler):
             sigma0 = self._initialize_sigma0(search_space)
         else:
             sigma0 = self._sigma0
+        sigma0 = max(sigma0, MIN_SIGMA0)
 
         optimizer = _Optimizer(search_space, self._x0, sigma0, self._cma_stds,
                                self._cma_opts)

--- a/optuna/integration/cma.py
+++ b/optuna/integration/cma.py
@@ -41,6 +41,9 @@ MIN_SIGMA0 = 1e-10  # Minimum value of sigma0 to avoid ZeroDivisionError in cma.
 class CmaEsSampler(BaseSampler):
     """A Sampler using cma library as the backend.
 
+    Note that parallel execution of trials may degrade the optimization performance of CMA-ES,
+    especially if the number of trials running in parallel exceeds the population size.
+
     Example:
 
         Optimize a simple quadratic function by using :class:`~optuna.integration.CmaEsSampler`.

--- a/optuna/integration/cma.py
+++ b/optuna/integration/cma.py
@@ -348,7 +348,7 @@ class _Optimizer(object):
 
         # individual_index may exceed the population size due to the parallel execution of multiple
         # trials. In such cases, `cma.cma.CMAEvolutionStrategy.ask` is called multiple times in an
-        # iteration, and that may deteriorate the optimization performance of CMA-ES.
+        # iteration, and that may degrade the optimization performance of CMA-ES.
         # In addition, please note that some trials may suggest the same parameters when multiple
         # samplers invoke this method simultaneously.
         while individual_index >= popsize:

--- a/optuna/integration/cma.py
+++ b/optuna/integration/cma.py
@@ -207,8 +207,8 @@ class CmaEsSampler(BaseSampler):
                 index = (len(distribution.choices) - 1) // 2
                 x0[name] = distribution.choices[index]
             else:
-                raise ValueError('Incompatible distribution is given for {}: {}.'.format(
-                    name, distribution))
+                raise NotImplementedError('The distribution {} is not implemented.'.format(
+                    distribution))
         return x0
 
     @staticmethod
@@ -230,8 +230,8 @@ class CmaEsSampler(BaseSampler):
             elif isinstance(distribution, CategoricalDistribution):
                 sigma0s.append((len(distribution.choices) - 1) / 6)
             else:
-                raise ValueError('Incompatible distribution is given for {}: {}.'.format(
-                    name, distribution))
+                raise NotImplementedError('The distribution {} is not implemented.'.format(
+                    distribution))
         return min(sigma0s)
 
     def _log_independent_sampling(self, trial, param_name):
@@ -281,7 +281,7 @@ class _Optimizer(object):
                 lows.append(dist.low - 0.5)
                 highs.append(dist.high + 0.5)
             else:
-                raise ValueError('Incompatible distribution is given: {}.'.format(dist))
+                raise NotImplementedError('The distribution {} is not implemented.'.format(dist))
 
         # Set initial params.
         initial_cma_params = []

--- a/optuna/integration/cma.py
+++ b/optuna/integration/cma.py
@@ -1,0 +1,318 @@
+from __future__ import absolute_import
+
+import math
+import numpy
+import random
+
+import optuna
+from optuna.distributions import CategoricalDistribution
+from optuna.distributions import DiscreteUniformDistribution
+from optuna.distributions import IntUniformDistribution
+from optuna.distributions import LogUniformDistribution
+from optuna.distributions import UniformDistribution
+from optuna.samplers import BaseSampler
+from optuna.structs import StudyDirection
+from optuna.structs import TrialState
+from optuna import types
+
+try:
+    import cma
+    _available = True
+except ImportError as e:
+    _import_error = e
+    # CmaEsSampler is disabled because cma is not available.
+    _available = False
+
+if types.TYPE_CHECKING:
+    from typing import Any  # NOQA
+    from typing import Dict  # NOQA
+    from typing import List  # NOQA
+    from typing import Optional  # NOQA
+
+    from optuna.distributions import BaseDistribution  # NOQA
+    from optuna.samplers.base import InTrialStudy  # NOQA
+    from optuna.structs import FrozenTrial  # NOQA
+
+
+class CmaEsSampler(BaseSampler):
+    """A Sampler using cma library as the backend.
+
+    Example:
+
+        Optimize a simple quadratic function by using :class:`~optuna.integration.CmaEsSampler`.
+
+        .. code::
+
+                def objective(trial):
+                    x = trial.suggest_uniform('x', -1, 1)
+                    y = trial.suggest_int('y', -1, 1)
+                    return x**2 + y
+
+                sampler = optuna.integration.CmaEsSampler(sigma0=0.3)
+                study = optuna.create_study(sampler=sampler)
+                study.optimize(objective, n_trials=100)
+
+    Args:
+
+        sigma0:
+            Initial standard deviation of CMA-ES. Please refer to `cma.CMAEvotionStrategy <http://c
+            ma.gforge.inria.fr/apidocs-pycma/cma.evolution_strategy.CMAEvolutionStrategy.html>`_
+            for further details.
+
+        seed:
+            A random seed for CMA-ES.
+
+        independent_sampler:
+            A :class:`~optuna.samplers.BaseSampler` instance that is used for independent
+            sampling. The parameters not contained in the relative search space are sampled
+            by this sampler.
+            The search space for :class:`~optuna.integration.CmaEsSampler` is determined by
+            :func:`~optuna.samplers.product_search_space()`.
+
+            If :obj:`None` is specified, :class:`~optuna.samplers.RandomSampler` is used
+            as the default.
+
+            .. seealso::
+                :class:`optuna.samplers` module provides built-in independent samplers
+                such as :class:`~optuna.samplers.RandomSampler` and
+                :class:`~optuna.samplers.TPESampler`.
+
+        warn_independent_sampling:
+            If this is :obj:`True`, a warning message is emitted when
+            the value of a parameter is sampled by using an independent sampler.
+
+            Note that the parameters of the first trial in a study are always sampled
+            via an independent sampler, so no warning messages are emitted in this case.
+
+        cma_opts:
+            Options passed to the constructor of
+            `cma.CMAEvotionStrategy <http://cma.gforge.inria.fr/apidocs-pycma/cma.evolution_strateg
+            y.CMAEvolutionStrategy.html>`_ class.
+
+            Note that ``BoundaryHandler``, ``bounds`` and ``seed`` arguments in ``cma_opts`` will
+            be ignored because it is added by :class:`~optuna.integration.CmaEsSampler`
+            automatically.
+    """
+
+    def __init__(self,
+                 sigma0,  # type: float
+                 seed=None,  # type: int
+                 cma_opts=None,  # type: Optional[Dict[str, Any]]
+                 independent_sampler=None,  # type: Optional[BaseSampler]
+                 warn_independent_sampling=True,  # type: bool
+                 ):
+        # type: (...) -> None
+
+        _check_cma_availability()
+
+        self._sigma0 = sigma0
+        if seed is None:
+            seed = random.randint(1, 2**32)
+        self._cma_opts = cma_opts or {}
+        self._cma_opts['seed'] = seed
+        self._independent_sampler = independent_sampler or optuna.samplers.RandomSampler(seed=seed)
+        self._warn_independent_sampling = warn_independent_sampling
+        self._logger = optuna.logging.get_logger(__name__)
+        self._initial_params = None  # type: Optional[Dict[str, Any]]
+
+    def infer_relative_search_space(self, study, trial):
+        # type: (InTrialStudy, FrozenTrial) -> Dict[str, BaseDistribution]
+
+        search_space = {}
+        for name, distribution in optuna.samplers.product_search_space(study).items():
+            if distribution.single():
+                # `cma` cannot handle distributions that contain just a single value,
+                # so we skip this distribution.
+                #
+                # Note that `Trial` takes care of this distribution during suggestion.
+                continue
+
+            search_space[name] = distribution
+
+        return search_space
+
+    def sample_independent(self, study, trial, param_name, param_distribution):
+        # type: (InTrialStudy, FrozenTrial, str, BaseDistribution) -> float
+
+        if self._warn_independent_sampling:
+            complete_trials = [t for t in study.trials if t.state == TrialState.COMPLETE]
+            if len(complete_trials) >= 1:
+                self._log_independent_sampling(trial, param_name)
+
+        return self._independent_sampler.sample_independent(study, trial, param_name,
+                                                            param_distribution)
+
+    def sample_relative(self, study, trial, search_space):
+        # type: (InTrialStudy, FrozenTrial, Dict[str, BaseDistribution]) -> Dict[str, float]
+
+        if len(search_space) == 0:
+            return {}
+
+        if len(search_space) == 1:
+            self._logger.info(
+                "`CmaEsSampler` does not support optimization of 1-D search space. "
+                "Use `{}` instead of it.".format(self._independent_sampler.__class__.__name__)
+            )
+            self._warn_independent_sampling = False
+            return {}
+
+        if self._initial_params is None:
+            self._initial_params = study.best_params
+
+        optimizer = _Optimizer(search_space, self._initial_params, self._sigma0, self._cma_opts)
+        trials = study.trials
+        n_told = optimizer.tell(trials, study.direction)
+        return optimizer.ask(trials, n_told)
+
+    def _log_independent_sampling(self, trial, param_name):
+        # type: (FrozenTrial, str) -> None
+
+        self._logger.warning(
+            "The parameter '{}' in trial#{} is sampled independently "
+            "by using `{}` instead of `CmaEsSampler` "
+            "(optimization performance may be degraded). "
+            "You can suppress this warning by setting `warn_independent_sampling` "
+            "to `False` in the constructor of `CmaEsSampler`, "
+            "if this independent sampling is intended behavior.".format(
+                param_name, trial.number, self._independent_sampler.__class__.__name__))
+
+
+class _Optimizer(object):
+    def __init__(self, search_space, initial_params, sigma0, cma_opts):
+        # type: (Dict[str, BaseDistribution], Dict[str, Any], float, Dict[str, Any]) -> None
+
+        self._search_space = search_space
+        self._param_names = list(sorted(self._search_space.keys()))
+
+        lows = []
+        highs = []
+        for param_name in self._param_names:
+            dist = self._search_space[param_name]
+            if isinstance(dist, CategoricalDistribution):
+                # Handle categorical values by ordinal representation.
+                lows.append(-0.5)
+                highs.append(len(dist.choices) - 0.5)
+            elif isinstance(dist, UniformDistribution) or \
+                    isinstance(dist, LogUniformDistribution):
+                lows.append(self._to_cma_params(search_space, param_name, dist.low))
+                highs.append(self._to_cma_params(search_space, param_name, dist.high))
+            elif isinstance(dist, DiscreteUniformDistribution):
+                r = dist.high - dist.low
+                lows.append(0 - 0.5 * dist.q)
+                highs.append(r + 0.5 * dist.q)
+            elif isinstance(dist, IntUniformDistribution):
+                lows.append(dist.low - 0.5)
+                highs.append(dist.high + 0.5)
+            else:
+                raise ValueError('Incompatible distribution is given: {}.'.format(dist))
+
+        # Set initial params.
+        initial_cma_params = []
+        for param_name in self._param_names:
+            initial_cma_params.append(self._to_cma_params(self._search_space,
+                                                          param_name,
+                                                          initial_params[param_name]))
+
+        cma_option = {
+            'BoundaryHandler': cma.BoundTransform,
+            'bounds': [lows, highs],
+        }
+        cma_opts.update(cma_option)
+
+        self._es = cma.CMAEvolutionStrategy(initial_cma_params, sigma0, cma_opts)
+
+    def tell(self, trials, study_direction):
+        # type: (List[FrozenTrial], StudyDirection) -> int
+
+        complete_trials = []
+        for trial in trials:
+            if trial.distributions != self._search_space:
+                continue
+            if trial.state != TrialState.COMPLETE:
+                continue
+            complete_trials.append(trial)
+
+        popsize = self._es.popsize
+        generation = len(complete_trials) // popsize
+        for i in range(generation):
+            xs = []
+            ys = []
+            for t in complete_trials[i * popsize:(i + 1) * popsize]:
+                x = [self._to_cma_params(self._search_space, name, t.params[name])
+                     for name in self._param_names]
+                xs.append(x)
+                ys.append(t.value)
+            if study_direction == StudyDirection.MAXIMIZE:
+                ys = [-1 * y if y is not None else y for y in ys]
+            self._es.ask()
+            self._es.tell(xs, ys)
+        return generation * popsize
+
+    def ask(self, trials, n_told):
+        # type: (List[FrozenTrial], int) -> Dict[str, Any]
+
+        individual_index = self._n_target_trials(trials) - n_told
+        popsize = self._es.popsize
+
+        # individual_index may exceed the population size when users execute multiple trials in
+        # parallel. Note that trial may suggest the same parameters when multiple samplers invoke
+        # this method simultaneously.
+        while individual_index >= popsize:
+            individual_index -= popsize
+            self._es.ask()
+        cma_params = self._es.ask()[individual_index]
+
+        ret_val = {}
+        for param_name, value in zip(self._param_names, cma_params):
+            ret_val[param_name] = self._to_optuna_params(self._search_space, param_name, value)
+        return ret_val
+
+    def _n_target_trials(self, trials):
+        # type: (List[FrozenTrial]) -> int
+
+        cnt = 0
+        for trial in trials:
+            if trial.distributions != self._search_space:
+                continue
+            cnt += 1
+        return cnt
+
+    def _to_cma_params(self, search_space, param_name, optuna_param_value):
+        # type: (Dict[str, BaseDistribution], str, Any) -> float
+
+        dist = search_space[param_name]
+        if isinstance(dist, LogUniformDistribution):
+            return math.log(optuna_param_value)
+        elif isinstance(dist, DiscreteUniformDistribution):
+            return optuna_param_value - dist.low
+        elif isinstance(dist, CategoricalDistribution):
+            return dist.choices.index(optuna_param_value)
+        return optuna_param_value
+
+    def _to_optuna_params(self, search_space, param_name, cma_param_value):
+        # type: (Dict[str, BaseDistribution], str, float) -> Any
+
+        dist = search_space[param_name]
+        if isinstance(dist, LogUniformDistribution):
+            return math.exp(cma_param_value)
+        if isinstance(dist, DiscreteUniformDistribution):
+            v = numpy.round(cma_param_value / dist.q) * dist.q + dist.low
+            # v may slightly exceed range due to round-off errors.
+            return float(min(max(v, dist.low), dist.high))
+        if isinstance(dist, IntUniformDistribution):
+            return int(numpy.round(cma_param_value))
+        if isinstance(dist, CategoricalDistribution):
+            v = int(numpy.round(cma_param_value))
+            return dist.choices[v]
+        return cma_param_value
+
+
+def _check_cma_availability():
+    # type: () -> None
+
+    if not _available:
+        raise ImportError(
+            'cma library is not available. Please install cma to use this feature. '
+            'cma can be installed by executing `$ pip install cma`. '
+            'For further information, please refer to the installation guide of cma. '
+            '(The actual import error is as follows: ' + str(_import_error) + ')')

--- a/optuna/integration/cma.py
+++ b/optuna/integration/cma.py
@@ -48,7 +48,7 @@ class CmaEsSampler(BaseSampler):
                     y = trial.suggest_int('y', -1, 1)
                     return x**2 + y
 
-                sampler = optuna.integration.CmaEsSampler(sigma0=0.3)
+                sampler = optuna.integration.CmaEsSampler()
                 study = optuna.create_study(sampler=sampler)
                 study.optimize(objective, n_trials=100)
 
@@ -72,7 +72,7 @@ class CmaEsSampler(BaseSampler):
         cma_stds:
             A dictionary of multipliers of sigma0 for each parameters. The default value is 1.0.
             Please refer to `cma.CMAEvotionStrategy <http://cma.gforge.inria.fr/apidocs-pycma/cma.e
-            volution_strategy.CMAEvolutionStrategy.html>`_ for further details of ``sigma0``.
+            volution_strategy.CMAEvolutionStrategy.html>`_ for further details of ``cma_stds``.
 
         seed:
             A random seed for CMA-ES.
@@ -114,7 +114,7 @@ class CmaEsSampler(BaseSampler):
             x0=None,  # type: Optional[Dict[str, Any]]
             sigma0=None,  # type: Optional[float]
             cma_stds=None,  # type: Optional[Dict[str, float]]
-            seed=None,  # type: int
+            seed=None,  # type: Optional[int]
             cma_opts=None,  # type: Optional[Dict[str, Any]]
             independent_sampler=None,  # type: Optional[BaseSampler]
             warn_independent_sampling=True,  # type: bool

--- a/optuna/integration/cma.py
+++ b/optuna/integration/cma.py
@@ -153,9 +153,9 @@ class CmaEsSampler(BaseSampler):
         search_space = {}
         for name, distribution in optuna.samplers.product_search_space(study).items():
             if distribution.single():
-                # `cma` cannot handle distributions that contain just a single value, so that
-                # we skip them. Note that the parameter values for such distributions are sampled
-                # in `Trial`.
+                # `cma` cannot handle distributions that contain just a single value, so we skip
+                # them. Note that the parameter values for such distributions are sampled in
+                # `Trial`.
                 continue
 
             search_space[name] = distribution

--- a/optuna/integration/cma.py
+++ b/optuna/integration/cma.py
@@ -130,6 +130,7 @@ class CmaEsSampler(BaseSampler):
             seed = random.randint(1, 2**32)
         self._cma_opts = cma_opts or {}
         self._cma_opts['seed'] = seed
+        self._cma_opts.setdefault('verbose', -2)
         self._independent_sampler = independent_sampler or optuna.samplers.RandomSampler(seed=seed)
         self._warn_independent_sampling = warn_independent_sampling
         self._logger = optuna.logging.get_logger(__name__)

--- a/optuna/integration/cma.py
+++ b/optuna/integration/cma.py
@@ -154,7 +154,8 @@ class CmaEsSampler(BaseSampler):
         for name, distribution in optuna.samplers.product_search_space(study).items():
             if distribution.single():
                 # `cma` cannot handle distributions that contain just a single value, so that
-                # the parameter values for such distributions are sampled by `sample_independent`.
+                # we skip them. Note that the parameter values for such distributions are sampled
+                # in `Trial`.
                 continue
 
             search_space[name] = distribution

--- a/optuna/testing/distribution.py
+++ b/optuna/testing/distribution.py
@@ -1,0 +1,23 @@
+from optuna.distributions import BaseDistribution
+from optuna import types
+
+if types.TYPE_CHECKING:
+    from typing import Dict  # NOQA
+
+
+class UnsupportedDistribution(BaseDistribution):
+
+    def single(self):
+        # type: () -> bool
+
+        return False
+
+    def _contains(self, param_value_in_internal_repr):
+        # type: (float) -> bool
+
+        return True
+
+    def _asdict(self):
+        # type: () -> Dict
+
+        return {}

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ def get_extras_require():
         'checking': ['autopep8', 'hacking'],
         'testing': [
             'pytest', 'mock', 'bokeh', 'plotly', 'chainer>=5.0.0', 'xgboost', 'mpi4py', 'lightgbm',
-            'keras', 'mxnet', 'scikit-optimize', 'tensorflow'
+            'keras', 'mxnet', 'scikit-optimize', 'tensorflow', 'cma'
         ],
         'document': ['sphinx', 'sphinx_rtd_theme'],
         'codecov': ['pytest-cov', 'codecov'],

--- a/tests/integration_tests/test_cma.py
+++ b/tests/integration_tests/test_cma.py
@@ -97,6 +97,30 @@ class TestCmaEsSampler(object):
             assert mock_object.call_count == 2
 
     @staticmethod
+    def test_sample_relative_n_startup_trials():
+        # type: () -> None
+
+        independent_sampler = DeterministicRelativeSampler({}, {})
+        sampler = optuna.integration.CmaEsSampler(n_startup_trials=2,
+                                                  independent_sampler=independent_sampler)
+        study = optuna.create_study(sampler=sampler)
+
+        # The independent sampler is used for Trial#0 and Trial#1.
+        # The CMA-ES is used for Trial#2.
+        with patch.object(
+                independent_sampler,
+                'sample_independent',
+                wraps=independent_sampler.sample_independent) as mock_independent, \
+            patch.object(
+                sampler,
+                'sample_relative',
+                wraps=sampler.sample_relative) as mock_relative:
+            study.optimize(lambda t: t.suggest_int('x', -1, 1) + t.suggest_int('y', -1, 1),
+                           n_trials=3)
+            assert mock_independent.call_count == 4  # The objective function has two parameters.
+            assert mock_relative.call_count == 3
+
+    @staticmethod
     def test_initialize_x0_with_unsupported_distribution():
         # type: () -> None
 

--- a/tests/integration_tests/test_cma.py
+++ b/tests/integration_tests/test_cma.py
@@ -1,0 +1,265 @@
+import cma
+import math
+from mock import call
+from mock import patch
+import pytest
+
+import optuna
+from optuna.distributions import CategoricalDistribution
+from optuna.distributions import DiscreteUniformDistribution
+from optuna.distributions import IntUniformDistribution
+from optuna.distributions import LogUniformDistribution
+from optuna.distributions import UniformDistribution
+from optuna.integration.cma import _Optimizer
+from optuna.structs import FrozenTrial
+from optuna.structs import StudyDirection
+from optuna.structs import TrialState
+from optuna.testing.sampler import DeterministicRelativeSampler
+
+if optuna.types.TYPE_CHECKING:
+    from typing import Any  # NOQA
+    from typing import Dict  # NOQA
+
+    from optuna.distributions import BaseDistribution  # NOQA
+
+
+class TestCmaEsSampler(object):
+    @staticmethod
+    def test_init_cma_opts():
+        # type: () -> None
+
+        sampler = optuna.integration.CmaEsSampler(
+            0.1,
+            seed=1,
+            cma_opts={'popsize': 5},
+            independent_sampler=DeterministicRelativeSampler({}, {}))
+        study = optuna.create_study(sampler=sampler)
+
+        with patch('optuna.integration.cma._Optimizer') as mock_obj:
+            mock_obj.ask.return_value = {'x': -1, 'y': -1}
+            study.optimize(
+                lambda t: t.suggest_int('x', -1, 1) + t.suggest_int('y', -1, 1), n_trials=2)
+            assert mock_obj.mock_calls[0] == call({
+                'x': IntUniformDistribution(low=-1, high=1),
+                'y': IntUniformDistribution(low=-1, high=1)
+            }, {
+                'x': -1,
+                'y': -1
+            }, 0.1, {
+                'popsize': 5,
+                'seed': 1
+            })
+
+    @staticmethod
+    def test_init_default_values():
+        # type: () -> None
+
+        sampler = optuna.integration.CmaEsSampler(0.1)
+        seed = sampler._cma_opts.get('seed')
+        assert isinstance(seed, int)
+        assert 0 < seed
+
+        assert isinstance(sampler._independent_sampler, optuna.samplers.RandomSampler)
+
+    @staticmethod
+    def test_infer_relative_search_space_single():
+        # type: () -> None
+
+        sampler = optuna.integration.CmaEsSampler(0.1)
+        study = optuna.create_study(sampler=sampler)
+
+        # The distribution has only one candidate.
+        study.optimize(lambda t: t.suggest_int('x', 1, 1), n_trials=1)
+        in_trial_study = optuna.study.InTrialStudy(study)
+        assert sampler.infer_relative_search_space(in_trial_study, study.best_trial) == {}
+
+    @staticmethod
+    def test_sample_relative_1d():
+        # type: () -> None
+
+        independent_sampler = DeterministicRelativeSampler({}, {})
+        sampler = optuna.integration.CmaEsSampler(0.1, independent_sampler=independent_sampler)
+        study = optuna.create_study(sampler=sampler)
+
+        # If search space is one dimensional, the independent sampler is always used.
+        with patch.object(
+                independent_sampler,
+                'sample_independent',
+                wraps=independent_sampler.sample_independent) as mock_object:
+            study.optimize(lambda t: t.suggest_int('x', -1, 1), n_trials=2)
+            assert mock_object.call_count == 2
+
+
+class TestOptimizer(object):
+    @staticmethod
+    @pytest.fixture
+    def search_space():
+        # type: () -> Dict[str, BaseDistribution]
+
+        return {
+            'c': CategoricalDistribution(('a', 'b')),
+            'd': DiscreteUniformDistribution(-1, 9, 2),
+            'i': IntUniformDistribution(-1, 1),
+            'l': LogUniformDistribution(0.001, 0.1),
+            'u': UniformDistribution(-2, 2),
+        }
+
+    @staticmethod
+    @pytest.fixture
+    def initial_params():
+        # type: () -> Dict[str, Any]
+
+        return {
+            'c': 'a',
+            'd': -1,
+            'i': -1,
+            'l': 0.001,
+            'u': -2,
+        }
+
+    @staticmethod
+    def test_init(search_space, initial_params):
+        # type: (Dict[str, BaseDistribution], Dict[str, Any]) -> None
+
+        with patch('cma.CMAEvolutionStrategy') as mock_obj:
+            optuna.integration.cma._Optimizer(search_space, initial_params, 0.2, {
+                'popsize': 4,
+                'seed': 1
+            })
+            assert mock_obj.mock_calls[0] == call(
+                [0, 0, -1, math.log(0.001), -2], 0.2, {
+                    'BoundaryHandler':
+                    cma.BoundTransform,
+                    'bounds': [[-0.5, -1.0, -1.5, math.log(0.001), -2],
+                               [1.5, 11.0, 1.5, math.log(0.1), 2]],
+                    'popsize':
+                    4,
+                    'seed':
+                    1
+                })
+
+    @staticmethod
+    @pytest.mark.parametrize('direction', [StudyDirection.MINIMIZE, StudyDirection.MAXIMIZE])
+    def test_tell(search_space, initial_params, direction):
+        # type: (Dict[str, BaseDistribution], Dict[str, Any], StudyDirection) -> None
+
+        optimizer = optuna.integration.cma._Optimizer(search_space, initial_params, 0.2, {
+            'popsize': 3,
+            'seed': 1
+        })
+
+        trials = [_create_frozen_trial(initial_params, search_space)]
+        assert 0 == optimizer.tell(trials, direction)
+
+        trials = [_create_frozen_trial(initial_params, search_space) for _ in range(3)]
+        assert 3 == optimizer.tell(trials, direction)
+
+    @staticmethod
+    @pytest.mark.parametrize('state', [TrialState.FAIL, TrialState.RUNNING, TrialState.PRUNED])
+    def test_tell_filter_by_state(search_space, initial_params, state):
+        # type: (Dict[str, BaseDistribution], Dict[str, Any], TrialState) -> None
+
+        optimizer = optuna.integration.cma._Optimizer(search_space, initial_params, 0.2, {
+            'popsize': 2,
+            'seed': 1
+        })
+
+        trials = [_create_frozen_trial(initial_params, search_space)]
+        trials.append(trials[0]._replace(state=state))
+        assert 0 == optimizer.tell(trials, StudyDirection.MINIMIZE)
+
+    @staticmethod
+    def test_tell_filter_by_distribution(search_space, initial_params):
+        # type: (Dict[str, BaseDistribution], Dict[str, Any]) -> None
+
+        optimizer = optuna.integration.cma._Optimizer(search_space, initial_params, 0.2, {
+            'popsize': 2,
+            'seed': 1
+        })
+
+        trials = [_create_frozen_trial(initial_params, search_space)]
+        distributions = trials[0].distributions.copy()
+        distributions['additional'] = UniformDistribution(0, 100)
+        trials.append(trials[0]._replace(distributions=distributions))
+        assert 0 == optimizer.tell(trials, StudyDirection.MINIMIZE)
+
+    @staticmethod
+    def test_ask(search_space, initial_params):
+        # type: (Dict[str, BaseDistribution], Dict[str, Any]) -> None
+
+        trials = [_create_frozen_trial(initial_params, search_space) for _ in range(3)]
+
+        # Create 0-th individual.
+        optimizer = _Optimizer(search_space, initial_params, 0.2, {'popsize': 3, 'seed': 1})
+        told = optimizer.tell(trials, StudyDirection.MINIMIZE)
+        params0 = optimizer.ask(trials, told)
+
+        # Ignore incompatible trial and create 0-th individual again.
+        optimizer = _Optimizer(search_space, initial_params, 0.2, {'popsize': 3, 'seed': 1})
+        told = optimizer.tell(trials, StudyDirection.MINIMIZE)
+        distributions = trials[0].distributions.copy()
+        distributions['additional'] = UniformDistribution(0, 100)
+        trials.append(trials[0]._replace(distributions=distributions))
+        params1 = optimizer.ask(trials, told)
+
+        assert params0 == params1
+
+        # Create first individual.
+        optimizer = _Optimizer(search_space, initial_params, 0.2, {'popsize': 3, 'seed': 1})
+        trials.append(trials[0])
+        told = optimizer.tell(trials, StudyDirection.MINIMIZE)
+        params2 = optimizer.ask(trials, told)
+
+        assert params0 != params2
+
+        optimizer = _Optimizer(search_space, initial_params, 0.2, {'popsize': 3, 'seed': 1})
+        told = optimizer.tell(trials, StudyDirection.MINIMIZE)
+        # Other worker adds three trials.
+        for _ in range(3):
+            trials.append(trials[0])
+        params3 = optimizer.ask(trials, told)
+
+        assert params0 != params3
+        assert params2 != params3
+
+    @staticmethod
+    def test_n_target_trials():
+        # type: () -> None
+
+        pass
+
+    @staticmethod
+    def test_to_cma_params():
+        # type: () -> None
+
+        pass
+
+    @staticmethod
+    def test_to_optuna_params():
+        # type: () -> None
+
+        pass
+
+
+def _create_frozen_trial(params, param_distributions):
+    # type: (Dict[str, Any], Dict[str, BaseDistribution]) -> FrozenTrial
+
+    params_in_internal_repr = {}
+    for param_name, param_value in params.items():
+        params_in_internal_repr[param_name] = param_distributions[param_name].to_internal_repr(
+            param_value)
+
+    return FrozenTrial(
+        number=0,
+        value=1.,
+        state=optuna.structs.TrialState.COMPLETE,
+        user_attrs={},
+        system_attrs={},
+        params=params,
+        params_in_internal_repr=params_in_internal_repr,
+        distributions=param_distributions,
+        intermediate_values={},
+        datetime_start=None,
+        datetime_complete=None,
+        trial_id=0,
+    )

--- a/tests/integration_tests/test_cma.py
+++ b/tests/integration_tests/test_cma.py
@@ -69,7 +69,7 @@ class TestCmaEsSampler(object):
         assert isinstance(sampler._independent_sampler, optuna.samplers.RandomSampler)
 
     @staticmethod
-    def test_infer_relative_search_space_single():
+    def test_infer_relative_search_space_1d():
         # type: () -> None
 
         sampler = optuna.integration.CmaEsSampler()

--- a/tests/integration_tests/test_sampler.py
+++ b/tests/integration_tests/test_sampler.py
@@ -12,14 +12,14 @@ if optuna.types.TYPE_CHECKING:
 
 parametrize_sampler = pytest.mark.parametrize('sampler_class', [
     optuna.integration.SkoptSampler,
-    lambda: optuna.integration.CmaEsSampler(0.1),
+    optuna.integration.CmaEsSampler,
 ])
 
 
 @pytest.mark.parametrize('sampler_class', [
     lambda: SkoptSampler(
         independent_sampler=FirstTrialOnlyRandomSampler(), skopt_kwargs={'n_initial_points': 5}),
-    lambda: CmaEsSampler(0.1, independent_sampler=FirstTrialOnlyRandomSampler()),
+    lambda: CmaEsSampler(independent_sampler=FirstTrialOnlyRandomSampler()),
 ])
 def test_suggested_value(sampler_class):
     # type: (Callable[[], BaseSampler]) -> None
@@ -106,7 +106,7 @@ def test_sample_independent(sampler_class):
 
 @pytest.mark.parametrize('sampler_class', [
     lambda x: SkoptSampler(warn_independent_sampling=x),
-    lambda x: CmaEsSampler(0.1, warn_independent_sampling=x),
+    lambda x: CmaEsSampler(warn_independent_sampling=x),
 ])
 def test_warn_independent_sampling(sampler_class):
     # type: (Callable[[bool], BaseSampler]) -> None

--- a/tests/integration_tests/test_sampler.py
+++ b/tests/integration_tests/test_sampler.py
@@ -4,11 +4,12 @@ import pytest
 import optuna
 from optuna.integration import CmaEsSampler
 from optuna.integration import SkoptSampler
-from optuna.samplers import BaseSampler  # NOQA
 from optuna.testing.sampler import FirstTrialOnlyRandomSampler
 
 if optuna.types.TYPE_CHECKING:
     from typing import Callable  # NOQA
+
+    from optuna.samplers import BaseSampler  # NOQA
 
 parametrize_sampler = pytest.mark.parametrize('sampler_class', [
     optuna.integration.SkoptSampler,

--- a/tests/integration_tests/test_sampler.py
+++ b/tests/integration_tests/test_sampler.py
@@ -1,0 +1,160 @@
+from mock import patch
+import pytest
+
+import optuna
+from optuna.integration import CmaEsSampler
+from optuna.integration import SkoptSampler
+from optuna.samplers import BaseSampler  # NOQA
+from optuna.testing.sampler import FirstTrialOnlyRandomSampler
+
+if optuna.types.TYPE_CHECKING:
+    from typing import Callable  # NOQA
+
+parametrize_sampler = pytest.mark.parametrize('sampler_class', [
+    optuna.integration.SkoptSampler,
+    lambda: optuna.integration.CmaEsSampler(0.1),
+])
+
+
+@pytest.mark.parametrize('sampler_class', [
+    lambda: SkoptSampler(
+        independent_sampler=FirstTrialOnlyRandomSampler(), skopt_kwargs={'n_initial_points': 5}),
+    lambda: CmaEsSampler(0.1, independent_sampler=FirstTrialOnlyRandomSampler()),
+])
+def test_suggested_value(sampler_class):
+    # type: (Callable[[], BaseSampler]) -> None
+
+    sampler = sampler_class()
+    # direction='minimize'
+    study = optuna.create_study(sampler=sampler, direction='minimize')
+    study.optimize(_objective, n_trials=10, catch=())
+    for trial in study.trials:
+        for param_name, param_value in trial.params_in_internal_repr.items():
+            assert trial.distributions[param_name]._contains(param_value)
+
+    # direction='maximize'
+    study = optuna.create_study(sampler=sampler, direction='maximize')
+    study.optimize(_objective, n_trials=10, catch=())
+    for trial in study.trials:
+        for param_name, param_value in trial.params_in_internal_repr.items():
+            assert trial.distributions[param_name]._contains(param_value)
+
+
+@parametrize_sampler
+def test_sample_independent(sampler_class):
+    # type: (Callable[[], BaseSampler]) -> None
+
+    sampler = sampler_class()
+    study = optuna.create_study(sampler=sampler)
+
+    # First trial.
+    def objective0(trial):
+        # type: (optuna.trial.Trial) -> float
+
+        p0 = trial.suggest_uniform('p0', 0, 10)
+        p1 = trial.suggest_loguniform('p1', 1, 10)
+        p2 = trial.suggest_int('p2', 0, 10)
+        p3 = trial.suggest_discrete_uniform('p3', 0, 9, 3)
+        p4 = trial.suggest_categorical('p4', ['10', '20', '30'])
+        return p0 + p1 + p2 + p3 + int(p4)
+
+    with patch.object(sampler, 'sample_independent') as mock_object:
+        mock_object.side_effect = [1, 2, 3, 3, '10']
+
+        study.optimize(objective0, n_trials=1)
+
+        # In first trial, all parameters were suggested via `sample_independent`.
+        assert mock_object.call_count == 5
+
+    # Second trial.
+    def objective1(trial):
+        # type: (optuna.trial.Trial) -> float
+
+        # p0, p2 and p4 are deleted.
+        p1 = trial.suggest_loguniform('p1', 1, 10)
+        p3 = trial.suggest_discrete_uniform('p3', 0, 9, 3)
+
+        # p5 is added.
+        p5 = trial.suggest_uniform('p5', 0, 1)
+
+        return p1 + p3 + p5
+
+    with patch.object(sampler, 'sample_independent') as mock_object:
+        mock_object.side_effect = [0]
+
+        study.optimize(objective1, n_trials=1)
+
+        assert [call[1][2] for call in mock_object.mock_calls] == ['p5']
+
+    # Third trial.
+    def objective2(trial):
+        # type: (optuna.trial.Trial) -> float
+
+        p1 = trial.suggest_loguniform('p1', 50, 100)  # The range has been changed
+        p3 = trial.suggest_discrete_uniform('p3', 0, 9, 3)
+        p5 = trial.suggest_uniform('p5', 0, 1)
+
+        return p1 + p3 + p5
+
+    with patch.object(sampler, 'sample_independent') as mock_object:
+        mock_object.side_effect = [90, 0.2]
+
+        study.optimize(objective2, n_trials=1)
+
+        assert [call[1][2] for call in mock_object.mock_calls] == ['p1', 'p5']
+
+
+@pytest.mark.parametrize('sampler_class', [
+    lambda x: SkoptSampler(warn_independent_sampling=x),
+    lambda x: CmaEsSampler(0.1, warn_independent_sampling=x),
+])
+def test_warn_independent_sampling(sampler_class):
+    # type: (Callable[[bool], BaseSampler]) -> None
+
+    # warn_independent_sampling=True
+    sampler = sampler_class(True)
+    study = optuna.create_study(sampler=sampler)
+
+    class_name = 'optuna.integration.{}'.format(sampler.__class__.__name__)
+    method_name = '{}._log_independent_sampling'.format(class_name)
+
+    with patch(method_name) as mock_object:
+        study.optimize(
+            lambda t: t.suggest_uniform('p0', 0, 10) + t.suggest_uniform('q0', 0, 10), n_trials=1)
+        assert mock_object.call_count == 0
+
+    with patch(method_name) as mock_object:
+        study.optimize(
+            lambda t: t.suggest_uniform('p1', 0, 10) + t.suggest_uniform('q1', 0, 10), n_trials=1)
+        assert mock_object.call_count == 2
+
+    # warn_independent_sampling=False
+    sampler = sampler_class(False)
+    study = optuna.create_study(sampler=sampler)
+
+    with patch(method_name) as mock_object:
+        study.optimize(
+            lambda t: t.suggest_uniform('p0', 0, 10) + t.suggest_uniform('q0', 0, 10), n_trials=1)
+        assert mock_object.call_count == 0
+
+    with patch(method_name) as mock_object:
+        study.optimize(
+            lambda t: t.suggest_uniform('p1', 0, 10) + t.suggest_uniform('q1', 0, 10), n_trials=1)
+        assert mock_object.call_count == 0
+
+
+def _objective(trial):
+    # type: (optuna.trial.Trial) -> float
+
+    p0 = trial.suggest_uniform('p0', -3.3, 5.2)
+    p1 = trial.suggest_uniform('p1', 2.0, 2.0)
+    p2 = trial.suggest_loguniform('p2', 0.0001, 0.3)
+    p3 = trial.suggest_loguniform('p3', 1.1, 1.1)
+    p4 = trial.suggest_int('p4', -100, 8)
+    p5 = trial.suggest_int('p5', -20, -20)
+    p6 = trial.suggest_discrete_uniform('p6', 10, 20, 2)
+    p7 = trial.suggest_discrete_uniform('p7', 0.1, 1.0, 0.1)
+    p8 = trial.suggest_discrete_uniform('p8', 2.2, 2.2, 0.5)
+    p9 = trial.suggest_categorical('p9', ['9', '3', '0', '8'])
+
+    return p0 + p1 + p2 + p3 + p4 + p5 + p6 + p7 + p8 + int(p9)

--- a/tests/integration_tests/test_skopt.py
+++ b/tests/integration_tests/test_skopt.py
@@ -6,7 +6,6 @@ from skopt.space import space
 import optuna
 from optuna import distributions
 from optuna.structs import FrozenTrial
-from optuna.testing.sampler import FirstTrialOnlyRandomSampler
 
 if optuna.types.TYPE_CHECKING:
     from typing import Any  # NOQA
@@ -55,91 +54,6 @@ def test_conversion_from_distribution_to_dimenstion():
         assert mock_object.mock_calls[0] == call(dimensions)
 
 
-def test_suggested_value():
-    # type: () -> None
-
-    independent_sampler = FirstTrialOnlyRandomSampler()
-    sampler = optuna.integration.SkoptSampler(independent_sampler=independent_sampler,
-                                              skopt_kwargs={'n_initial_points': 5})
-
-    # direction='minimize'
-    study = optuna.create_study(sampler=sampler, direction='minimize')
-    study.optimize(_objective, n_trials=10, catch=())
-    for trial in study.trials:
-        for param_name, param_value in trial.params_in_internal_repr.items():
-            assert trial.distributions[param_name]._contains(param_value)
-
-    # direction='maximize'
-    study = optuna.create_study(sampler=sampler, direction='maximize')
-    study.optimize(_objective, n_trials=10, catch=())
-    for trial in study.trials:
-        for param_name, param_value in trial.params_in_internal_repr.items():
-            assert trial.distributions[param_name]._contains(param_value)
-
-
-def test_sample_independent():
-    # type: () -> None
-
-    sampler = optuna.integration.SkoptSampler()
-    study = optuna.create_study(sampler=sampler)
-
-    # First trial.
-    def objective0(trial):
-        # type: (optuna.trial.Trial) -> float
-
-        p0 = trial.suggest_uniform('p0', 0, 10)
-        p1 = trial.suggest_loguniform('p1', 1, 10)
-        p2 = trial.suggest_int('p2', 0, 10)
-        p3 = trial.suggest_discrete_uniform('p3', 0, 9, 3)
-        p4 = trial.suggest_categorical('p4', ['10', '20', '30'])
-        return p0 + p1 + p2 + p3 + int(p4)
-
-    with patch.object(sampler, 'sample_independent') as mock_object:
-        mock_object.side_effect = [1, 2, 3, 3, '10']
-
-        study.optimize(objective0, n_trials=1)
-
-        # In first trial, all parameters were suggested via `sample_independent`.
-        assert mock_object.call_count == 5
-
-    # Second trial.
-    def objective1(trial):
-        # type: (optuna.trial.Trial) -> float
-
-        # p0, p2 and p4 are deleted.
-        p1 = trial.suggest_loguniform('p1', 1, 10)
-        p3 = trial.suggest_discrete_uniform('p3', 0, 9, 3)
-
-        # p5 is added.
-        p5 = trial.suggest_uniform('p5', 0, 1)
-
-        return p1 + p3 + p5
-
-    with patch.object(sampler, 'sample_independent') as mock_object:
-        mock_object.side_effect = [0]
-
-        study.optimize(objective1, n_trials=1)
-
-        assert [call[1][2] for call in mock_object.mock_calls] == ['p5']
-
-    # Third trial.
-    def objective2(trial):
-        # type: (optuna.trial.Trial) -> float
-
-        p1 = trial.suggest_loguniform('p1', 50, 100)  # The range has been changed
-        p3 = trial.suggest_discrete_uniform('p3', 0, 9, 3)
-        p5 = trial.suggest_uniform('p5', 0, 1)
-
-        return p1 + p3 + p5
-
-    with patch.object(sampler, 'sample_independent') as mock_object:
-        mock_object.side_effect = [90, 0.2]
-
-        study.optimize(objective2, n_trials=1)
-
-        assert [call[1][2] for call in mock_object.mock_calls] == ['p1', 'p5']
-
-
 def test_skopt_kwargs():
     # type: () -> None
 
@@ -165,34 +79,6 @@ def test_skopt_kwargs_dimenstions():
 
         expected_dimensions = [space.Integer(-10, 10)]
         assert mock_object.mock_calls[0] == call(expected_dimensions)
-
-
-def test_warn_independent_sampling():
-    # type: () -> None
-
-    # warn_independent_sampling=True
-    sampler = optuna.integration.SkoptSampler(warn_independent_sampling=True)
-    study = optuna.create_study(sampler=sampler)
-
-    with patch('optuna.integration.skopt.SkoptSampler._log_independent_sampling') as mock_object:
-        study.optimize(lambda t: t.suggest_uniform('p0', 0, 10), n_trials=1)
-        assert mock_object.call_count == 0
-
-    with patch('optuna.integration.skopt.SkoptSampler._log_independent_sampling') as mock_object:
-        study.optimize(lambda t: t.suggest_uniform('p1', 0, 10), n_trials=1)
-        assert mock_object.call_count == 1
-
-    # warn_independent_sampling=False
-    sampler = optuna.integration.SkoptSampler(warn_independent_sampling=False)
-    study = optuna.create_study(sampler=sampler)
-
-    with patch('optuna.integration.skopt.SkoptSampler._log_independent_sampling') as mock_object:
-        study.optimize(lambda t: t.suggest_uniform('p0', 0, 10), n_trials=1)
-        assert mock_object.call_count == 0
-
-    with patch('optuna.integration.skopt.SkoptSampler._log_independent_sampling') as mock_object:
-        study.optimize(lambda t: t.suggest_uniform('p1', 0, 10), n_trials=1)
-        assert mock_object.call_count == 0
 
 
 def test_is_compatible():

--- a/tests/samplers_tests/test_samplers.py
+++ b/tests/samplers_tests/test_samplers.py
@@ -26,7 +26,7 @@ parametrize_sampler = pytest.mark.parametrize(
         optuna.samplers.RandomSampler,
         lambda: optuna.samplers.TPESampler(n_startup_trials=0),
         lambda: optuna.integration.SkoptSampler(skopt_kwargs={'n_initial_points': 1}),
-        lambda: optuna.integration.CmaEsSampler(0.1)
+        lambda: optuna.integration.CmaEsSampler()
     ])
 
 

--- a/tests/samplers_tests/test_samplers.py
+++ b/tests/samplers_tests/test_samplers.py
@@ -25,7 +25,8 @@ parametrize_sampler = pytest.mark.parametrize(
     [
         optuna.samplers.RandomSampler,
         lambda: optuna.samplers.TPESampler(n_startup_trials=0),
-        lambda: optuna.integration.SkoptSampler(skopt_kwargs={'n_initial_points': 1})
+        lambda: optuna.integration.SkoptSampler(skopt_kwargs={'n_initial_points': 1}),
+        lambda: optuna.integration.CmaEsSampler(0.1)
     ])
 
 


### PR DESCRIPTION
This PR adds a new sampler, which is based on the CMA-ES algorithm. This sampler is a thin wrapper of [pycma](https://github.com/CMA-ES/pycma/tree/master/cma).

## Benchmark Results

Settings:
- Problems: 38 ([sigopt/evalset/auc-test-suites](https://github.com/sigopt/evalset/blob/master/evalset/icml2016_tests.py#L83))
- Metrics: best objective vaalue (average of 100 studies)
- n_trials: 80

| Solver         | Borda | Firsts |
|:---------------|------:|-------:|
| (a) optuna#cma |    29 |     36 |
| (b) optuna#tpe |     2 |      9 |

See [this gist](https://gist.github.com/toshihikoyanase/6916751f1edb44fbe4804707731b2476) for further details.

## Opinions Wanted

*1. `sigma0` argument of `CmaEsSampler`*

`CmaEsSampler.__init__` requires `sigma0` argument, which is an initial standard deviation of CMA-ES ([see here for further details](https://github.com/CMA-ES/pycma/blob/master/cma/evolution_strategy.py#L1030)). It is problem dependent, and `pycma` does not provide default values. I simply followed the `pycma`, but it may not be user-friendly. If you have any questions or comments, please let me know.

*Current implementation*
As a result of offline discussion with @sile, I decided to use `range_of_variable / 6` as the default value for `sigma0`. This value is determined by the following comment on `sigma0`:

> [the optimum is expected to lie within about `x0` +- ``3*sigma0``](https://github.com/CMA-ES/pycma/blob/master/cma/evolution_strategy.py#L1030)

*2. Initial solution `x0`*

`CMAEvolutionStrategy` in `pycma` also has a required parameter [`x0`](https://github.com/CMA-ES/pycma/blob/master/cma/evolution_strategy.py#L1021), which is a starting point of search. `CmaEsSampler` uses the best trial as `x0` and does not provide the way to set the initial point externally. What do you think if I add a new argument to `CmaEsSampler.__init__` to set `x0`.

*Current implementation*
The default value of `x0` is determined by `mean(low, high)` to cover the range of variable with default `sigma0` value.