### PR TITLE
Remove `_id` suffix from `BaseStorage.create_new_{study,trial}_id` methods.

### DIFF
--- a/optuna/storages/base.py
+++ b/optuna/storages/base.py
@@ -28,7 +28,7 @@ class BaseStorage(object):
     # Basic study manipulation
 
     @abc.abstractmethod
-    def create_new_study_id(self, study_name=None):
+    def create_new_study(self, study_name=None):
         # type: (Optional[str]) -> int
 
         raise NotImplementedError

--- a/optuna/storages/base.py
+++ b/optuna/storages/base.py
@@ -98,7 +98,7 @@ class BaseStorage(object):
     # Basic trial manipulation
 
     @abc.abstractmethod
-    def create_new_trial_id(self, study_id):
+    def create_new_trial(self, study_id):
         # type: (int) -> int
 
         raise NotImplementedError

--- a/optuna/storages/in_memory.py
+++ b/optuna/storages/in_memory.py
@@ -135,7 +135,7 @@ class InMemoryStorage(base.BaseStorage):
                 datetime_start=datetime_start)
         ]
 
-    def create_new_trial_id(self, study_id):
+    def create_new_trial(self, study_id):
         # type: (int) -> int
 
         self._check_study_id(study_id)

--- a/optuna/storages/in_memory.py
+++ b/optuna/storages/in_memory.py
@@ -46,7 +46,7 @@ class InMemoryStorage(base.BaseStorage):
         self.__dict__.update(state)
         self._lock = threading.RLock()
 
-    def create_new_study_id(self, study_name=None):
+    def create_new_study(self, study_name=None):
         # type: (Optional[str]) -> int
 
         if study_name is not None:

--- a/optuna/storages/rdb/storage.py
+++ b/optuna/storages/rdb/storage.py
@@ -326,7 +326,7 @@ class RDBStorage(BaseStorage):
 
         return study_sumarries
 
-    def create_new_trial_id(self, study_id):
+    def create_new_trial(self, study_id):
         # type: (int) -> int
 
         session = self.scoped_session()

--- a/optuna/storages/rdb/storage.py
+++ b/optuna/storages/rdb/storage.py
@@ -77,7 +77,7 @@ class RDBStorage(BaseStorage):
 
         self._finished_trials_cache = _FinishedTrialsCache(enable_cache)
 
-    def create_new_study_id(self, study_name=None):
+    def create_new_study(self, study_name=None):
         # type: (Optional[str]) -> int
 
         session = self.scoped_session()

--- a/optuna/study.py
+++ b/optuna/study.py
@@ -545,7 +545,7 @@ def create_study(
 
     storage = storages.get_storage(storage)
     try:
-        study_id = storage.create_new_study_id(study_name)
+        study_id = storage.create_new_study(study_name)
     except structs.DuplicatedStudyError:
         if load_if_exists:
             assert study_name is not None

--- a/optuna/study.py
+++ b/optuna/study.py
@@ -440,7 +440,7 @@ class Study(BaseStudy):
     def _run_trial(self, func, catch):
         # type: (ObjectiveFuncType, Union[Tuple[()], Tuple[Type[Exception]]]) -> trial_module.Trial
 
-        trial_id = self._storage.create_new_trial_id(self.study_id)
+        trial_id = self._storage.create_new_trial(self.study_id)
         trial = trial_module.Trial(self, trial_id)
         trial_number = trial.number
 

--- a/optuna/testing/integration.py
+++ b/optuna/testing/integration.py
@@ -16,6 +16,6 @@ class DeterministicPruner(optuna.pruners.BasePruner):
 def create_running_trial(study, value):
     # type: (optuna.study.Study, float) -> optuna.trial.Trial
 
-    trial_id = study._storage.create_new_trial_id(study.study_id)
+    trial_id = study._storage.create_new_trial(study.study_id)
     study._storage.set_trial_value(trial_id, value)
     return optuna.trial.Trial(study, trial_id)

--- a/tests/integration_tests/test_chainermn.py
+++ b/tests/integration_tests/test_chainermn.py
@@ -516,7 +516,7 @@ def _create_new_chainermn_trial(study, comm):
     # type: (Study, CommunicatorBase) -> integration.chainermn.ChainerMNTrial
 
     if comm.rank == 0:
-        trial_id = study._storage.create_new_trial_id(study.study_id)
+        trial_id = study._storage.create_new_trial(study.study_id)
         trial = Trial(study, trial_id)
         mn_trial = integration.chainermn.ChainerMNTrial(trial, comm)
     else:

--- a/tests/integration_tests/test_tensorflow.py
+++ b/tests/integration_tests/test_tensorflow.py
@@ -83,7 +83,7 @@ def test_init_with_is_higher_better(is_higher_better):
     )
 
     study = optuna.create_study()
