### PR TITLE
Reduce a query count of PercentilePruner and MedianPruner

### DIFF
--- a/optuna/pruners/percentile.py
+++ b/optuna/pruners/percentile.py
@@ -4,7 +4,8 @@ import numpy as np
 from optuna.pruners import BasePruner
 from optuna.structs import StudyDirection
 from optuna.structs import TrialState
-from optuna import types, structs
+from optuna import structs
+from optuna import types
 
 if types.TYPE_CHECKING:
     from optuna.storages import BaseStorage  # NOQA

--- a/optuna/pruners/percentile.py
+++ b/optuna/pruners/percentile.py
@@ -6,16 +6,38 @@ from optuna import structs
 from optuna import types
 
 if types.TYPE_CHECKING:
+    from typing import List  # NOQA
+
     from optuna.storages import BaseStorage  # NOQA
 
 
-def get_best_intermediate_result_over_steps(trial, direction):
+def _get_best_intermediate_result_over_steps(trial, direction):
     # type: (structs.FrozenTrial, structs.StudyDirection) -> float
 
     values = np.array(list(trial.intermediate_values.values()), np.float)
     if direction == structs.StudyDirection.MAXIMIZE:
         return np.nanmax(values)
     return np.nanmin(values)
+
+
+def _get_percentile_intermediate_result_over_trials(all_trials, direction, step, percentile):
+    # type: (List[structs.FrozenTrial], structs.StudyDirection, int, float) -> float
+
+    completed_trials = [t for t in all_trials if t.state == structs.TrialState.COMPLETE]
+
+    if len(completed_trials) == 0:
+        raise ValueError("No trials have been completed.")
+
+    if direction == structs.StudyDirection.MAXIMIZE:
+        percentile = 100 - percentile
+
+    return float(
+        np.nanpercentile(
+            np.array([
+                t.intermediate_values[step]
+                for t in completed_trials if step in t.intermediate_values
+            ], np.float),
+            percentile))
 
 
 class PercentilePruner(BasePruner):
@@ -73,11 +95,13 @@ class PercentilePruner(BasePruner):
             return False
 
         direction = storage.get_study_direction(study_id)
-        best_intermediate_result = get_best_intermediate_result_over_steps(trial, direction)
+        best_intermediate_result = _get_best_intermediate_result_over_steps(trial, direction)
         if math.isnan(best_intermediate_result):
             return True
 
-        p = storage.get_percentile_intermediate_result_over_trials(study_id, step, self.percentile)
+        all_trials = storage.get_all_trials(study_id)
+        p = _get_percentile_intermediate_result_over_trials(
+            all_trials, direction, step, self.percentile)
         if math.isnan(p):
             return False
 

--- a/optuna/pruners/percentile.py
+++ b/optuna/pruners/percentile.py
@@ -2,8 +2,6 @@ import math
 import numpy as np
 
 from optuna.pruners import BasePruner
-from optuna.structs import StudyDirection
-from optuna.structs import TrialState
 from optuna import structs
 from optuna import types
 
@@ -59,7 +57,7 @@ class PercentilePruner(BasePruner):
         # type: (BaseStorage, int, int, int) -> bool
         """Please consult the documentation for :func:`BasePruner.prune`."""
 
-        n_trials = storage.get_n_trials(study_id, TrialState.COMPLETE)
+        n_trials = storage.get_n_trials(study_id, structs.TrialState.COMPLETE)
 
         if n_trials == 0:
             return False
@@ -83,6 +81,6 @@ class PercentilePruner(BasePruner):
         if math.isnan(p):
             return False
 
-        if direction == StudyDirection.MAXIMIZE:
+        if direction == structs.StudyDirection.MAXIMIZE:
             return best_intermediate_result < p
         return best_intermediate_result > p

--- a/optuna/storages/base.py
+++ b/optuna/storages/base.py
@@ -1,9 +1,7 @@
 import abc
-import numpy as np
 import six
 
-from optuna import distributions  # NOQA
-from optuna import structs  # NOQA
+from optuna import structs
 from optuna import types
 
 if types.TYPE_CHECKING:
