### PR TITLE
Add `intersection_search_space` function.

### DIFF
--- a/docs/source/reference/samplers.rst
+++ b/docs/source/reference/samplers.rst
@@ -14,4 +14,5 @@ Samplers
     :members:
     :exclude-members: infer_relative_search_space, sample_relative, sample_independent
 
+.. autofunction:: intersection_search_space
 .. autofunction:: product_search_space

--- a/optuna/integration/skopt.py
+++ b/optuna/integration/skopt.py
@@ -56,7 +56,7 @@ class SkoptSampler(BaseSampler):
             sampling. The parameters not contained in the relative search space are sampled
             by this sampler.
             The search space for :class:`~optuna.integration.SkoptSampler` is determined by
-            :func:`~optuna.samplers.product_search_space()`.
+            :func:`~optuna.samplers.intersection_search_space()`.
 
             If :obj:`None` is specified, :class:`~optuna.samplers.RandomSampler` is used
             as the default.
@@ -99,7 +99,7 @@ class SkoptSampler(BaseSampler):
         # type: (InTrialStudy, FrozenTrial) -> Dict[str, BaseDistribution]
 
         search_space = {}
-        for name, distribution in samplers.product_search_space(study).items():
+        for name, distribution in samplers.intersection_search_space(study).items():
             if distribution.single():
                 if not isinstance(distribution, distributions.CategoricalDistribution):
                     # `skopt` cannot handle non-categorical distributions that contain just
@@ -211,7 +211,7 @@ class _Optimizer(object):
     def _is_compatible(self, trial):
         # type: (FrozenTrial) -> bool
 
-        # Thanks to `product_search_space()` function, in sequential optimization,
+        # Thanks to `intersection_search_space()` function, in sequential optimization,
         # the parameters of complete trials are always compatible with the search space.
         #
         # However, in distributed optimization, incompatible trials may complete on a worker

--- a/optuna/samplers/__init__.py
+++ b/optuna/samplers/__init__.py
@@ -1,4 +1,7 @@
+import warnings
+
 import optuna
+from optuna import logging
 from optuna.samplers.base import BaseSampler  # NOQA
 from optuna.samplers.random import RandomSampler  # NOQA
 from optuna.samplers.tpe import TPESampler  # NOQA
@@ -10,11 +13,11 @@ if optuna.types.TYPE_CHECKING:
     from optuna.study import BaseStudy  # NOQA
 
 
-def product_search_space(study):
+def intersection_search_space(study):
     # type: (BaseStudy) -> Dict[str, BaseDistribution]
-    """Return the product search space of the :class:`~optuna.study.BaseStudy`.
+    """Return the intersection search space of the :class:`~optuna.study.BaseStudy`.
 
-    Product search space contains the product set of parameter distributions that have been
+    Intersection search space contains the intersection of parameter distributions that have been
     suggested in the completed trials of the study so far.
     If there are multiple parameters that have the same name but different distributions,
     neither is included in the resulting search space
@@ -44,3 +47,32 @@ def product_search_space(study):
             del search_space[param_name]
 
     return search_space or {}
+
+
+def product_search_space(study):
+    # type: (BaseStudy) -> Dict[str, BaseDistribution]
+    """Return the product search space of the :class:`~optuna.study.BaseStudy`.
+
+    **[NOTICE]**
+    This function is deprecated.
+    Please use :func:`~optuna.samplers.intersection_search_space` instead.
+
+    Product search space contains the product set of parameter distributions that have been
+    suggested in the completed trials of the study so far.
+    If there are multiple parameters that have the same name but different distributions,
+    neither is included in the resulting search space
+    (i.e., the parameters with dynamic value ranges are excluded).
+
+    Returns:
+        A dictionary containing the parameter names and parameter's distributions.
+    """
+
+    warnings.warn(
+        '`product_search_space` function is deprecated. '
+        'Please use `intersection_search_space` function instead.', DeprecationWarning)
+
+    logger = logging.get_logger(__name__)
+    logger.warning('`product_search_space` function is deprecated. '
+                   'Please use `intersection_search_space` function instead.')
+
+    return intersection_search_space(study)

--- a/optuna/samplers/__init__.py
+++ b/optuna/samplers/__init__.py
@@ -54,7 +54,6 @@ def product_search_space(study):
     """Return the product search space of the :class:`~optuna.study.BaseStudy`.
 
     .. deprecated:: 0.14.0
-        This function is a deprecated alias of :func:`~optuna.samplers.intersection_search_space`.
         Please use :func:`~optuna.samplers.intersection_search_space` instead.
     """
 

