### PR TITLE
Change property access in TrialState for Python 3.4.

### DIFF
--- a/optuna/structs.py
+++ b/optuna/structs.py
@@ -30,7 +30,7 @@ class TrialState(enum.Enum):
     def is_finished(self):
         # type: () -> bool
 
-        return self != self.RUNNING
+        return self != TrialState.RUNNING
 
 
 class StudyDirection(enum.Enum):


### PR DESCRIPTION
This PR changes the way to access the `TrialState`'s property so that users can use Optuna on Python 3.4 in some way.