### PR TITLE
Make tpe faster

### DIFF
--- a/optuna/samplers/tpe/sampler.py
+++ b/optuna/samplers/tpe/sampler.py
@@ -85,17 +85,15 @@ class TPESampler(base.BaseSampler):
     def sample_independent(self, study, trial, param_name, param_distribution):
         # type: (InTrialStudy, FrozenTrial, str, BaseDistribution) -> Any
 
-        observation_pairs = _get_observation_pairs(study, param_name)
+        values, scores = _get_observation_pairs(study, param_name)
 
-        n = len(observation_pairs)
+        n = len(values)
 
         if n < self.n_startup_trials:
             return self.random_sampler.sample_independent(
                 study, trial, param_name, param_distribution)
 
-        below_param_values, above_param_values = self._split_observation_pairs(
-            list(range(n)), [p[0] for p in observation_pairs], list(range(n)),
-            [p[1] for p in observation_pairs])
+        below_param_values, above_param_values = self._split_observation_pairs(values, scores)
 
         if isinstance(param_distribution, distributions.UniformDistribution):
             return self._sample_uniform(param_distribution, below_param_values, above_param_values)
@@ -126,28 +124,18 @@ class TPESampler(base.BaseSampler):
 
     def _split_observation_pairs(
             self,
-            config_idxs,  # type: List[int]
             config_vals,  # type: List[float]
-            loss_idxs,  # type: List[int]
             loss_vals  # type: List[Tuple[float, float]]
     ):
         # type: (...) -> Tuple[np.ndarray, np.ndarray]
 
-        config_idxs, config_vals, loss_idxs = map(
-            np.asarray, [config_idxs, config_vals, loss_idxs])
+        config_vals = np.asarray(config_vals)
         loss_vals = np.asarray(loss_vals, dtype=[('step', float), ('score', float)])
 
         n_below = self.gamma(len(config_vals))
         loss_ascending = np.argsort(loss_vals)
-
-        keep_idxs = set(loss_idxs[loss_ascending[:n_below]])
-        below = [v for i, v in zip(config_idxs, config_vals) if i in keep_idxs]
-
-        keep_idxs = set(loss_idxs[loss_ascending[n_below:]])
-        above = [v for i, v in zip(config_idxs, config_vals) if i in keep_idxs]
-
-        below = np.asarray(below, dtype=float)
-        above = np.asarray(above, dtype=float)
+        below = config_vals[np.sort(loss_ascending[:n_below])]
+        above = config_vals[np.sort(loss_ascending[n_below:])]
         return below, above
 
     def _sample_uniform(self, distribution, below, above):
@@ -450,7 +438,7 @@ class TPESampler(base.BaseSampler):
 
 
 def _get_observation_pairs(study, param_name):
-    # type: (InTrialStudy, str) -> List[Tuple[float, Tuple[float, float]]]
+    # type: (InTrialStudy, str) -> Tuple[[float], Tuple[float, float]]
     """Get observation pairs from the study.
 
        This function collects observation pairs from the complete or pruned trials of the study.
@@ -473,7 +461,8 @@ def _get_observation_pairs(study, param_name):
     if study.direction == StudyDirection.MAXIMIZE:
         sign = -1
 
-    pairs = []
+    values = []
+    scores = []
     for trial in study.trials:
         if param_name not in trial.params_in_internal_repr:
             continue
@@ -490,6 +479,7 @@ def _get_observation_pairs(study, param_name):
             continue
 
         param_value = trial.params_in_internal_repr[param_name]
-        pairs.append((param_value, score))
+        values.append(param_value)
+        scores.append(score)
 
-    return pairs
+    return values, scores

--- a/optuna/samplers/tpe/sampler.py
+++ b/optuna/samplers/tpe/sampler.py
@@ -486,7 +486,7 @@ class TPESampler(base.BaseSampler):
 
 
 def _get_observation_pairs(study, param_name):
-    # type: (InTrialStudy, str) -> Tuple[[float], Tuple[float, float]]
+    # type: (InTrialStudy, str) -> Tuple[List[float], List[Tuple[float, float]]]
     """Get observation pairs from the study.
 
        This function collects observation pairs from the complete or pruned trials of the study.

--- a/tests/samplers_tests/tpe_tests/test_sampler.py
+++ b/tests/samplers_tests/tpe_tests/test_sampler.py
@@ -42,12 +42,14 @@ def test_get_observation_pairs():
 
     in_trial_study = InTrialStudy(study)
 
-    assert tpe.sampler._get_observation_pairs(in_trial_study, 'x') == [
-        (5.0, (-float('inf'), 5.0)),  # COMPLETE
-        (5.0, (-7, 2)),  # PRUNED (with intermediate values)
-        (5.0, (float('inf'), 0.0))  # PRUNED (without intermediate values)
-    ]
-    assert tpe.sampler._get_observation_pairs(in_trial_study, 'y') == []
+    assert tpe.sampler._get_observation_pairs(in_trial_study, 'x') == (
+        [5.0, 5.0, 5.0],
+        [
+            (-float('inf'), 5.0),   # COMPLETE
+            (-7, 2),  # PRUNED (with intermediate values)
+            (float('inf'), 0.0)  # PRUNED (without intermediate values)
+        ])
+    assert tpe.sampler._get_observation_pairs(in_trial_study, 'y') == ([], [])
 
     # direction=maximize.
     study = optuna.create_study(direction='maximize')
@@ -56,9 +58,11 @@ def test_get_observation_pairs():
 
     in_trial_study = InTrialStudy(study)
 
-    assert tpe.sampler._get_observation_pairs(in_trial_study, 'x') == [
-        (5.0, (-float('inf'), -5.0)),  # COMPLETE
-        (5.0, (-7, -2)),  # PRUNED (with intermediate values)
-        (5.0, (float('inf'), 0.0))  # PRUNED (without intermediate values)
-    ]
-    assert tpe.sampler._get_observation_pairs(in_trial_study, 'y') == []
+    assert tpe.sampler._get_observation_pairs(in_trial_study, 'x') ==  (
+        [5.0, 5.0, 5.0],
+        [
+            (-float('inf'), -5.0),   # COMPLETE
+            (-7, -2),  # PRUNED (with intermediate values)
+            (float('inf'), 0.0)  # PRUNED (without intermediate values)
+        ])
+    assert tpe.sampler._get_observation_pairs(in_trial_study, 'y') == ([], [])

--- a/tests/samplers_tests/tpe_tests/test_sampler.py
+++ b/tests/samplers_tests/tpe_tests/test_sampler.py
@@ -58,7 +58,7 @@ def test_get_observation_pairs():
 
     in_trial_study = InTrialStudy(study)
 
-    assert tpe.sampler._get_observation_pairs(in_trial_study, 'x') ==  (
+    assert tpe.sampler._get_observation_pairs(in_trial_study, 'x') == (
         [5.0, 5.0, 5.0],
         [
             (-float('inf'), -5.0),   # COMPLETE


### PR DESCRIPTION
Hi,
I wrote a simple patch to refactor TPE.
It approximately makes the speed of TPE 10 times faster and makes it easier to read.
When using TPE for 10,000 trials with two parameters, it used to take 2 hours, but with this, it takes less than 15 minutes.