### PR TITLE
Fix document CI failure.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,7 +76,7 @@ jobs:
       - run:
           name: install
           command: |
-            python -m venv venv || virtualenv venv
+            python -m venv venv || virtualenv venv --python=python3
             . venv/bin/activate
             pip install .[document]
 


### PR DESCRIPTION
This PR fixes [the CI failure](https://circleci.com/gh/pfnet/optuna/15313) by changing the python version used for building the documentation to Python3.
For the cause of the failure, please see https://sourceforge.net/p/docutils/bugs/365/.