### PR TITLE
Call session commit after read access.

### DIFF
--- a/optuna/storages/rdb/storage.py
+++ b/optuna/storages/rdb/storage.py
@@ -209,10 +209,11 @@ class RDBStorage(BaseStorage):
         session = self.scoped_session()
 
         attributes = models.StudyUserAttributeModel.where_study_id(study_id, session)
+        user_attrs = {attr.key: json.loads(attr.value_json) for attr in attributes}
         # Terminate transaction explicitly to avoid connection timeout during query.
         self._commit(session)
 
-        return {attr.key: json.loads(attr.value_json) for attr in attributes}
+        return user_attrs
 
     def get_study_system_attrs(self, study_id):
         # type: (int) -> Dict[str, Any]
@@ -220,10 +221,11 @@ class RDBStorage(BaseStorage):
         session = self.scoped_session()
 
         attributes = models.StudySystemAttributeModel.where_study_id(study_id, session)
+        system_attrs = {attr.key: json.loads(attr.value_json) for attr in attributes}
         # Terminate transaction explicitly to avoid connection timeout during query.
         self._commit(session)
 
-        return {attr.key: json.loads(attr.value_json) for attr in attributes}
+        return system_attrs
 
     def get_trial_user_attrs(self, trial_id):
         # type: (int) -> Dict[str, Any]
@@ -231,10 +233,11 @@ class RDBStorage(BaseStorage):
         session = self.scoped_session()
 
         attributes = models.TrialUserAttributeModel.where_trial_id(trial_id, session)
+        user_attrs = {attr.key: json.loads(attr.value_json) for attr in attributes}
         # Terminate transaction explicitly to avoid connection timeout during query.
         self._commit(session)
 
-        return {attr.key: json.loads(attr.value_json) for attr in attributes}
+        return user_attrs
 
     def get_trial_system_attrs(self, trial_id):
         # type: (int) -> Dict[str, Any]
@@ -242,10 +245,11 @@ class RDBStorage(BaseStorage):
         session = self.scoped_session()
 
         attributes = models.TrialSystemAttributeModel.where_trial_id(trial_id, session)
+        system_attrs = {attr.key: json.loads(attr.value_json) for attr in attributes}
         # Terminate transaction explicitly to avoid connection timeout during query.
         self._commit(session)
 
-        return {attr.key: json.loads(attr.value_json) for attr in attributes}
+        return system_attrs
 
     # TODO(sano): Optimize this method to reduce the number of queries.
     def get_all_study_summaries(self):
@@ -381,6 +385,8 @@ class RDBStorage(BaseStorage):
             distributions.check_distribution_compatibility(
                 distributions.json_to_distribution(trial_param.distribution_json), distribution)
 
+            # Terminate transaction explicitly to avoid connection timeout during query.
+            self._commit(session)
             # Return False when distribution is compatible but parameter has already been set.
             return False
 
@@ -771,6 +777,8 @@ class _VersionManager(object):
 
         version_info = models.VersionInfoModel.find(session)
         if version_info is not None:
