### PR TITLE
Reduce CI time.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,10 +22,10 @@ workflows:
     jobs:
       - checks
       - document
-      - tests-python37
-      - tests-python36
-      - tests-python35
-      - tests-python27
+      - tests-python37-slow
+      - tests-python36-slow
+      - tests-python35-slow
+      - tests-python27-slow
       - examples-python37
       - examples-python36
       - examples-python35
@@ -142,6 +142,49 @@ jobs:
       - image: circleci/python:2.7
     steps:
       [checkout, run: *install, run: *tests, run: *tests-mn]
+
+  tests-python37-slow:
+    docker:
+      - image: circleci/python:3.7
+    steps:
+      - checkout
+
+      - run: *install
+      - run: &tests-slow
+          name: tests-slow
+          command: |
+            . venv/bin/activate
+            pytest tests
+          environment:
+            OMP_NUM_THREADS: 1
+            INCLUDE_SLOW_TESTS: 1
+
+      - run: &tests-mn-slow
+          name: tests-mn-slow
+          command: |
+            . venv/bin/activate
+            mpirun -n 2 -- pytest tests/integration_tests/test_chainermn.py
+          environment:
+            OMP_NUM_THREADS: 1
+            INCLUDE_SLOW_TESTS: 1
+
+  tests-python36-slow:
+    docker:
+      - image: circleci/python:3.6
+    steps:
+      [checkout, run: *install, run: *tests-slow, run: *tests-mn-slow]
+
+  tests-python35-slow:
+    docker:
+      - image: circleci/python:3.5
+    steps:
+      [checkout, run: *install, run: *tests-slow, run: *tests-mn-slow]
+
+  tests-python27-slow:
+    docker:
+      - image: circleci/python:2.7
+    steps:
+      [checkout, run: *install, run: *tests-slow, run: *tests-mn-slow]
 
   codecov:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,10 +22,10 @@ workflows:
     jobs:
       - checks
       - document
-      - tests-python37-slow
-      - tests-python36-slow
-      - tests-python35-slow
-      - tests-python27-slow
+      - tests-python37-full
+      - tests-python36-full
+      - tests-python35-full
+      - tests-python27-full
       - examples-python37
       - examples-python36
       - examples-python35
@@ -143,15 +143,15 @@ jobs:
     steps:
       [checkout, run: *install, run: *tests, run: *tests-mn]
 
-  tests-python37-slow:
+  tests-python37-full:
     docker:
       - image: circleci/python:3.7
     steps:
       - checkout
 
       - run: *install
-      - run: &tests-slow
-          name: tests-slow
+      - run: &tests-full
+          name: tests-full
           command: |
             . venv/bin/activate
             pytest tests
@@ -159,8 +159,8 @@ jobs:
             OMP_NUM_THREADS: 1
             INCLUDE_SLOW_TESTS: 1
 
-      - run: &tests-mn-slow
-          name: tests-mn-slow
+      - run: &tests-mn-full
+          name: tests-mn-full
           command: |
             . venv/bin/activate
             mpirun -n 2 -- pytest tests/integration_tests/test_chainermn.py
@@ -168,23 +168,23 @@ jobs:
             OMP_NUM_THREADS: 1
             INCLUDE_SLOW_TESTS: 1
 
-  tests-python36-slow:
+  tests-python36-full:
     docker:
       - image: circleci/python:3.6
     steps:
-      [checkout, run: *install, run: *tests-slow, run: *tests-mn-slow]
+      [checkout, run: *install, run: *tests-full, run: *tests-mn-full]
 
-  tests-python35-slow:
+  tests-python35-full:
     docker:
       - image: circleci/python:3.5
     steps:
-      [checkout, run: *install, run: *tests-slow, run: *tests-mn-slow]
+      [checkout, run: *install, run: *tests-full, run: *tests-mn-full]
 
-  tests-python27-slow:
+  tests-python27-full:
     docker:
       - image: circleci/python:2.7
     steps:
-      [checkout, run: *install, run: *tests-slow, run: *tests-mn-slow]
+      [checkout, run: *install, run: *tests-full, run: *tests-mn-full]
 
   codecov:
     docker:

--- a/tests/integration_tests/test_chainermn.py
+++ b/tests/integration_tests/test_chainermn.py
@@ -1,4 +1,5 @@
 import gc
+import os
 import pytest
 
 from optuna import create_study
@@ -39,7 +40,11 @@ except ImportError:
 
 STORAGE_MODES = ['new', 'common']
 PRUNER_INIT_FUNCS = [lambda: pruners.MedianPruner(), lambda: pruners.SuccessiveHalvingPruner()]
-CACHE_MODES = [True, False]
+
+if os.getenv('INCLUDE_SLOW_TESTS') is None:
+    CACHE_MODES = [True]
+else:
+    CACHE_MODES = [True, False]
 
 
 def setup_module():

--- a/tests/test_study.py
+++ b/tests/test_study.py
@@ -1,5 +1,6 @@
 import itertools
 import multiprocessing
+import os
 import pandas as pd
 import pickle
 import pytest
@@ -23,7 +24,14 @@ STORAGE_MODES = [
     'common',  # We use a sqlite DB file for the whole experiments.
 ]
 
-CACHE_MODES = [True, False]
+if os.getenv('INCLUDE_SLOW_TESTS') is None:
+    MAX_N_TRIALS = 20
+    N_JOBS_LIST = [1, 2]
+    CACHE_MODES = [True]
+else:
+    MAX_N_TRIALS = 50
+    N_JOBS_LIST = [1, 2, 10, -1]
+    CACHE_MODES = [True, False]
 
 
 def setup_module():
@@ -159,8 +167,8 @@ def test_optimize_with_direction():
 @pytest.mark.parametrize(
     'n_trials, n_jobs, storage_mode, cache_mode',
     itertools.product(
-        (0, 1, 2, 50),  # n_trials
-        (1, 2, 10, -1),  # n_jobs
+        (0, 1, 2, MAX_N_TRIALS),  # n_trials
+        N_JOBS_LIST,  # n_jobs
         STORAGE_MODES,  # storage_mode
         CACHE_MODES,  # cache_mode
     ))
@@ -179,8 +187,8 @@ def test_optimize_parallel(n_trials, n_jobs, storage_mode, cache_mode):
 @pytest.mark.parametrize(
     'n_trials, n_jobs, storage_mode, cache_mode',
     itertools.product(
-        (0, 1, 2, 50, None),  # n_trials
-        (1, 2, 10, -1),  # n_jobs
+        (0, 1, 2, MAX_N_TRIALS, None),  # n_trials
+        N_JOBS_LIST,  # n_jobs
         STORAGE_MODES,  # storage_mode
         CACHE_MODES,  # cache_mode
     ))


### PR DESCRIPTION
This PR excludes unimportant and heavy tests (e.g., highly parallel test, cache disabled storage test) from per commit CI target.
Besides, this PR adds `tests-python*-full` circle CI jobs. Those jobs execute full test cases and are triggered only by daily CIs.

The following result shows this PR reduces the execution time of per commit CI by about half:
```console
$ time -p circleci build --job tests-python37-full
...
Success!
real 1082.75
user 0.07
sys 0.09

$ time -p circleci build --job tests-python37
$ Success!
...
real 522.46
user 0.14
sys 0.04