### PR TITLE
Add NaN intermediate value handling to `TPESampler`.

### DIFF
--- a/optuna/samplers/tpe/sampler.py
+++ b/optuna/samplers/tpe/sampler.py
@@ -1,3 +1,4 @@
+import math
 import numpy as np
 import scipy.special
 
@@ -520,7 +521,10 @@ def _get_observation_pairs(study, param_name):
         elif trial.state is structs.TrialState.PRUNED:
             if len(trial.intermediate_values) > 0:
                 step, intermediate_value = max(trial.intermediate_values.items())
-                score = (-step, sign * intermediate_value)
+                if math.isnan(intermediate_value):
+                    score = (-step, float('inf'))
+                else:
+                    score = (-step, sign * intermediate_value)
             else:
                 score = (float('inf'), 0.0)
         else:

--- a/tests/samplers_tests/tpe_tests/test_sampler.py
+++ b/tests/samplers_tests/tpe_tests/test_sampler.py
@@ -31,22 +31,26 @@ def test_get_observation_pairs():
             trial.report(2, 7)
             raise TrialPruned()
         elif trial.number == 2:
+            trial.report(float('nan'), 3)
+            raise TrialPruned()
+        elif trial.number == 3:
             raise TrialPruned()
         else:
             raise RuntimeError()
 
     # direction=minimize.
     study = optuna.create_study(direction='minimize')
-    study.optimize(objective, n_trials=4)
+    study.optimize(objective, n_trials=5)
     study.storage.create_new_trial_id(study.study_id)  # Create a running trial.
 
     in_trial_study = InTrialStudy(study)
 
     assert tpe.sampler._get_observation_pairs(in_trial_study, 'x') == (
-        [5.0, 5.0, 5.0],
+        [5.0, 5.0, 5.0, 5.0],
         [
             (-float('inf'), 5.0),   # COMPLETE
             (-7, 2),  # PRUNED (with intermediate values)
+            (-3, float('inf')),  # PRUNED (with a NaN intermediate value; it's treated as infinity)
             (float('inf'), 0.0)  # PRUNED (without intermediate values)
         ])
     assert tpe.sampler._get_observation_pairs(in_trial_study, 'y') == ([], [])
@@ -59,10 +63,11 @@ def test_get_observation_pairs():
     in_trial_study = InTrialStudy(study)
 
     assert tpe.sampler._get_observation_pairs(in_trial_study, 'x') == (
-        [5.0, 5.0, 5.0],
+        [5.0, 5.0, 5.0, 5.0],
         [
             (-float('inf'), -5.0),   # COMPLETE
             (-7, -2),  # PRUNED (with intermediate values)
+            (-3, float('inf')),  # PRUNED (with a NaN intermediate value; it's treated as infinity)
             (float('inf'), 0.0)  # PRUNED (without intermediate values)
         ])
     assert tpe.sampler._get_observation_pairs(in_trial_study, 'y') == ([], [])


### PR DESCRIPTION
By this PR, `TPESampler` becomes to be able to handle trials that contain NaN intermediate values.