+            # Terminate transaction explicitly to avoid connection timeout during query.
+            RDBStorage._commit(session)
             return
 
         version_info = models.VersionInfoModel(

--- a/optuna/storages/rdb/storage.py
+++ b/optuna/storages/rdb/storage.py
@@ -165,7 +165,7 @@ class RDBStorage(BaseStorage):
         session = self.scoped_session()
 
         study = models.StudyModel.find_or_raise_by_name(study_name, session)
-        # Terminate transaction explicitly to avoid connection timeout during query.
+        # Terminate transaction explicitly to avoid connection timeout during transaction.
         self._commit(session)
 
         return study.study_id
@@ -176,7 +176,7 @@ class RDBStorage(BaseStorage):
         session = self.scoped_session()
 
         trial = models.TrialModel.find_or_raise_by_id(trial_id, session)
-        # Terminate transaction explicitly to avoid connection timeout during query.
+        # Terminate transaction explicitly to avoid connection timeout during transaction.
         self._commit(session)
 
         return trial.study_id
@@ -187,7 +187,7 @@ class RDBStorage(BaseStorage):
         session = self.scoped_session()
 
         study = models.StudyModel.find_or_raise_by_id(study_id, session)
-        # Terminate transaction explicitly to avoid connection timeout during query.
+        # Terminate transaction explicitly to avoid connection timeout during transaction.
         self._commit(session)
 
         return study.study_name
@@ -198,7 +198,7 @@ class RDBStorage(BaseStorage):
         session = self.scoped_session()
 
         study = models.StudyModel.find_or_raise_by_id(study_id, session)
-        # Terminate transaction explicitly to avoid connection timeout during query.
+        # Terminate transaction explicitly to avoid connection timeout during transaction.
         self._commit(session)
 
         return study.direction
@@ -210,7 +210,7 @@ class RDBStorage(BaseStorage):
 
         attributes = models.StudyUserAttributeModel.where_study_id(study_id, session)
         user_attrs = {attr.key: json.loads(attr.value_json) for attr in attributes}
-        # Terminate transaction explicitly to avoid connection timeout during query.
+        # Terminate transaction explicitly to avoid connection timeout during transaction.
         self._commit(session)
 
         return user_attrs
@@ -222,7 +222,7 @@ class RDBStorage(BaseStorage):
 
         attributes = models.StudySystemAttributeModel.where_study_id(study_id, session)
         system_attrs = {attr.key: json.loads(attr.value_json) for attr in attributes}
-        # Terminate transaction explicitly to avoid connection timeout during query.
+        # Terminate transaction explicitly to avoid connection timeout during transaction.
         self._commit(session)
 
         return system_attrs
@@ -234,7 +234,7 @@ class RDBStorage(BaseStorage):
 
         attributes = models.TrialUserAttributeModel.where_trial_id(trial_id, session)
         user_attrs = {attr.key: json.loads(attr.value_json) for attr in attributes}
-        # Terminate transaction explicitly to avoid connection timeout during query.
+        # Terminate transaction explicitly to avoid connection timeout during transaction.
         self._commit(session)
 
         return user_attrs
@@ -246,7 +246,7 @@ class RDBStorage(BaseStorage):
 
         attributes = models.TrialSystemAttributeModel.where_trial_id(trial_id, session)
         system_attrs = {attr.key: json.loads(attr.value_json) for attr in attributes}
-        # Terminate transaction explicitly to avoid connection timeout during query.
+        # Terminate transaction explicitly to avoid connection timeout during transaction.
         self._commit(session)
 
         return system_attrs
@@ -321,7 +321,7 @@ class RDBStorage(BaseStorage):
                     n_trials=len(study_trial_models),
                     datetime_start=datetime_start))
 
-        # Terminate transaction explicitly to avoid connection timeout during query.
+        # Terminate transaction explicitly to avoid connection timeout during transaction.
         self._commit(session)
 
         return study_sumarries
@@ -348,7 +348,7 @@ class RDBStorage(BaseStorage):
 
         trial_number = trial.count_past_trials(session)
 
-        # Terminate transaction explicitly to avoid connection timeout during query.
+        # Terminate transaction explicitly to avoid connection timeout during transaction.
         self._commit(session)
 
         self.set_trial_system_attr(trial.trial_id, '_number', trial_number)
@@ -385,7 +385,7 @@ class RDBStorage(BaseStorage):
             distributions.check_distribution_compatibility(
                 distributions.json_to_distribution(trial_param.distribution_json), distribution)
 
-            # Terminate transaction explicitly to avoid connection timeout during query.
+            # Terminate transaction explicitly to avoid connection timeout during transaction.
             self._commit(session)
             # Return False when distribution is compatible but parameter has already been set.
             return False
@@ -409,7 +409,7 @@ class RDBStorage(BaseStorage):
         trial = models.TrialModel.find_or_raise_by_id(trial_id, session)
         trial_param = models.TrialParamModel.find_or_raise_by_trial_and_param_name(
             trial, param_name, session)
