### PR TITLE
Add a type hint.

### DIFF
--- a/optuna/study.py
+++ b/optuna/study.py
@@ -365,7 +365,8 @@ class Study(BaseStudy):
                     column_agg[field].add((field, non_nested_field))
             records.append(record)
 
-        columns = sum((sorted(column_agg[k]) for k in structs.FrozenTrial._fields), [])
+        columns = sum((sorted(column_agg[k]) for k in structs.FrozenTrial._fields),
+                      [])  # type: List[Tuple['str', 'str']]
 
         return pd.DataFrame(records, columns=pd.MultiIndex.from_tuples(columns))
 


### PR DESCRIPTION
This PR fixes the error on type checking as can be seen in [here](https://circleci.com/gh/pfnet/optuna/15074).
The error message is about missing the type hint for the variable `columns`, and this PR simply adds it.
> optuna/study.py:368: error: Need type annotation for ‘columns’
