### PR TITLE
Prevent TensorFlowPruningHook from reporting None.

### DIFF
--- a/optuna/integration/tensorflow.py
+++ b/optuna/integration/tensorflow.py
@@ -97,6 +97,8 @@ class TensorFlowPruningHook(SessionRunHook):
             # If there exists a new evaluation summary.
             if summary_step > self.current_summary_step:
                 current_score = latest_eval_metrics[self.metric]
+                if current_score is None:
+                    current_score = float('nan')
                 self.trial.report(current_score, step=summary_step)
                 self.current_summary_step = summary_step
             if self.trial.should_prune():


### PR DESCRIPTION
Current `oputna.integration.TensorFlowPruningHook` reports `None` as an intermediate value when the returned value of `tensorflow_estimator.python.estimator.early_stopping.read_eval_metrics` contains `None`. The intermediate values should be `float`, and some samplers will cause errors when they encounter non-float values (e.g., [TPESampler](https://github.com/pfnet/optuna/blob/master/optuna/samplers/tpe/sampler.py#L523)).

This PR converts `None` to `NaN` before reporting it as an intermediate value.