-    trial_id = study._storage.create_new_trial_id(study.study_id)
+    trial_id = study._storage.create_new_trial(study.study_id)
 
     with pytest.raises(ValueError):
         TensorFlowPruningHook(

--- a/tests/pruners_tests/test_median.py
+++ b/tests/pruners_tests/test_median.py
@@ -12,7 +12,7 @@ def test_median_pruner_with_one_trial():
     # type: () -> None
 
     study = optuna.study.create_study()
-    trial = optuna.trial.Trial(study, study._storage.create_new_trial_id(study.study_id))
+    trial = optuna.trial.Trial(study, study._storage.create_new_trial(study.study_id))
     trial.report(1, 1)
     pruner = optuna.pruners.MedianPruner(0, 0)
 
@@ -29,11 +29,11 @@ def test_median_pruner_intermediate_values(direction_value):
     pruner = optuna.pruners.MedianPruner(0, 0)
     study = optuna.study.create_study(direction=direction)
 
-    trial = optuna.trial.Trial(study, study._storage.create_new_trial_id(study.study_id))
+    trial = optuna.trial.Trial(study, study._storage.create_new_trial(study.study_id))
     trial.report(1, 1)
     study._storage.set_trial_state(trial._trial_id, TrialState.COMPLETE)
 
-    trial = optuna.trial.Trial(study, study._storage.create_new_trial_id(study.study_id))
+    trial = optuna.trial.Trial(study, study._storage.create_new_trial(study.study_id))
     # A pruner is not activated if a trial has no intermediate values.
     assert not pruner.prune(
         study=study, trial=study._storage.get_trial(trial.trial_id))
@@ -50,21 +50,21 @@ def test_median_pruner_intermediate_values_nan():
     pruner = optuna.pruners.MedianPruner(0, 0)
     study = optuna.study.create_study()
 
-    trial = optuna.trial.Trial(study, study._storage.create_new_trial_id(study.study_id))
+    trial = optuna.trial.Trial(study, study._storage.create_new_trial(study.study_id))
     trial.report(float('nan'), 1)
     # A pruner is not activated if the study does not have any previous trials.
     assert not pruner.prune(
         study=study, trial=study._storage.get_trial(trial.trial_id))
     study._storage.set_trial_state(trial._trial_id, TrialState.COMPLETE)
 
-    trial = optuna.trial.Trial(study, study._storage.create_new_trial_id(study.study_id))
+    trial = optuna.trial.Trial(study, study._storage.create_new_trial(study.study_id))
     trial.report(float('nan'), 1)
     # A pruner is activated if the best intermediate value of this trial is NaN.
     assert pruner.prune(
         study=study, trial=study._storage.get_trial(trial.trial_id))
     study._storage.set_trial_state(trial._trial_id, TrialState.COMPLETE)
 
-    trial = optuna.trial.Trial(study, study._storage.create_new_trial_id(study.study_id))
+    trial = optuna.trial.Trial(study, study._storage.create_new_trial(study.study_id))
     trial.report(1, 1)
     # A pruner is not activated if the median intermediate value is NaN.
     assert not pruner.prune(
@@ -77,18 +77,18 @@ def test_median_pruner_n_startup_trials():
     pruner = optuna.pruners.MedianPruner(2, 0)
     study = optuna.study.create_study()
 
-    trial = optuna.trial.Trial(study, study._storage.create_new_trial_id(study.study_id))
+    trial = optuna.trial.Trial(study, study._storage.create_new_trial(study.study_id))
     trial.report(1, 1)
     study._storage.set_trial_state(trial._trial_id, TrialState.COMPLETE)
 
-    trial = optuna.trial.Trial(study, study._storage.create_new_trial_id(study.study_id))
+    trial = optuna.trial.Trial(study, study._storage.create_new_trial(study.study_id))
     trial.report(2, 1)
     # A pruner is not activated during startup trials.
     assert not pruner.prune(
         study=study, trial=study._storage.get_trial(trial.trial_id))
     study._storage.set_trial_state(trial._trial_id, TrialState.COMPLETE)
 
-    trial = optuna.trial.Trial(study, study._storage.create_new_trial_id(study.study_id))
+    trial = optuna.trial.Trial(study, study._storage.create_new_trial(study.study_id))
     trial.report(3, 1)
     # A pruner is activated after startup trials.
     assert pruner.prune(
@@ -101,12 +101,12 @@ def test_median_pruner_n_warmup_steps():
     pruner = optuna.pruners.MedianPruner(0, 1)
     study = optuna.study.create_study()
 
-    trial = optuna.trial.Trial(study, study._storage.create_new_trial_id(study.study_id))
+    trial = optuna.trial.Trial(study, study._storage.create_new_trial(study.study_id))
     trial.report(1, 1)
     trial.report(1, 2)
     study._storage.set_trial_state(trial._trial_id, TrialState.COMPLETE)
 
-    trial = optuna.trial.Trial(study, study._storage.create_new_trial_id(study.study_id))
+    trial = optuna.trial.Trial(study, study._storage.create_new_trial(study.study_id))
     trial.report(2, 1)
     # A pruner is not activated during warm-up steps.
     assert not pruner.prune(

--- a/tests/pruners_tests/test_percentile.py
+++ b/tests/pruners_tests/test_percentile.py
@@ -18,7 +18,7 @@ def test_percentile_pruner_with_one_trial():
     # type: () -> None
 
     study = optuna.study.create_study()
-    trial = optuna.trial.Trial(study, study._storage.create_new_trial_id(study.study_id))
+    trial = optuna.trial.Trial(study, study._storage.create_new_trial(study.study_id))
     trial.report(1, 1)
     pruner = optuna.pruners.PercentilePruner(25.0, 0, 0)
 
@@ -39,11 +39,11 @@ def test_25_percentile_pruner_intermediate_values(direction_value):
     study = optuna.study.create_study(direction=direction)
 
     for v in intermediate_values:
-        trial = optuna.trial.Trial(study, study._storage.create_new_trial_id(study.study_id))
+        trial = optuna.trial.Trial(study, study._storage.create_new_trial(study.study_id))
         trial.report(v, 1)
         study._storage.set_trial_state(trial._trial_id, TrialState.COMPLETE)
 
-    trial = optuna.trial.Trial(study, study._storage.create_new_trial_id(study.study_id))
+    trial = optuna.trial.Trial(study, study._storage.create_new_trial(study.study_id))
     # A pruner is not activated if a trial has no intermediate values.
     assert not pruner.prune(
         study=study, trial=study._storage.get_trial(trial.trial_id))
@@ -60,21 +60,21 @@ def test_25_percentile_pruner_intermediate_values_nan():
     pruner = optuna.pruners.PercentilePruner(25.0, 0, 0)
     study = optuna.study.create_study()
 
-    trial = optuna.trial.Trial(study, study._storage.create_new_trial_id(study.study_id))
+    trial = optuna.trial.Trial(study, study._storage.create_new_trial(study.study_id))
     trial.report(float('nan'), 1)
     # A pruner is not activated if the study does not have any previous trials.
     assert not pruner.prune(
         study=study, trial=study._storage.get_trial(trial.trial_id))
     study._storage.set_trial_state(trial._trial_id, TrialState.COMPLETE)
 
-    trial = optuna.trial.Trial(study, study._storage.create_new_trial_id(study.study_id))
+    trial = optuna.trial.Trial(study, study._storage.create_new_trial(study.study_id))
     trial.report(float('nan'), 1)
     # A pruner is activated if the best intermediate value of this trial is NaN.
     assert pruner.prune(
         study=study, trial=study._storage.get_trial(trial.trial_id))
     study._storage.set_trial_state(trial._trial_id, TrialState.COMPLETE)
 
-    trial = optuna.trial.Trial(study, study._storage.create_new_trial_id(study.study_id))
+    trial = optuna.trial.Trial(study, study._storage.create_new_trial(study.study_id))
     trial.report(1, 1)
     # A pruner is not activated if the 25 percentile intermediate value is NaN.
     assert not pruner.prune(
@@ -94,14 +94,14 @@ def test_get_best_intermediate_result_over_steps(direction_expected):
         study = optuna.study.create_study(direction="maximize")
 
     # FrozenTrial.intermediate_values has no elements.
-    trial_id_empty = study._storage.create_new_trial_id(study.study_id)
+    trial_id_empty = study._storage.create_new_trial(study.study_id)
     trial_empty = study._storage.get_trial(trial_id_empty)
 
     with pytest.raises(ValueError):
         percentile._get_best_intermediate_result_over_steps(trial_empty, direction)
 
     # Input value has no NaNs but float values.
-    trial_id_float = study._storage.create_new_trial_id(study.study_id)
+    trial_id_float = study._storage.create_new_trial(study.study_id)
     trial_float = optuna.trial.Trial(study, trial_id_float)
     trial_float.report(0.1, step=0)
     trial_float.report(0.2, step=1)
@@ -110,7 +110,7 @@ def test_get_best_intermediate_result_over_steps(direction_expected):
         frozen_trial_float, direction)
 
     # Input value has a float value and a NaN.
-    trial_id_float_nan = study._storage.create_new_trial_id(study.study_id)
+    trial_id_float_nan = study._storage.create_new_trial(study.study_id)
     trial_float_nan = optuna.trial.Trial(study, trial_id_float_nan)
     trial_float_nan.report(0.3, step=0)
     trial_float_nan.report(float('nan'), step=1)
@@ -119,7 +119,7 @@ def test_get_best_intermediate_result_over_steps(direction_expected):
         frozen_trial_float_nan, direction)
 
     # Input value has a NaN only.
-    trial_id_nan = study._storage.create_new_trial_id(study.study_id)
+    trial_id_nan = study._storage.create_new_trial(study.study_id)
     trial_nan = optuna.trial.Trial(study, trial_id_nan)
     trial_nan.report(float('nan'), step=0)
     frozen_trial_nan = study._storage.get_trial(trial_id_nan)
@@ -134,7 +134,7 @@ def test_get_percentile_intermediate_result_over_trials():
         # type: (int, List[List[float]]) -> Study
 
         _study = optuna.study.create_study(direction="minimize")
-        trial_ids = [_study._storage.create_new_trial_id(
+        trial_ids = [_study._storage.create_new_trial(
             _study.study_id) for _ in range(trial_num)]
 
         for step, values in enumerate(_intermediate_values):

--- a/tests/pruners_tests/test_successive_halving.py
+++ b/tests/pruners_tests/test_successive_halving.py
@@ -16,13 +16,13 @@ def test_successive_halving_pruner_intermediate_values(direction_value):
         min_resource=1, reduction_factor=2, min_early_stopping_rate=0)
     study = optuna.study.create_study(direction=direction)
 
-    trial = optuna.trial.Trial(study, study._storage.create_new_trial_id(study.study_id))
+    trial = optuna.trial.Trial(study, study._storage.create_new_trial(study.study_id))
     trial.report(1, 1)
 
     # A pruner is not activated at a first trial.
     assert not pruner.prune(study=study, trial=study._storage.get_trial(trial.trial_id))
 
-    trial = optuna.trial.Trial(study, study._storage.create_new_trial_id(study.study_id))
+    trial = optuna.trial.Trial(study, study._storage.create_new_trial(study.study_id))
     # A pruner is not activated if a trial has no intermediate values.
     assert not pruner.prune(study=study, trial=study._storage.get_trial(trial.trial_id))
 
@@ -40,26 +40,26 @@ def test_successive_halving_pruner_rung_check():
 
     # Report 7 trials in advance.
     for i in range(7):
-        trial = optuna.trial.Trial(study, study._storage.create_new_trial_id(study.study_id))
+        trial = optuna.trial.Trial(study, study._storage.create_new_trial(study.study_id))
         trial.report(0.1 * (i + 1), step=7)
         pruner.prune(study=study, trial=study._storage.get_trial(trial.trial_id))
 
     # Report a trial that has the 7-th value from bottom.
-    trial = optuna.trial.Trial(study, study._storage.create_new_trial_id(study.study_id))
+    trial = optuna.trial.Trial(study, study._storage.create_new_trial(study.study_id))
     trial.report(0.75, step=7)
     pruner.prune(study=study, trial=study._storage.get_trial(trial.trial_id))
     assert 'completed_rung_0' in trial.system_attrs
     assert 'completed_rung_1' not in trial.system_attrs
 
     # Report a trial that has the third value from bottom.
-    trial = optuna.trial.Trial(study, study._storage.create_new_trial_id(study.study_id))
+    trial = optuna.trial.Trial(study, study._storage.create_new_trial(study.study_id))
     trial.report(0.25, step=7)
     pruner.prune(study=study, trial=study._storage.get_trial(trial.trial_id))
     assert 'completed_rung_1' in trial.system_attrs
     assert 'completed_rung_2' not in trial.system_attrs
 
     # Report a trial that has the lowest value.
-    trial = optuna.trial.Trial(study, study._storage.create_new_trial_id(study.study_id))
+    trial = optuna.trial.Trial(study, study._storage.create_new_trial(study.study_id))
     trial.report(0.05, step=7)
     pruner.prune(study=study, trial=study._storage.get_trial(trial.trial_id))
     assert 'completed_rung_2' in trial.system_attrs
@@ -73,7 +73,7 @@ def test_successive_halving_pruner_first_trial_is_not_pruned():
         min_resource=1, reduction_factor=2, min_early_stopping_rate=0)
     study = optuna.study.create_study()
 
-    trial = optuna.trial.Trial(study, study._storage.create_new_trial_id(study.study_id))
+    trial = optuna.trial.Trial(study, study._storage.create_new_trial(study.study_id))
     for i in range(10):
         trial.report(1, step=i)
 
@@ -96,7 +96,7 @@ def test_successive_halving_pruner_with_nan():
         min_resource=2, reduction_factor=2, min_early_stopping_rate=0)
     study = optuna.study.create_study()
 
-    trial = optuna.trial.Trial(study, study._storage.create_new_trial_id(study.study_id))
+    trial = optuna.trial.Trial(study, study._storage.create_new_trial(study.study_id))
 
     # A pruner is not activated if the step is not a rung completion point.
     trial.report(float('nan'), step=1)
@@ -121,7 +121,7 @@ def test_successive_halving_pruner_min_resource_parameter():
     # min_resource=1: The rung 0 ends at step 1.
     pruner = optuna.pruners.SuccessiveHalvingPruner(
         min_resource=1, reduction_factor=2, min_early_stopping_rate=0)
-    trial = optuna.trial.Trial(study, study._storage.create_new_trial_id(study.study_id))
+    trial = optuna.trial.Trial(study, study._storage.create_new_trial(study.study_id))
 
     trial.report(1, step=1)
     assert not pruner.prune(study=study, trial=study._storage.get_trial(trial.trial_id))
@@ -131,7 +131,7 @@ def test_successive_halving_pruner_min_resource_parameter():
     # min_resource=2: The rung 0 ends at step 2.
     pruner = optuna.pruners.SuccessiveHalvingPruner(
         min_resource=2, reduction_factor=2, min_early_stopping_rate=0)
-    trial = optuna.trial.Trial(study, study._storage.create_new_trial_id(study.study_id))
+    trial = optuna.trial.Trial(study, study._storage.create_new_trial(study.study_id))
 
     trial.report(1, step=1)
     assert not pruner.prune(study=study, trial=study._storage.get_trial(trial.trial_id))
@@ -156,7 +156,7 @@ def test_successive_halving_pruner_reduction_factor_parameter():
     # reduction_factor=2: The rung 0 ends at step 1.
     pruner = optuna.pruners.SuccessiveHalvingPruner(
         min_resource=1, reduction_factor=2, min_early_stopping_rate=0)
-    trial = optuna.trial.Trial(study, study._storage.create_new_trial_id(study.study_id))
+    trial = optuna.trial.Trial(study, study._storage.create_new_trial(study.study_id))
 
     trial.report(1, step=1)
     assert not pruner.prune(study=study, trial=study._storage.get_trial(trial.trial_id))
@@ -166,7 +166,7 @@ def test_successive_halving_pruner_reduction_factor_parameter():
     # reduction_factor=3: The rung 1 ends at step 3.
     pruner = optuna.pruners.SuccessiveHalvingPruner(
         min_resource=1, reduction_factor=3, min_early_stopping_rate=0)
-    trial = optuna.trial.Trial(study, study._storage.create_new_trial_id(study.study_id))
+    trial = optuna.trial.Trial(study, study._storage.create_new_trial(study.study_id))
 
     trial.report(1, step=1)
     assert not pruner.prune(study=study, trial=study._storage.get_trial(trial.trial_id))
@@ -196,7 +196,7 @@ def test_successive_halving_pruner_min_early_stopping_rate_parameter():
     # min_early_stopping_rate=0: The rung 0 ends at step 1.
     pruner = optuna.pruners.SuccessiveHalvingPruner(
         min_resource=1, reduction_factor=2, min_early_stopping_rate=0)
-    trial = optuna.trial.Trial(study, study._storage.create_new_trial_id(study.study_id))
+    trial = optuna.trial.Trial(study, study._storage.create_new_trial(study.study_id))
 
     trial.report(1, step=1)
     assert not pruner.prune(study=study, trial=study._storage.get_trial(trial.trial_id))
@@ -205,7 +205,7 @@ def test_successive_halving_pruner_min_early_stopping_rate_parameter():
     # min_early_stopping_rate=1: The rung 0 ends at step 2.
     pruner = optuna.pruners.SuccessiveHalvingPruner(
         min_resource=1, reduction_factor=2, min_early_stopping_rate=1)
-    trial = optuna.trial.Trial(study, study._storage.create_new_trial_id(study.study_id))
+    trial = optuna.trial.Trial(study, study._storage.create_new_trial(study.study_id))
 
     trial.report(1, step=1)
     assert not pruner.prune(study=study, trial=study._storage.get_trial(trial.trial_id))

--- a/tests/samplers_tests/test_samplers.py
+++ b/tests/samplers_tests/test_samplers.py
@@ -143,7 +143,7 @@ def test_categorical(sampler_class, choices):
 def _create_new_trial(study):
     # type: (Study) -> FrozenTrial
 
-    trial_id = study._storage.create_new_trial_id(study.study_id)
+    trial_id = study._storage.create_new_trial(study.study_id)
     return study._storage.get_trial(trial_id)
 
 

--- a/tests/samplers_tests/tpe_tests/test_sampler.py
+++ b/tests/samplers_tests/tpe_tests/test_sampler.py
@@ -40,7 +40,7 @@ def test_get_observation_pairs():
     # direction=minimize.
     study = optuna.create_study(direction='minimize')
     study.optimize(objective, n_trials=5)
-    study._storage.create_new_trial_id(study.study_id)  # Create a running trial.
+    study._storage.create_new_trial(study.study_id)  # Create a running trial.
 
     assert tpe.sampler._get_observation_pairs(study, 'x') == (
         [5.0, 5.0, 5.0, 5.0],
@@ -55,7 +55,7 @@ def test_get_observation_pairs():
     # direction=maximize.
     study = optuna.create_study(direction='maximize')
     study.optimize(objective, n_trials=4)
-    study._storage.create_new_trial_id(study.study_id)  # Create a running trial.
+    study._storage.create_new_trial(study.study_id)  # Create a running trial.
 
     assert tpe.sampler._get_observation_pairs(study, 'x') == (
         [5.0, 5.0, 5.0, 5.0],

--- a/tests/storages_tests/rdb_tests/test_storage.py
+++ b/tests/storages_tests/rdb_tests/test_storage.py
@@ -125,7 +125,7 @@ def test_set_trial_param_to_check_distribution_json():
     session = storage.scoped_session()
     study_id = storage.create_new_study_id()
 
-    trial_id = storage.create_new_trial_id(study_id)
+    trial_id = storage.create_new_trial(study_id)
     storage.set_trial_param(trial_id, 'x', 1.5, example_distributions['x'])
     storage.set_trial_param(trial_id, 'y', 2, example_distributions['y'])
 
@@ -148,8 +148,8 @@ def test_get_all_study_summaries_with_multiple_studies():
     study_id_1 = storage.create_new_study_id()
     storage.set_study_direction(study_id_1, StudyDirection.MINIMIZE)
 
-    trial_id_1_1 = storage.create_new_trial_id(study_id_1)
-    trial_id_1_2 = storage.create_new_trial_id(study_id_1)
+    trial_id_1_1 = storage.create_new_trial(study_id_1)
+    trial_id_1_2 = storage.create_new_trial(study_id_1)
 
     storage.set_trial_value(trial_id_1_1, 100)
     storage.set_trial_value(trial_id_1_2, 0)
@@ -161,8 +161,8 @@ def test_get_all_study_summaries_with_multiple_studies():
     study_id_2 = storage.create_new_study_id()
     storage.set_study_direction(study_id_2, StudyDirection.MAXIMIZE)
 
-    trial_id_2_1 = storage.create_new_trial_id(study_id_2)
-    trial_id_2_2 = storage.create_new_trial_id(study_id_2)
+    trial_id_2_1 = storage.create_new_trial(study_id_2)
+    trial_id_2_2 = storage.create_new_trial(study_id_2)
 
     storage.set_trial_value(trial_id_2_1, -100)
     storage.set_trial_value(trial_id_2_2, -200)
@@ -267,10 +267,10 @@ def test_create_new_trial_number():
     storage = create_test_storage()
     study_id = storage.create_new_study_id()
 
-    trial_id = storage.create_new_trial_id(study_id)
+    trial_id = storage.create_new_trial(study_id)
     assert storage._create_new_trial_number(trial_id) == 0
 
-    trial_id = storage.create_new_trial_id(study_id)
+    trial_id = storage.create_new_trial(study_id)
     assert storage._create_new_trial_number(trial_id) == 1
 
 
@@ -281,7 +281,7 @@ def test_update_finished_trial():
     study_id = storage.create_new_study_id()
 
     # Running trials are allowed to be updated.
-    trial_id = storage.create_new_trial_id(study_id)
+    trial_id = storage.create_new_trial(study_id)
     assert storage.get_trial(trial_id).state == TrialState.RUNNING
 
     storage.set_trial_intermediate_value(trial_id, 3, 5)
@@ -293,7 +293,7 @@ def test_update_finished_trial():
 
     # Finished trials are not allowed to be updated.
     for state in [TrialState.COMPLETE, TrialState.PRUNED, TrialState.FAIL]:
-        trial_id = storage.create_new_trial_id(study_id)
+        trial_id = storage.create_new_trial(study_id)
         storage.set_trial_state(trial_id, state)
 
         with pytest.raises(RuntimeError):
@@ -330,7 +330,7 @@ def test_storage_cache():
         # type: (RDBStorage, int) -> List[FrozenTrial]
 
         for state in [TrialState.RUNNING, TrialState.COMPLETE, TrialState.PRUNED, TrialState.FAIL]:
-            trial_id = storage.create_new_trial_id(study_id)
+            trial_id = storage.create_new_trial(study_id)
             storage.set_trial_state(trial_id, state)
 
         trials = storage.get_all_trials(study_id)

--- a/tests/storages_tests/rdb_tests/test_storage.py
+++ b/tests/storages_tests/rdb_tests/test_storage.py
@@ -87,7 +87,7 @@ def test_engine_kwargs():
         create_test_storage(engine_kwargs={'wrong_key': 'wrong_value'})
 
 
-def test_create_new_study_id_multiple_studies():
+def test_create_new_study_multiple_studies():
     # type: () -> None
 
     storage = create_test_storage()
@@ -103,7 +103,7 @@ def test_create_new_study_id_multiple_studies():
     assert result[1].study_id == study_id_2
 
 
-def test_create_new_study_id_duplicated_name():
+def test_create_new_study_duplicated_name():
     # type: () -> None
 
     storage = create_test_storage()

--- a/tests/storages_tests/rdb_tests/test_storage.py
+++ b/tests/storages_tests/rdb_tests/test_storage.py
@@ -93,8 +93,8 @@ def test_create_new_study_id_multiple_studies():
     storage = create_test_storage()
     session = storage.scoped_session()
 
-    study_id_1 = storage.create_new_study_id()
-    study_id_2 = storage.create_new_study_id()
+    study_id_1 = storage.create_new_study()
+    study_id_2 = storage.create_new_study()
 
     result = session.query(StudyModel).all()
     result = sorted(result, key=lambda x: x.study_id)
@@ -108,9 +108,9 @@ def test_create_new_study_id_duplicated_name():
 
     storage = create_test_storage()
     study_name = 'sample_study_name'
-    storage.create_new_study_id(study_name)
+    storage.create_new_study(study_name)
     with pytest.raises(DuplicatedStudyError):
-        storage.create_new_study_id(study_name)
+        storage.create_new_study(study_name)
 
 
 def test_set_trial_param_to_check_distribution_json():
@@ -123,7 +123,7 @@ def test_set_trial_param_to_check_distribution_json():
 
     storage = create_test_storage()
     session = storage.scoped_session()
-    study_id = storage.create_new_study_id()
+    study_id = storage.create_new_study()
 
     trial_id = storage.create_new_trial(study_id)
     storage.set_trial_param(trial_id, 'x', 1.5, example_distributions['x'])
@@ -145,7 +145,7 @@ def test_get_all_study_summaries_with_multiple_studies():
     storage = create_test_storage()
 
     # Set up a MINIMIZE study.
-    study_id_1 = storage.create_new_study_id()
+    study_id_1 = storage.create_new_study()
     storage.set_study_direction(study_id_1, StudyDirection.MINIMIZE)
 
     trial_id_1_1 = storage.create_new_trial(study_id_1)
@@ -158,7 +158,7 @@ def test_get_all_study_summaries_with_multiple_studies():
     storage.set_trial_state(trial_id_1_2, TrialState.COMPLETE)
 
     # Set up a MAXIMIZE study.
-    study_id_2 = storage.create_new_study_id()
+    study_id_2 = storage.create_new_study()
     storage.set_study_direction(study_id_2, StudyDirection.MAXIMIZE)
 
     trial_id_2_1 = storage.create_new_trial(study_id_2)
@@ -171,7 +171,7 @@ def test_get_all_study_summaries_with_multiple_studies():
     storage.set_trial_state(trial_id_2_2, TrialState.COMPLETE)
 
     # Set up an empty study.
-    study_id_3 = storage.create_new_study_id()
+    study_id_3 = storage.create_new_study()
 
     summaries = storage.get_all_study_summaries()
     summaries = sorted(summaries, key=lambda x: x.study_id)
@@ -265,7 +265,7 @@ def test_create_new_trial_number():
     # type: () -> None
 
     storage = create_test_storage()
-    study_id = storage.create_new_study_id()
+    study_id = storage.create_new_study()
 
     trial_id = storage.create_new_trial(study_id)
     assert storage._create_new_trial_number(trial_id) == 0
@@ -278,7 +278,7 @@ def test_update_finished_trial():
     # type: () -> None
 
     storage = create_test_storage()
-    study_id = storage.create_new_study_id()
+    study_id = storage.create_new_study()
 
     # Running trials are allowed to be updated.
     trial_id = storage.create_new_trial(study_id)
@@ -340,7 +340,7 @@ def test_storage_cache():
 
     # Storage cache is disabled.
     storage = create_test_storage(enable_cache=False)
-    study_id = storage.create_new_study_id()
+    study_id = storage.create_new_study()
     trials = setup_trials(storage, study_id)
 
     with patch.object(
@@ -356,7 +356,7 @@ def test_storage_cache():
 
     # Storage cache is enabled.
     storage = create_test_storage(enable_cache=True)
-    study_id = storage.create_new_study_id()
+    study_id = storage.create_new_study()
     trials = setup_trials(storage, study_id)
 
     with patch.object(

--- a/tests/storages_tests/test_storages.py
+++ b/tests/storages_tests/test_storages.py
@@ -125,13 +125,13 @@ def test_create_new_study(storage_init_func):
 
 @pytest.mark.parametrize('storage_mode', STORAGE_MODES)
 @pytest.mark.parametrize('cache_mode', CACHE_MODES)
-def test_create_new_study_id_with_name(storage_mode, cache_mode):
+def test_create_new_study_with_name(storage_mode, cache_mode):
     # type: (str, bool) -> None
 
     with StorageSupplier(storage_mode, cache_mode) as storage:
 
         # Generate unique study_name from the current function name and storage_mode.
-        function_name = test_create_new_study_id_with_name.__name__
+        function_name = test_create_new_study_with_name.__name__
         study_name = function_name + '/' + storage_mode + '/' + str(cache_mode)
         storage = optuna.storages.get_storage(storage)
         study_id = storage.create_new_study(study_name)
@@ -380,7 +380,7 @@ def test_set_and_get_trial_param(storage_init_func):
     # Setup trial_3: setting new params (to different study from trial_1).
     if isinstance(storage, InMemoryStorage):
         with pytest.raises(ValueError):
-            # InMemoryStorage shares the same study if create_new_study_id is additionally invoked.
+            # InMemoryStorage shares the same study if create_new_study is additionally invoked.
             # Thus, the following line should fail due to distribution incompatibility.
             storage.set_trial_param(trial_id_3, 'y', 1, distribution_y_2)
     else:

--- a/tests/storages_tests/test_storages.py
+++ b/tests/storages_tests/test_storages.py
@@ -177,7 +177,7 @@ def test_get_study_id_from_trial_id(storage_mode, cache_mode):
         # Check if trial_number starts from 0.
         study_id = storage.create_new_study_id()
 
-        trial_id = storage.create_new_trial_id(study_id)
+        trial_id = storage.create_new_trial(study_id)
         assert storage.get_study_id_from_trial_id(trial_id) == study_id
 
 
@@ -248,13 +248,13 @@ def test_set_and_get_study_system_attrs(storage_init_func):
 
 
 @parametrize_storage
-def test_create_new_trial_id(storage_init_func):
+def test_create_new_trial(storage_init_func):
     # type: (Callable[[], BaseStorage]) -> None
 
     storage = storage_init_func()
 
     study_id = storage.create_new_study_id()
-    trial_id = storage.create_new_trial_id(study_id)
+    trial_id = storage.create_new_trial(study_id)
 
     trials = storage.get_all_trials(study_id)
     assert len(trials) == 1
@@ -278,10 +278,10 @@ def test_get_trial_number_from_id(storage_mode, cache_mode):
         # Check if trial_number starts from 0.
         study_id = storage.create_new_study_id()
 
-        trial_id = storage.create_new_trial_id(study_id)
+        trial_id = storage.create_new_trial(study_id)
         assert storage.get_trial_number_from_id(trial_id) == 0
 
-        trial_id = storage.create_new_trial_id(study_id)
+        trial_id = storage.create_new_trial(study_id)
         assert storage.get_trial_number_from_id(trial_id) == 1
 
 
@@ -295,10 +295,10 @@ def test_get_trial_number_from_id_with_empty_system_attrs(storage_mode, cache_mo
         storage = optuna.storages.get_storage(storage)
         study_id = storage.create_new_study_id()
         with patch.object(storage, 'get_trial_system_attrs', return_value=dict()) as _mock_attrs:
-            trial_id = storage.create_new_trial_id(study_id)
+            trial_id = storage.create_new_trial(study_id)
             assert storage.get_trial_number_from_id(trial_id) == 0
 
-            trial_id = storage.create_new_trial_id(study_id)
+            trial_id = storage.create_new_trial(study_id)
             assert storage.get_trial_number_from_id(trial_id) == 1
 
             if storage_mode == 'none':
@@ -312,8 +312,8 @@ def test_set_trial_state(storage_init_func):
 
     storage = storage_init_func()
 
-    trial_id_1 = storage.create_new_trial_id(storage.create_new_study_id())
-    trial_id_2 = storage.create_new_trial_id(storage.create_new_study_id())
+    trial_id_1 = storage.create_new_trial(storage.create_new_study_id())
+    trial_id_2 = storage.create_new_trial(storage.create_new_study_id())
 
     storage.set_trial_state(trial_id_1, TrialState.RUNNING)
     assert storage.get_trial(trial_id_1).state == TrialState.RUNNING
@@ -337,9 +337,9 @@ def test_set_and_get_trial_param(storage_init_func):
 
     # Setup test across multiple studies and trials.
     study_id = storage.create_new_study_id()
-    trial_id_1 = storage.create_new_trial_id(study_id)
-    trial_id_2 = storage.create_new_trial_id(study_id)
-    trial_id_3 = storage.create_new_trial_id(storage.create_new_study_id())
+    trial_id_1 = storage.create_new_trial(study_id)
+    trial_id_2 = storage.create_new_trial(study_id)
+    trial_id_3 = storage.create_new_trial(storage.create_new_study_id())
 
     # Setup Distributions.
     distribution_x = UniformDistribution(low=1.0, high=2.0)
@@ -397,9 +397,9 @@ def test_set_trial_value(storage_init_func):
 
     # Setup test across multiple studies and trials.
     study_id = storage.create_new_study_id()
-    trial_id_1 = storage.create_new_trial_id(study_id)
-    trial_id_2 = storage.create_new_trial_id(study_id)
-    trial_id_3 = storage.create_new_trial_id(storage.create_new_study_id())
+    trial_id_1 = storage.create_new_trial(study_id)
+    trial_id_2 = storage.create_new_trial(study_id)
+    trial_id_3 = storage.create_new_trial(storage.create_new_study_id())
 
     # Test setting new value.
     storage.set_trial_value(trial_id_1, 0.5)
@@ -418,9 +418,9 @@ def test_set_trial_intermediate_value(storage_init_func):
 
     # Setup test across multiple studies and trials.
     study_id = storage.create_new_study_id()
-    trial_id_1 = storage.create_new_trial_id(study_id)
-    trial_id_2 = storage.create_new_trial_id(study_id)
-    trial_id_3 = storage.create_new_trial_id(storage.create_new_study_id())
+    trial_id_1 = storage.create_new_trial(study_id)
+    trial_id_2 = storage.create_new_trial(study_id)
+    trial_id_3 = storage.create_new_trial(storage.create_new_study_id())
 
     # Test setting new values.
     assert storage.set_trial_intermediate_value(trial_id_1, 0, 0.3)
@@ -442,7 +442,7 @@ def test_set_trial_user_attr(storage_init_func):
     # type: (Callable[[], BaseStorage]) -> None
 
     storage = storage_init_func()
-    trial_id_1 = storage.create_new_trial_id(storage.create_new_study_id())
+    trial_id_1 = storage.create_new_trial(storage.create_new_study_id())
 
     def check_set_and_get(trial_id, key, value):
         # type: (int, str, Any) -> None
@@ -459,7 +459,7 @@ def test_set_trial_user_attr(storage_init_func):
     check_set_and_get(trial_id_1, 'dataset', 'ImageNet')
 
     # Test another trial.
-    trial_id_2 = storage.create_new_trial_id(storage.create_new_study_id())
+    trial_id_2 = storage.create_new_trial(storage.create_new_study_id())
     check_set_and_get(trial_id_2, 'baseline_score', 0.001)
     assert len(storage.get_trial(trial_id_2).user_attrs) == 1
     assert storage.get_trial(trial_id_2).user_attrs['baseline_score'] == 0.001
@@ -471,7 +471,7 @@ def test_set_and_get_tiral_system_attr(storage_init_func):
 
     storage = storage_init_func()
     study_id = storage.create_new_study_id()
-    trial_id_1 = storage.create_new_trial_id(study_id)
+    trial_id_1 = storage.create_new_trial(study_id)
 
     def check_set_and_get(trial_id, key, value):
         # type: (int, str, Any) -> None
@@ -489,7 +489,7 @@ def test_set_and_get_tiral_system_attr(storage_init_func):
     check_set_and_get(trial_id_1, 'dataset', 'ImageNet')
 
     # Test another trial.
-    trial_id_2 = storage.create_new_trial_id(study_id)
+    trial_id_2 = storage.create_new_trial(study_id)
     check_set_and_get(trial_id_2, 'baseline_score', 0.001)
     system_attrs = storage.get_trial(trial_id_2).system_attrs
     # TODO(Yanase): Remove number from system_attrs after adding TrialModel.number.
@@ -514,7 +514,7 @@ def test_get_all_study_summaries(storage_init_func):
     datetime_2 = datetime.now()
 
     # Set up trial 2.
-    trial_id_2 = storage.create_new_trial_id(study_id)
+    trial_id_2 = storage.create_new_trial(study_id)
     storage.set_trial_value(trial_id_2, 2.0)
 
     for key, value in EXAMPLE_ATTRS.items():
@@ -617,7 +617,7 @@ def test_get_n_trials(storage_init_func):
 def _create_new_trial_with_example_trial(storage, study_id, distributions, example_trial):
     # type: (BaseStorage, int, Dict[str, BaseDistribution], FrozenTrial) -> int
 
-    trial_id = storage.create_new_trial_id(study_id)
+    trial_id = storage.create_new_trial(study_id)
 
     if example_trial.value is not None:
         storage.set_trial_value(trial_id, example_trial.value)

--- a/tests/storages_tests/test_storages.py
+++ b/tests/storages_tests/test_storages.py
@@ -111,11 +111,11 @@ def teardown_module():
 
 
 @parametrize_storage
-def test_create_new_study_id(storage_init_func):
+def test_create_new_study(storage_init_func):
     # type: (Callable[[], BaseStorage]) -> None
 
     storage = storage_init_func()
-    study_id = storage.create_new_study_id()
+    study_id = storage.create_new_study()
 
     summaries = storage.get_all_study_summaries()
     assert len(summaries) == 1
@@ -134,7 +134,7 @@ def test_create_new_study_id_with_name(storage_mode, cache_mode):
         function_name = test_create_new_study_id_with_name.__name__
         study_name = function_name + '/' + storage_mode + '/' + str(cache_mode)
         storage = optuna.storages.get_storage(storage)
-        study_id = storage.create_new_study_id(study_name)
+        study_id = storage.create_new_study(study_name)
 
         assert study_name == storage.get_study_name_from_id(study_id)
 
@@ -175,7 +175,7 @@ def test_get_study_id_from_trial_id(storage_mode, cache_mode):
         storage = optuna.storages.get_storage(storage)
 
         # Check if trial_number starts from 0.
-        study_id = storage.create_new_study_id()
+        study_id = storage.create_new_study()
 
         trial_id = storage.create_new_trial(study_id)
         assert storage.get_study_id_from_trial_id(trial_id) == study_id
@@ -186,7 +186,7 @@ def test_set_and_get_study_direction(storage_init_func):
     # type: (Callable[[], BaseStorage]) -> None
 
     storage = storage_init_func()
-    study_id = storage.create_new_study_id()
+    study_id = storage.create_new_study()
 
     def check_set_and_get(direction):
         # type: (StudyDirection) -> None
@@ -209,7 +209,7 @@ def test_set_and_get_study_user_attrs(storage_init_func):
     # type: (Callable[[], BaseStorage]) -> None
 
     storage = storage_init_func()
-    study_id = storage.create_new_study_id()
+    study_id = storage.create_new_study()
 
     def check_set_and_get(key, value):
         # type: (str, Any) -> None
@@ -231,7 +231,7 @@ def test_set_and_get_study_system_attrs(storage_init_func):
     # type: (Callable[[], BaseStorage]) -> None
 
     storage = storage_init_func()
-    study_id = storage.create_new_study_id()
+    study_id = storage.create_new_study()
 
     def check_set_and_get(key, value):
         # type: (str, Any) -> None
@@ -253,7 +253,7 @@ def test_create_new_trial(storage_init_func):
 
     storage = storage_init_func()
 
-    study_id = storage.create_new_study_id()
+    study_id = storage.create_new_study()
     trial_id = storage.create_new_trial(study_id)
 
     trials = storage.get_all_trials(study_id)
@@ -276,7 +276,7 @@ def test_get_trial_number_from_id(storage_mode, cache_mode):
         storage = optuna.storages.get_storage(storage)
 
         # Check if trial_number starts from 0.
-        study_id = storage.create_new_study_id()
+        study_id = storage.create_new_study()
 
         trial_id = storage.create_new_trial(study_id)
         assert storage.get_trial_number_from_id(trial_id) == 0
@@ -293,7 +293,7 @@ def test_get_trial_number_from_id_with_empty_system_attrs(storage_mode, cache_mo
 
     with StorageSupplier(storage_mode, cache_mode) as storage:
         storage = optuna.storages.get_storage(storage)
-        study_id = storage.create_new_study_id()
+        study_id = storage.create_new_study()
         with patch.object(storage, 'get_trial_system_attrs', return_value=dict()) as _mock_attrs:
             trial_id = storage.create_new_trial(study_id)
             assert storage.get_trial_number_from_id(trial_id) == 0
@@ -312,8 +312,8 @@ def test_set_trial_state(storage_init_func):
 
     storage = storage_init_func()
 
-    trial_id_1 = storage.create_new_trial(storage.create_new_study_id())
-    trial_id_2 = storage.create_new_trial(storage.create_new_study_id())
+    trial_id_1 = storage.create_new_trial(storage.create_new_study())
+    trial_id_2 = storage.create_new_trial(storage.create_new_study())
 
     storage.set_trial_state(trial_id_1, TrialState.RUNNING)
     assert storage.get_trial(trial_id_1).state == TrialState.RUNNING
@@ -336,10 +336,10 @@ def test_set_and_get_trial_param(storage_init_func):
     storage = storage_init_func()
 
     # Setup test across multiple studies and trials.
-    study_id = storage.create_new_study_id()
+    study_id = storage.create_new_study()
     trial_id_1 = storage.create_new_trial(study_id)
     trial_id_2 = storage.create_new_trial(study_id)
-    trial_id_3 = storage.create_new_trial(storage.create_new_study_id())
+    trial_id_3 = storage.create_new_trial(storage.create_new_study())
 
     # Setup Distributions.
     distribution_x = UniformDistribution(low=1.0, high=2.0)
@@ -396,10 +396,10 @@ def test_set_trial_value(storage_init_func):
     storage = storage_init_func()
 
     # Setup test across multiple studies and trials.
-    study_id = storage.create_new_study_id()
+    study_id = storage.create_new_study()
     trial_id_1 = storage.create_new_trial(study_id)
     trial_id_2 = storage.create_new_trial(study_id)
-    trial_id_3 = storage.create_new_trial(storage.create_new_study_id())
+    trial_id_3 = storage.create_new_trial(storage.create_new_study())
 
     # Test setting new value.
     storage.set_trial_value(trial_id_1, 0.5)
@@ -417,10 +417,10 @@ def test_set_trial_intermediate_value(storage_init_func):
     storage = storage_init_func()
 
     # Setup test across multiple studies and trials.
-    study_id = storage.create_new_study_id()
+    study_id = storage.create_new_study()
     trial_id_1 = storage.create_new_trial(study_id)
     trial_id_2 = storage.create_new_trial(study_id)
-    trial_id_3 = storage.create_new_trial(storage.create_new_study_id())
+    trial_id_3 = storage.create_new_trial(storage.create_new_study())
 
     # Test setting new values.
     assert storage.set_trial_intermediate_value(trial_id_1, 0, 0.3)
@@ -442,7 +442,7 @@ def test_set_trial_user_attr(storage_init_func):
     # type: (Callable[[], BaseStorage]) -> None
 
     storage = storage_init_func()
-    trial_id_1 = storage.create_new_trial(storage.create_new_study_id())
+    trial_id_1 = storage.create_new_trial(storage.create_new_study())
 
     def check_set_and_get(trial_id, key, value):
         # type: (int, str, Any) -> None
@@ -459,7 +459,7 @@ def test_set_trial_user_attr(storage_init_func):
     check_set_and_get(trial_id_1, 'dataset', 'ImageNet')
 
     # Test another trial.
-    trial_id_2 = storage.create_new_trial(storage.create_new_study_id())
+    trial_id_2 = storage.create_new_trial(storage.create_new_study())
     check_set_and_get(trial_id_2, 'baseline_score', 0.001)
     assert len(storage.get_trial(trial_id_2).user_attrs) == 1
     assert storage.get_trial(trial_id_2).user_attrs['baseline_score'] == 0.001
@@ -470,7 +470,7 @@ def test_set_and_get_tiral_system_attr(storage_init_func):
     # type: (Callable[[], BaseStorage]) -> None
 
     storage = storage_init_func()
-    study_id = storage.create_new_study_id()
+    study_id = storage.create_new_study()
     trial_id_1 = storage.create_new_trial(study_id)
 
     def check_set_and_get(trial_id, key, value):
@@ -501,7 +501,7 @@ def test_get_all_study_summaries(storage_init_func):
     # type: (Callable[[], BaseStorage]) -> None
 
     storage = storage_init_func()
-    study_id = storage.create_new_study_id()
+    study_id = storage.create_new_study()
 
     storage.set_study_direction(study_id, StudyDirection.MINIMIZE)
 
@@ -538,7 +538,7 @@ def test_get_trial(storage_init_func):
     # type: (Callable[[], BaseStorage]) -> None
 
     storage = storage_init_func()
-    study_id = storage.create_new_study_id()
+    study_id = storage.create_new_study()
 
     for example_trial in EXAMPLE_TRIALS:
         datetime_before = datetime.now()
@@ -566,8 +566,8 @@ def test_get_all_trials(storage_init_func):
     # type: (Callable[[], BaseStorage]) -> None
 
     storage = storage_init_func()
-    study_id_1 = storage.create_new_study_id()
-    study_id_2 = storage.create_new_study_id()
+    study_id_1 = storage.create_new_study()
+    study_id_2 = storage.create_new_study()
 
     datetime_before = datetime.now()
 
@@ -603,7 +603,7 @@ def test_get_n_trials(storage_init_func):
     # type: (Callable[[], BaseStorage]) -> None
 
     storage = storage_init_func()
-    study_id = storage.create_new_study_id()
+    study_id = storage.create_new_study()
 
     _create_new_trial_with_example_trial(storage, study_id, EXAMPLE_DISTRIBUTIONS,
                                          EXAMPLE_TRIALS[0])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -149,7 +149,7 @@ def test_study_set_user_attr_command(options):
         storage = RDBStorage(storage_url)
 
         # Create study.
-        study_name = storage.get_study_name_from_id(storage.create_new_study_id())
+        study_name = storage.get_study_name_from_id(storage.create_new_study())
 
         base_command = ['optuna', 'study', 'set-user-attr', '--study', study_name]
         base_command = _add_option(base_command, '--storage', storage_url, 'storage' in options)
@@ -246,7 +246,7 @@ def test_dashboard_command(options):
             tempfile.NamedTemporaryFile('r') as tf_report:
 
         storage = RDBStorage(storage_url)
-        study_name = storage.get_study_name_from_id(storage.create_new_study_id())
+        study_name = storage.get_study_name_from_id(storage.create_new_study())
 
         command = ['optuna', 'dashboard', '--study', study_name, '--out', tf_report.name]
         command = _add_option(command, '--storage', storage_url, 'storage' in options)
@@ -268,7 +268,7 @@ def test_dashboard_command_with_allow_websocket_origin(origins):
             tempfile.NamedTemporaryFile('r') as tf_report:
 
         storage = RDBStorage(storage_url)
-        study_name = storage.get_study_name_from_id(storage.create_new_study_id())
+        study_name = storage.get_study_name_from_id(storage.create_new_study())
         command = [
             'optuna', 'dashboard', '--study', study_name, '--out', tf_report.name, '--storage',
             storage_url
@@ -297,7 +297,7 @@ def test_study_optimize_command(options):
     with StorageConfigSupplier(TEST_CONFIG_TEMPLATE) as (storage_url, config_path):
         storage = RDBStorage(storage_url)
 
-        study_name = storage.get_study_name_from_id(storage.create_new_study_id())
+        study_name = storage.get_study_name_from_id(storage.create_new_study())
         command = [
             'optuna', 'study', 'optimize', '--study', study_name, '--n-trials', '10', __file__,
             'objective_func'

--- a/tests/test_trial.py
+++ b/tests/test_trial.py
@@ -31,7 +31,7 @@ def test_suggest_uniform(storage_init_func):
 
     with patch.object(sampler, 'sample_independent', mock) as mock_object:
         study = create_study(storage_init_func(), sampler=sampler)
-        trial = Trial(study, study._storage.create_new_trial_id(study.study_id))
+        trial = Trial(study, study._storage.create_new_trial(study.study_id))
         distribution = distributions.UniformDistribution(low=0., high=3.)
 
         assert trial._suggest('x', distribution) == 1.  # Test suggesting a param.
@@ -51,7 +51,7 @@ def test_suggest_discrete_uniform(storage_init_func):
 
     with patch.object(sampler, 'sample_independent', mock) as mock_object:
         study = create_study(storage_init_func(), sampler=sampler)
-        trial = Trial(study, study._storage.create_new_trial_id(study.study_id))
+        trial = Trial(study, study._storage.create_new_trial(study.study_id))
         distribution = distributions.DiscreteUniformDistribution(low=0., high=3., q=1.)
 
         assert trial._suggest('x', distribution) == 1.  # Test suggesting a param.
@@ -66,7 +66,7 @@ def test_suggest_low_equals_high(storage_init_func):
     # type: (typing.Callable[[], storages.BaseStorage]) -> None
 
     study = create_study(storage_init_func(), sampler=samplers.TPESampler(n_startup_trials=0))
-    trial = Trial(study, study._storage.create_new_trial_id(study.study_id))
+    trial = Trial(study, study._storage.create_new_trial(study.study_id))
 
     # Parameter values are determined without suggestion when low == high.
     with patch.object(trial, '_suggest', wraps=trial._suggest) as mock_object:
@@ -137,7 +137,7 @@ def test_suggest_discrete_uniform_range(storage_init_func, range_config):
     mock.side_effect = lambda study, trial, param_name, distribution: distribution.high
     with patch.object(sampler, 'sample_independent', mock) as mock_object:
         study = create_study(storage_init_func(), sampler=sampler)
-        trial = Trial(study, study._storage.create_new_trial_id(study.study_id))
+        trial = Trial(study, study._storage.create_new_trial(study.study_id))
 
         x = trial.suggest_discrete_uniform('x', range_config['low'], range_config['high'],
                                            range_config['q'])
@@ -149,7 +149,7 @@ def test_suggest_discrete_uniform_range(storage_init_func, range_config):
     mock.side_effect = lambda study, trial, param_name, distribution: distribution.low
     with patch.object(sampler, 'sample_independent', mock) as mock_object:
         study = create_study(storage_init_func(), sampler=sampler)
-        trial = Trial(study, study._storage.create_new_trial_id(study.study_id))
+        trial = Trial(study, study._storage.create_new_trial(study.study_id))
 
         x = trial.suggest_discrete_uniform('x', range_config['low'], range_config['high'],
                                            range_config['q'])
@@ -167,7 +167,7 @@ def test_suggest_int(storage_init_func):
 
     with patch.object(sampler, 'sample_independent', mock) as mock_object:
         study = create_study(storage_init_func(), sampler=sampler)
-        trial = Trial(study, study._storage.create_new_trial_id(study.study_id))
+        trial = Trial(study, study._storage.create_new_trial(study.study_id))
         distribution = distributions.IntUniformDistribution(low=0, high=3)
 
         assert trial._suggest('x', distribution) == 1  # Test suggesting a param.
@@ -209,7 +209,7 @@ def test_trial_should_prune():
 
     pruner = DeterministicPruner(True)
     study = create_study(pruner=pruner)
-    trial = Trial(study, study._storage.create_new_trial_id(study.study_id))
+    trial = Trial(study, study._storage.create_new_trial(study.study_id))
     trial.report(1, 1)
     assert trial.should_prune()
 
@@ -336,7 +336,7 @@ def test_relative_parameters(storage_init_func):
     def create_trial():
         # type: () -> Trial
 
-        return Trial(study, study._storage.create_new_trial_id(study.study_id))
+        return Trial(study, study._storage.create_new_trial(study.study_id))
 
     # Suggested from `relative_params`.
     trial0 = create_trial()


### PR DESCRIPTION
Because these methods create not only the identifier of a new study/trial but also its instance, this PR modifies the method names to match the actual functionalities.