--- a/optuna/samplers/__init__.py
+++ b/optuna/samplers/__init__.py
@@ -53,18 +53,9 @@ def product_search_space(study):
     # type: (BaseStudy) -> Dict[str, BaseDistribution]
     """Return the product search space of the :class:`~optuna.study.BaseStudy`.
 
-    **[NOTICE]**
-    This function is deprecated.
-    Please use :func:`~optuna.samplers.intersection_search_space` instead.
-
-    Product search space contains the product set of parameter distributions that have been
-    suggested in the completed trials of the study so far.
-    If there are multiple parameters that have the same name but different distributions,
-    neither is included in the resulting search space
-    (i.e., the parameters with dynamic value ranges are excluded).
-
-    Returns:
-        A dictionary containing the parameter names and parameter's distributions.
+    .. deprecated:: 0.14.0
+        This function is a deprecated alias of :func:`~optuna.samplers.intersection_search_space`.
+        Please use :func:`~optuna.samplers.intersection_search_space` instead.
     """
 
     warnings.warn(

--- a/optuna/samplers/base.py
+++ b/optuna/samplers/base.py
@@ -49,8 +49,8 @@ class BaseSampler(object):
             A dictionary containing the parameter names and parameter's distributions.
 
         .. seealso::
-            Please refer to :func:`~optuna.samplers.product_search_space` as an implementation of
-            :func:`~optuna.samplers.BaseSampler.infer_relative_search_space`.
+            Please refer to :func:`~optuna.samplers.intersection_search_space` as an
+            implementation of :func:`~optuna.samplers.BaseSampler.infer_relative_search_space`.
         """
 
         raise NotImplementedError

--- a/tests/integration_tests/test_skopt.py
+++ b/tests/integration_tests/test_skopt.py
@@ -202,7 +202,7 @@ def test_is_compatible():
     study = optuna.create_study(sampler=sampler)
 
     study.optimize(lambda t: t.suggest_uniform('p0', 0, 10), n_trials=1)
-    search_space = optuna.samplers.product_search_space(study)
+    search_space = optuna.samplers.intersection_search_space(study)
     assert search_space == {'p0': distributions.UniformDistribution(low=0, high=10)}
 
     optimizer = optuna.integration.skopt._Optimizer(search_space, {})

--- a/tests/samplers_tests/test_samplers.py
+++ b/tests/samplers_tests/test_samplers.py
@@ -213,6 +213,46 @@ def test_sample_relative():
         assert trial.params == {'a': 3.2, 'b': 'baz', 'c': 30, 'd': 30, 'e': 30}
 
 
+def test_intersection_search_space():
+    # type: () -> None
+
+    study = optuna.create_study()
+
+    # No trial.
+    assert optuna.samplers.intersection_search_space(study) == {}
+
+    # First trial.
+    study.optimize(lambda t: t.suggest_int('x', 0, 10) + t.suggest_uniform('y', -3, 3), n_trials=1)
+    assert optuna.samplers.intersection_search_space(study) == {
+        'x': IntUniformDistribution(low=0, high=10),
+        'y': UniformDistribution(low=-3, high=3)
+    }
+
+    # Second trial (only 'y' parameter is suggested in this trial).
+    study.optimize(lambda t: t.suggest_uniform('y', -3, 3), n_trials=1)
+    assert optuna.samplers.intersection_search_space(study) == {
+        'y': UniformDistribution(low=-3, high=3)
+    }
+
+    # Failed or pruned trials are not considered in the calculation of a product search space.
+    def objective(trial, exception):
+        # type: (optuna.trial.Trial, Exception) -> float
+
+        trial.suggest_uniform('z', 0, 1)
+        raise exception
+
+    study.optimize(lambda t: objective(t, RuntimeError()), n_trials=1)
+    study.optimize(lambda t: objective(t, optuna.structs.TrialPruned()), n_trials=1)
+    assert optuna.samplers.intersection_search_space(study) == {
+        'y': UniformDistribution(low=-3, high=3)
+    }
+
+    # If two parameters have the same name but different distributions,
+    # those are regarded as different trials.
+    study.optimize(lambda t: t.suggest_uniform('y', -1, 1), n_trials=1)
+    assert optuna.samplers.intersection_search_space(study) == {}
+
+
 def test_product_search_space():
     # type: () -> None
 


### PR DESCRIPTION
This PR adds `intersection_search_space` function and deprecates `product_search_space`.
The new function has the same functionality as `product_search_space` but, we think, the name `intersection_search_space` is more friendly for many users.