@@ -11,6 +9,8 @@ if types.TYPE_CHECKING:
     from typing import Dict  # NOQA
     from typing import List  # NOQA
     from typing import Optional  # NOQA
+
+    from optuna import distributions  # NOQA
 
 DEFAULT_STUDY_NAME_PREFIX = 'no-name-'
 
@@ -198,30 +198,6 @@ class BaseStorage(object):
         # type: (int) -> Dict[str, Any]
 
         return self.get_trial(trial_id).system_attrs
-
-    # Methods for PercentilePruner and MedianPruner
-
-    def get_percentile_intermediate_result_over_trials(self, study_id, step, percentile):
-        # type: (int, int, float) -> float
-
-        all_trials = [
-            t for t in self.get_all_trials(study_id) if t.state == structs.TrialState.COMPLETE
-        ]
-
-        if len(all_trials) == 0:
-            raise ValueError("No trials have been completed.")
-
-        direction = self.get_study_direction(study_id)
-        if direction == structs.StudyDirection.MAXIMIZE:
-            percentile = 100 - percentile
-
-        return float(
-            np.nanpercentile(
-                np.array([
-                    t.intermediate_values[step]
-                    for t in all_trials if step in t.intermediate_values
-                ], np.float),
-                percentile))
 
     def remove_session(self):
         # type: () -> None

--- a/optuna/storages/base.py
+++ b/optuna/storages/base.py
@@ -201,16 +201,6 @@ class BaseStorage(object):
 
     # Methods for PercentilePruner and MedianPruner
 
-    def get_best_intermediate_result_over_steps(self, trial_id):
-        # type: (int) -> float
-
-        values = np.array(list(self.get_trial(trial_id).intermediate_values.values()), np.float)
-
-        study_id = self.get_study_id_from_trial_id(trial_id)
-        if self.get_study_direction(study_id) == structs.StudyDirection.MAXIMIZE:
-            return np.nanmax(values)
-        return np.nanmin(values)
-
     def get_percentile_intermediate_result_over_trials(self, study_id, step, percentile):
         # type: (int, int, float) -> float
 

--- a/tests/pruners_tests/test_percentile.py
+++ b/tests/pruners_tests/test_percentile.py
@@ -1,8 +1,11 @@
+import math
+
 import pytest
 
 import optuna
-from optuna.structs import TrialState
+from optuna.structs import TrialState, StudyDirection
 from optuna import types
+from optuna.pruners.percentile import get_best_intermediate_result_over_steps
 
 if types.TYPE_CHECKING:
     from typing import List  # NOQA
@@ -74,3 +77,46 @@ def test_25_percentile_pruner_intermediate_values_nan():
     # A pruner is not activated if the 25 percentile intermediate value is NaN.
     assert not pruner.prune(
         storage=study.storage, study_id=study.study_id, trial_id=trial._trial_id, step=1)
+
+
+@pytest.mark.parametrize('direction_expected', [(StudyDirection.MINIMIZE, 0.1),
+                                                (StudyDirection.MAXIMIZE, 0.2)])
+def test_get_best_intermediate_result_over_steps(direction_expected):
+    # type: (Tuple[StudyDirection, float]) -> None
+
+    direction, expected = direction_expected
+
+    if direction == StudyDirection.MINIMIZE:
+        study = optuna.study.create_study(direction="minimize")
+    else:
+        study = optuna.study.create_study(direction="maximize")
+
+    # FrozenTrial.intermediate_values has no elements.
+    trial_id_empty = study.storage.create_new_trial_id(study.study_id)
+    trial_empty = study.storage.get_trial(trial_id_empty)
+
+    with pytest.raises(ValueError):
+        get_best_intermediate_result_over_steps(trial_empty, direction)
+
+    # Input value has no NaNs but float values.
+    trial_id_float = study.storage.create_new_trial_id(study.study_id)
+    trial_float = optuna.trial.Trial(study, trial_id_float)
+    trial_float.report(0.1, step=0)
+    trial_float.report(0.2, step=1)
+    frozen_trial_float = study.storage.get_trial(trial_id_float)
+    assert expected == get_best_intermediate_result_over_steps(frozen_trial_float, direction)
+
+    # Input value has a float value and a NaN.
+    trial_id_float_nan = study.storage.create_new_trial_id(study.study_id)
+    trial_float_nan = optuna.trial.Trial(study, trial_id_float_nan)
+    trial_float_nan.report(0.3, step=0)
+    trial_float_nan.report(float('nan'), step=1)
+    frozen_trial_float_nan = study.storage.get_trial(trial_id_float_nan)
+    assert 0.3 == get_best_intermediate_result_over_steps(frozen_trial_float_nan, direction)
+
+    # Input value has a NaN only.
+    trial_id_nan = study.storage.create_new_trial_id(study.study_id)
+    trial_nan = optuna.trial.Trial(study, trial_id_nan)
+    trial_nan.report(float('nan'), step=0)
+    frozen_trial_nan = study.storage.get_trial(trial_id_nan)
+    assert math.isnan(get_best_intermediate_result_over_steps(frozen_trial_nan, direction))