-        # Terminate transaction explicitly to avoid connection timeout during query.
+        # Terminate transaction explicitly to avoid connection timeout during transaction.
         self._commit(session)
 
         return trial_param.param_value
@@ -521,7 +521,7 @@ class RDBStorage(BaseStorage):
 
         self._finished_trials_cache.cache_trial_if_finished(frozen_trial)
 
-        # Terminate transaction explicitly to avoid connection timeout during query.
+        # Terminate transaction explicitly to avoid connection timeout during transaction.
         self._commit(session)
 
         return frozen_trial
@@ -547,7 +547,7 @@ class RDBStorage(BaseStorage):
         study = models.StudyModel.find_or_raise_by_id(study_id, session)
         trial_ids = models.TrialModel.get_all_trial_ids_where_study(study, session)
 
-        # Terminate transaction explicitly to avoid connection timeout during query.
+        # Terminate transaction explicitly to avoid connection timeout during transaction.
         self._commit(session)
 
         return trial_ids
@@ -567,7 +567,7 @@ class RDBStorage(BaseStorage):
         all_trials = self._merge_trials_orm(
             trials, params, values, user_attributes, system_attributes)
 
-        # Terminate transaction explicitly to avoid connection timeout during query.
+        # Terminate transaction explicitly to avoid connection timeout during transaction.
         self._commit(session)
         return all_trials
 
@@ -578,7 +578,7 @@ class RDBStorage(BaseStorage):
         study = models.StudyModel.find_or_raise_by_id(study_id, session)
         n_trials = models.TrialModel.count(session, study, state)
 
-        # Terminate transaction explicitly to avoid connection timeout during query.
+        # Terminate transaction explicitly to avoid connection timeout during transaction.
         self._commit(session)
         return n_trials
 
@@ -777,7 +777,7 @@ class _VersionManager(object):
 
         version_info = models.VersionInfoModel.find(session)
         if version_info is not None:
-            # Terminate transaction explicitly to avoid connection timeout during query.
+            # Terminate transaction explicitly to avoid connection timeout during transaction.
             RDBStorage._commit(session)
             return
 
@@ -822,7 +822,7 @@ class _VersionManager(object):
         # NOTE: After invocation of `_init_version_info_model` method,
         #       it is ensured that a `VersionInfoModel` entry exists.
         version_info = models.VersionInfoModel.find(session)
-        # Terminate transaction explicitly to avoid connection timeout during query.
+        # Terminate transaction explicitly to avoid connection timeout during transaction.
         RDBStorage._commit(session)
 
         assert version_info is not None
@@ -884,7 +884,7 @@ class _VersionManager(object):
         session = self.scoped_session()
 
         version_info = models.VersionInfoModel.find(session)
-        # Terminate transaction explicitly to avoid connection timeout during query.
+        # Terminate transaction explicitly to avoid connection timeout during transaction.
         RDBStorage._commit(session)
 
         if version_info is None:


### PR DESCRIPTION
This PR adds `session.commit()` to read access in `RDBStorage` in order to terminate transactions explicitly.

When I used `RDBStorage` with `MySQL`, the options to reconnect DB connections were ignored.
More specifically, I encountered `pymysql.err.OperationalError: (2013, 'Lost connection to MySQL server during query')` even if I set `pool_recycle` or `pool_pre_ping=True` as follows:

```python
import optuna
import time

url = 'mysql+pymysql://...'

def objective(trial):
    return trial.suggest_int('x', -10, 10)

storage = optuna.storages.RDBStorage(url, {'pool_recycle': 30}) # pool_recycle
study = optuna.create_study(storage=storage)
study.optimize(objective, n_trials=10)
print('Best value: {} (params: {})\n'.format(study.best_value, study.best_params))

time.sleep(70)
study.optimize(objective, n_trials=10)
```

The current implementation of `RDBStorage`  reuses scoped sessions and they sometimes prevent reconnection by keeping the transaction implicitly. Therefore, I added `session.commit` to `RDBStorage`'s methods to reconnect connections properly.