### PR TITLE
Disable dask-ml example if the Python version is 2.7.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -230,7 +230,7 @@ jobs:
           name: examples
           command: |
             . venv/bin/activate
-            for file in `find examples -name '*.py' -not -name 'chainermn_*.py'`
+            for file in `find examples -name '*.py' -not -name 'chainermn_*.py' -not -name 'dask_ml*.py'`
             do
                python $file
             done
@@ -250,17 +250,26 @@ jobs:
           environment:
             OMP_NUM_THREADS: 1
 
+      - run: &examples-dask-ml
+          name: examples-dask-ml
+          command: |
+            . venv/bin/activate
+            for file in `find examples -name 'dask_ml*.py'`
+            do
+               python $file
+            done
+
   examples-python36:
     docker:
       - image: circleci/python:3.6
     steps:
-      [checkout, run: *install, run: *install-examples, run: *examples, run: *examples-mn]
+      [checkout, run: *install, run: *install-examples, run: *examples, run: *examples-mn, run: *examples-dask-ml]
 
   examples-python35:
     docker:
       - image: circleci/python:3.5
     steps:
-      [checkout, run: *install, run: *install-examples, run: *examples, run: *examples-mn]
+      [checkout, run: *install, run: *install-examples, run: *examples, run: *examples-mn, run: *examples-dask-ml]
 
   examples-python27:
     docker:


### PR DESCRIPTION
This PR fixes [the CI failure](https://circleci.com/gh/pfnet/optuna/16939).

FYI: https://github.com/dask/dask-ml/pull/500 (`dask-ml` has dropped Python2.7)