--- a/tests/pruners_tests/test_percentile.py
+++ b/tests/pruners_tests/test_percentile.py
@@ -1,11 +1,11 @@
 import math
-
 import pytest
 
 import optuna
-from optuna.structs import TrialState, StudyDirection
-from optuna import types
 from optuna.pruners.percentile import get_best_intermediate_result_over_steps
+from optuna.structs import StudyDirection
+from optuna.structs import TrialState
+from optuna import types
 
 if types.TYPE_CHECKING:
     from typing import List  # NOQA

--- a/tests/storages_tests/test_storages.py
+++ b/tests/storages_tests/test_storages.py
@@ -626,41 +626,6 @@ def test_get_n_trials(storage_init_func):
 
 
 @parametrize_storage
-@pytest.mark.parametrize('direction_expected', [(StudyDirection.MINIMIZE, 0.1),
-                                                (StudyDirection.MAXIMIZE, 0.2)])
-def test_get_best_intermediate_result_over_steps(storage_init_func, direction_expected):
-    # type: (Callable[[], BaseStorage], Tuple[StudyDirection, float]) -> None
-
-    direction, expected = direction_expected
-
-    storage = storage_init_func()
-    study_id = storage.create_new_study_id()
-    storage.set_study_direction(study_id, direction)
-
-    # FrozenTrial.intermediate_values has no elements.
-    trial_id_empty = storage.create_new_trial_id(study_id)
-    with pytest.raises(ValueError):
-        storage.get_best_intermediate_result_over_steps(trial_id_empty)
-
-    # Input value has no NaNs but float values.
-    trial_id_float = storage.create_new_trial_id(study_id)
-    storage.set_trial_intermediate_value(trial_id_float, 0, 0.1)
-    storage.set_trial_intermediate_value(trial_id_float, 1, 0.2)
-    assert expected == storage.get_best_intermediate_result_over_steps(trial_id_float)
-
-    # Input value has a float value and a NaN.
-    trial_id_float_nan = storage.create_new_trial_id(study_id)
-    storage.set_trial_intermediate_value(trial_id_float_nan, 0, 0.3)
-    storage.set_trial_intermediate_value(trial_id_float_nan, 1, float('nan'))
-    assert 0.3 == storage.get_best_intermediate_result_over_steps(trial_id_float_nan)
-
-    # Input value has a NaN only.
-    trial_id_nan = storage.create_new_trial_id(study_id)
-    storage.set_trial_intermediate_value(trial_id_nan, 0, float('nan'))
-    assert math.isnan(storage.get_best_intermediate_result_over_steps(trial_id_nan))
-
-
-@parametrize_storage
 def test_get_percentile_intermediate_result_over_trials(storage_init_func):
     # type: (Callable[[], BaseStorage]) -> None
 


### PR DESCRIPTION
Pass FrozenTrial and StudyDirection to get best intermediate result. And this change make it avoids to define `get_best_intermediate_result_over_steps` (which is only for PercentilePruner) in storage package.