### PR TITLE
Reduce memory usage of CatBoost example.

### DIFF
--- a/examples/catboost_simple.py
+++ b/examples/catboost_simple.py
@@ -34,10 +34,11 @@ def objective(trial):
     param = {
         'objective': trial.suggest_categorical('objective', ['Logloss', 'CrossEntropy']),
         'colsample_bylevel': trial.suggest_uniform('colsample_bylevel', 0.01, 0.1),
-        'depth': trial.suggest_int('depth', 1, 16),
+        'depth': trial.suggest_int('depth', 1, 12),
         'boosting_type': trial.suggest_categorical('boosting_type', ['Ordered', 'Plain']),
         'bootstrap_type': trial.suggest_categorical('bootstrap_type',
-                                                    ['Bayesian', 'Bernoulli', 'MVS'])
+                                                    ['Bayesian', 'Bernoulli', 'MVS']),
+        'used_ram_limit': '3gb'
     }
 
     if param['bootstrap_type'] == 'Bayesian':


### PR DESCRIPTION
After merging https://github.com/pfnet/optuna/pull/477, the daily CI of Optuna became to fail occasionally due to memory shortage (see: https://circleci.com/gh/pfnet/optuna/16916).

This PR aims to reduce memory usage of `catboost_simple.py` by applying the following changes:
- Changes the max value of `depth` parameter from 16 to 12
- Adds `'used_ram_limit': '3gb'` option (note that this isn't a hard limit)