### PR TITLE
Add function for optimization history visualization

### DIFF
--- a/examples/visualization/plot_optimization_history.ipynb
+++ b/examples/visualization/plot_optimization_history.ipynb
@@ -1,0 +1,1134 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Visualizing Optimization History in Jupyter Notebook\n",
+    "\n",
+    "This notebook demonstrates a visualization utility of Optuna.\n",
+    "After optimizing the hyperparameter of neural networks, `plot_optimization_history()` plots optimization history in a study."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setting up MNIST Dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "from sklearn.datasets import fetch_openml\n",
+    "from sklearn.model_selection import train_test_split\n",
+    "\n",
+    "mnist = fetch_openml('mnist_784', version=1)\n",
+    "classes = list(set(mnist.target))\n",
+    "x_train, x_test, y_train, y_test = train_test_split(mnist.data, mnist.target)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Defining Objective Function"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sklearn.neural_network import MLPClassifier\n",
+    "\n",
+    "def objective(trial):\n",
+    "\n",
+    "    layers = []\n",
+    "    n_layers = trial.suggest_int('n_layers', 1, 4)\n",
+    "    for i in range(n_layers):\n",
+    "        layers.append(trial.suggest_int('n_units_l{}'.format(i), 1, 128))\n",
+    "\n",
+    "    clf = MLPClassifier(hidden_layer_sizes=tuple(layers))\n",
+    "\n",
+    "    for step in range(100):\n",
+    "        clf.partial_fit(x_train, y_train, classes=classes)\n",
+    "\n",
+    "        intermediate_value = 1.0 - clf.score(x_test, y_test)  # Report intermediate objective value.\n",
+    "        trial.report(intermediate_value, step)\n",
+    "\n",
+    "        if trial.should_prune(step):\n",
+    "            raise optuna.structs.TrialPruned()  # Handle pruning based on the intermediate value.\n",
+    "\n",
+    "    return 1.0 - clf.score(x_test, y_test)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Running Optimization"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import optuna\n",
+    "optuna.logging.set_verbosity(optuna.logging.WARNING)  # This verbosity change is just to simplify the notebook output.\n",
+    "\n",
+    "study = optuna.create_study(pruner=optuna.pruners.SuccessiveHalvingPruner())\n",
+    "study.optimize(objective, n_trials=25)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Plotting Optimization History of Study"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "        <script type=\"text/javascript\">\n",
+       "        window.PlotlyConfig = {MathJaxConfig: 'local'};\n",
+       "        if (window.MathJax) {MathJax.Hub.Config({SVG: {font: \"STIX-Web\"}});}\n",
+       "        if (typeof require !== 'undefined') {\n",
+       "        require.undef(\"plotly\");\n",
+       "        requirejs.config({\n",
+       "            paths: {\n",
+       "                'plotly': ['https://cdn.plot.ly/plotly-latest.min']\n",
+       "            }\n",
+       "        });\n",
+       "        require(['plotly'], function(Plotly) {\n",
+       "            window._Plotly = Plotly;\n",
+       "        });\n",
+       "        }\n",
+       "        </script>\n",
+       "        "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "mode": "markers",
+         "name": "Objective Value",
+         "type": "scatter",
+         "x": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11,
+          12,
+          13,
+          14,
+          15,
+          16,
+          17,
+          18,
+          19,
+          20,
+          21,
+          22,
+          23,
+          24
+         ],
+         "y": [
+          0.029657142857142826,
+          0.8985714285714286,
+          0.11434285714285719,
+          0.19017142857142855,
+          0.1133142857142857,
+          0.3388,
+          0.3724571428571428,
+          0.03382857142857143,
+          0.13171428571428567,
+          0.10337142857142856,
+          0.06251428571428574,
+          0.8959428571428572,
+          0.06285714285714283,
+          0.1372,
+          0.0610857142857143,
+          0.09268571428571426,
+          0.7203999999999999,
+          0.030057142857142893,
+          0.6307428571428572,
+          0.10440000000000005,
+          0.05879999999999996,
+          0.03891428571428568,
+          0.8864,
+          0.8862857142857143,
+          0.48240000000000005
+         ]
+        },
+        {
+         "name": "Best Value",
+         "type": "scatter",
+         "x": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11,
+          12,
+          13,
+          14,
+          15,
+          16,
+          17,
+          18,
+          19,
+          20,
+          21,
+          22,
+          23,
+          24
+         ],
+         "y": [
+          0.029657142857142826,
+          0.029657142857142826,
+          0.029657142857142826,
+          0.029657142857142826,
+          0.029657142857142826,
+          0.029657142857142826,
+          0.029657142857142826,
+          0.029657142857142826,
+          0.029657142857142826,
+          0.029657142857142826,
+          0.029657142857142826,
+          0.029657142857142826,
+          0.029657142857142826,
+          0.029657142857142826,
+          0.029657142857142826,
+          0.029657142857142826,
+          0.029657142857142826,
+          0.029657142857142826,
+          0.029657142857142826,
+          0.029657142857142826,
+          0.029657142857142826,
+          0.029657142857142826,
+          0.029657142857142826,
+          0.029657142857142826,
+          0.029657142857142826
+         ]
+        }
+       ],
+       "layout": {
+        "template": {
+         "data": {
+          "bar": [
+           {
+            "error_x": {
+             "color": "#2a3f5f"
+            },
+            "error_y": {
+             "color": "#2a3f5f"
+            },
+            "marker": {
+             "line": {
+              "color": "#E5ECF6",
+              "width": 0.5
+             }
+            },
+            "type": "bar"
+           }
+          ],
+          "barpolar": [
+           {
+            "marker": {
+             "line": {
+              "color": "#E5ECF6",
+              "width": 0.5
+             }
+            },
+            "type": "barpolar"
+           }
+          ],
+          "carpet": [
+           {
+            "aaxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "white",
+             "linecolor": "white",
+             "minorgridcolor": "white",
+             "startlinecolor": "#2a3f5f"
+            },
+            "baxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "white",
+             "linecolor": "white",
+             "minorgridcolor": "white",
+             "startlinecolor": "#2a3f5f"
+            },
+            "type": "carpet"
+           }
+          ],
+          "choropleth": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "choropleth"
+           }
+          ],
+          "contour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "contour"
+           }
+          ],
+          "contourcarpet": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "contourcarpet"
+           }
+          ],
+          "heatmap": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmap"
+           }
+          ],
+          "heatmapgl": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmapgl"
+           }
+          ],
+          "histogram": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "histogram"
+           }
+          ],
+          "histogram2d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2d"
+           }
+          ],
+          "histogram2dcontour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2dcontour"
+           }
+          ],
+          "mesh3d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "mesh3d"
+           }
+          ],
+          "parcoords": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "parcoords"
+           }
+          ],
+          "scatter": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatter"
+           }
+          ],
+          "scatter3d": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatter3d"
+           }
+          ],
+          "scattercarpet": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattercarpet"
+           }
+          ],
+          "scattergeo": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergeo"
+           }
+          ],
+          "scattergl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergl"
+           }
+          ],
+          "scattermapbox": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermapbox"
+           }
+          ],
+          "scatterpolar": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolar"
+           }
+          ],
+          "scatterpolargl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolargl"
+           }
+          ],
+          "scatterternary": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterternary"
+           }
+          ],
+          "surface": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "surface"
+           }
+          ],
+          "table": [
+           {
+            "cells": {
+             "fill": {
+              "color": "#EBF0F8"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "header": {
+             "fill": {
+              "color": "#C8D4E3"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "type": "table"
+           }
+          ]
+         },
+         "layout": {
+          "annotationdefaults": {
+           "arrowcolor": "#2a3f5f",
+           "arrowhead": 0,
+           "arrowwidth": 1
+          },
+          "colorscale": {
+           "diverging": [
+            [
+             0,
+             "#8e0152"
+            ],
+            [
+             0.1,
+             "#c51b7d"
+            ],
+            [
+             0.2,
+             "#de77ae"
+            ],
+            [
+             0.3,
+             "#f1b6da"
+            ],
+            [
+             0.4,
+             "#fde0ef"
+            ],
+            [
+             0.5,
+             "#f7f7f7"
+            ],
+            [
+             0.6,
+             "#e6f5d0"
+            ],
+            [
+             0.7,
+             "#b8e186"
+            ],
+            [
+             0.8,
+             "#7fbc41"
+            ],
+            [
+             0.9,
+             "#4d9221"
+            ],
+            [
+             1,
+             "#276419"
+            ]
+           ],
+           "sequential": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ],
+           "sequentialminus": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ]
+          },
+          "colorway": [
+           "#636efa",
+           "#EF553B",
+           "#00cc96",
+           "#ab63fa",
+           "#FFA15A",
+           "#19d3f3",
+           "#FF6692",
+           "#B6E880",
+           "#FF97FF",
+           "#FECB52"
+          ],
+          "font": {
+           "color": "#2a3f5f"
+          },
+          "geo": {
+           "bgcolor": "white",
+           "lakecolor": "white",
+           "landcolor": "#E5ECF6",
+           "showlakes": true,
+           "showland": true,
+           "subunitcolor": "white"
+          },
+          "hoverlabel": {
+           "align": "left"
+          },
+          "hovermode": "closest",
+          "mapbox": {
+           "style": "light"
+          },
+          "paper_bgcolor": "white",
+          "plot_bgcolor": "#E5ECF6",
+          "polar": {
+           "angularaxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           },
+           "bgcolor": "#E5ECF6",
+           "radialaxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           }
+          },
+          "scene": {
+           "xaxis": {
+            "backgroundcolor": "#E5ECF6",
+            "gridcolor": "white",
+            "gridwidth": 2,
+            "linecolor": "white",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "white"
+           },
+           "yaxis": {
+            "backgroundcolor": "#E5ECF6",
+            "gridcolor": "white",
+            "gridwidth": 2,
+            "linecolor": "white",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "white"
+           },
+           "zaxis": {
+            "backgroundcolor": "#E5ECF6",
+            "gridcolor": "white",
+            "gridwidth": 2,
+            "linecolor": "white",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "white"
+           }
+          },
+          "shapedefaults": {
+           "line": {
+            "color": "#2a3f5f"
+           }
+          },
+          "ternary": {
+           "aaxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           },
+           "baxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           },
+           "bgcolor": "#E5ECF6",
+           "caxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           }
+          },
+          "title": {
+           "x": 0.05
+          },
+          "xaxis": {
+           "automargin": true,
+           "gridcolor": "white",
+           "linecolor": "white",
+           "ticks": "",
+           "zerolinecolor": "white",
+           "zerolinewidth": 2
+          },
+          "yaxis": {
+           "automargin": true,
+           "gridcolor": "white",
+           "linecolor": "white",
+           "ticks": "",
+           "zerolinecolor": "white",
+           "zerolinewidth": 2
+          }
+         }
+        },
+        "title": {
+         "text": "Optimization History Plot"
+        },
+        "xaxis": {
+         "title": {
+          "text": "Trial"
+         }
+        },
+        "yaxis": {
+         "title": {
+          "text": "Objective Value"
+         }
+        }
+       }
+      },
+      "text/html": [
+       "<div>\n",
+       "        \n",
+       "        \n",
+       "            <div id=\"d5ac79e2-2338-488c-88b6-858816b8692f\" class=\"plotly-graph-div\" style=\"height:525px; width:100%;\"></div>\n",
+       "            <script type=\"text/javascript\">\n",
+       "                require([\"plotly\"], function(Plotly) {\n",
+       "                    window.PLOTLYENV=window.PLOTLYENV || {};\n",
+       "                    \n",
+       "                if (document.getElementById(\"d5ac79e2-2338-488c-88b6-858816b8692f\")) {\n",
+       "                    Plotly.newPlot(\n",
+       "                        'd5ac79e2-2338-488c-88b6-858816b8692f',\n",
+       "                        [{\"mode\": \"markers\", \"name\": \"Objective Value\", \"type\": \"scatter\", \"x\": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24], \"y\": [0.029657142857142826, 0.8985714285714286, 0.11434285714285719, 0.19017142857142855, 0.1133142857142857, 0.3388, 0.3724571428571428, 0.03382857142857143, 0.13171428571428567, 0.10337142857142856, 0.06251428571428574, 0.8959428571428572, 0.06285714285714283, 0.1372, 0.0610857142857143, 0.09268571428571426, 0.7203999999999999, 0.030057142857142893, 0.6307428571428572, 0.10440000000000005, 0.05879999999999996, 0.03891428571428568, 0.8864, 0.8862857142857143, 0.48240000000000005]}, {\"name\": \"Best Value\", \"type\": \"scatter\", \"x\": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24], \"y\": [0.029657142857142826, 0.029657142857142826, 0.029657142857142826, 0.029657142857142826, 0.029657142857142826, 0.029657142857142826, 0.029657142857142826, 0.029657142857142826, 0.029657142857142826, 0.029657142857142826, 0.029657142857142826, 0.029657142857142826, 0.029657142857142826, 0.029657142857142826, 0.029657142857142826, 0.029657142857142826, 0.029657142857142826, 0.029657142857142826, 0.029657142857142826, 0.029657142857142826, 0.029657142857142826, 0.029657142857142826, 0.029657142857142826, 0.029657142857142826, 0.029657142857142826]}],\n",
+       "                        {\"template\": {\"data\": {\"bar\": [{\"error_x\": {\"color\": \"#2a3f5f\"}, \"error_y\": {\"color\": \"#2a3f5f\"}, \"marker\": {\"line\": {\"color\": \"#E5ECF6\", \"width\": 0.5}}, \"type\": \"bar\"}], \"barpolar\": [{\"marker\": {\"line\": {\"color\": \"#E5ECF6\", \"width\": 0.5}}, \"type\": \"barpolar\"}], \"carpet\": [{\"aaxis\": {\"endlinecolor\": \"#2a3f5f\", \"gridcolor\": \"white\", \"linecolor\": \"white\", \"minorgridcolor\": \"white\", \"startlinecolor\": \"#2a3f5f\"}, \"baxis\": {\"endlinecolor\": \"#2a3f5f\", \"gridcolor\": \"white\", \"linecolor\": \"white\", \"minorgridcolor\": \"white\", \"startlinecolor\": \"#2a3f5f\"}, \"type\": \"carpet\"}], \"choropleth\": [{\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}, \"type\": \"choropleth\"}], \"contour\": [{\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}, \"colorscale\": [[0.0, \"#0d0887\"], [0.1111111111111111, \"#46039f\"], [0.2222222222222222, \"#7201a8\"], [0.3333333333333333, \"#9c179e\"], [0.4444444444444444, \"#bd3786\"], [0.5555555555555556, \"#d8576b\"], [0.6666666666666666, \"#ed7953\"], [0.7777777777777778, \"#fb9f3a\"], [0.8888888888888888, \"#fdca26\"], [1.0, \"#f0f921\"]], \"type\": \"contour\"}], \"contourcarpet\": [{\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}, \"type\": \"contourcarpet\"}], \"heatmap\": [{\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}, \"colorscale\": [[0.0, \"#0d0887\"], [0.1111111111111111, \"#46039f\"], [0.2222222222222222, \"#7201a8\"], [0.3333333333333333, \"#9c179e\"], [0.4444444444444444, \"#bd3786\"], [0.5555555555555556, \"#d8576b\"], [0.6666666666666666, \"#ed7953\"], [0.7777777777777778, \"#fb9f3a\"], [0.8888888888888888, \"#fdca26\"], [1.0, \"#f0f921\"]], \"type\": \"heatmap\"}], \"heatmapgl\": [{\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}, \"colorscale\": [[0.0, \"#0d0887\"], [0.1111111111111111, \"#46039f\"], [0.2222222222222222, \"#7201a8\"], [0.3333333333333333, \"#9c179e\"], [0.4444444444444444, \"#bd3786\"], [0.5555555555555556, \"#d8576b\"], [0.6666666666666666, \"#ed7953\"], [0.7777777777777778, \"#fb9f3a\"], [0.8888888888888888, \"#fdca26\"], [1.0, \"#f0f921\"]], \"type\": \"heatmapgl\"}], \"histogram\": [{\"marker\": {\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}}, \"type\": \"histogram\"}], \"histogram2d\": [{\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}, \"colorscale\": [[0.0, \"#0d0887\"], [0.1111111111111111, \"#46039f\"], [0.2222222222222222, \"#7201a8\"], [0.3333333333333333, \"#9c179e\"], [0.4444444444444444, \"#bd3786\"], [0.5555555555555556, \"#d8576b\"], [0.6666666666666666, \"#ed7953\"], [0.7777777777777778, \"#fb9f3a\"], [0.8888888888888888, \"#fdca26\"], [1.0, \"#f0f921\"]], \"type\": \"histogram2d\"}], \"histogram2dcontour\": [{\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}, \"colorscale\": [[0.0, \"#0d0887\"], [0.1111111111111111, \"#46039f\"], [0.2222222222222222, \"#7201a8\"], [0.3333333333333333, \"#9c179e\"], [0.4444444444444444, \"#bd3786\"], [0.5555555555555556, \"#d8576b\"], [0.6666666666666666, \"#ed7953\"], [0.7777777777777778, \"#fb9f3a\"], [0.8888888888888888, \"#fdca26\"], [1.0, \"#f0f921\"]], \"type\": \"histogram2dcontour\"}], \"mesh3d\": [{\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}, \"type\": \"mesh3d\"}], \"parcoords\": [{\"line\": {\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}}, \"type\": \"parcoords\"}], \"scatter\": [{\"marker\": {\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}}, \"type\": \"scatter\"}], \"scatter3d\": [{\"line\": {\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}}, \"marker\": {\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}}, \"type\": \"scatter3d\"}], \"scattercarpet\": [{\"marker\": {\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}}, \"type\": \"scattercarpet\"}], \"scattergeo\": [{\"marker\": {\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}}, \"type\": \"scattergeo\"}], \"scattergl\": [{\"marker\": {\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}}, \"type\": \"scattergl\"}], \"scattermapbox\": [{\"marker\": {\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}}, \"type\": \"scattermapbox\"}], \"scatterpolar\": [{\"marker\": {\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}}, \"type\": \"scatterpolar\"}], \"scatterpolargl\": [{\"marker\": {\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}}, \"type\": \"scatterpolargl\"}], \"scatterternary\": [{\"marker\": {\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}}, \"type\": \"scatterternary\"}], \"surface\": [{\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}, \"colorscale\": [[0.0, \"#0d0887\"], [0.1111111111111111, \"#46039f\"], [0.2222222222222222, \"#7201a8\"], [0.3333333333333333, \"#9c179e\"], [0.4444444444444444, \"#bd3786\"], [0.5555555555555556, \"#d8576b\"], [0.6666666666666666, \"#ed7953\"], [0.7777777777777778, \"#fb9f3a\"], [0.8888888888888888, \"#fdca26\"], [1.0, \"#f0f921\"]], \"type\": \"surface\"}], \"table\": [{\"cells\": {\"fill\": {\"color\": \"#EBF0F8\"}, \"line\": {\"color\": \"white\"}}, \"header\": {\"fill\": {\"color\": \"#C8D4E3\"}, \"line\": {\"color\": \"white\"}}, \"type\": \"table\"}]}, \"layout\": {\"annotationdefaults\": {\"arrowcolor\": \"#2a3f5f\", \"arrowhead\": 0, \"arrowwidth\": 1}, \"colorscale\": {\"diverging\": [[0, \"#8e0152\"], [0.1, \"#c51b7d\"], [0.2, \"#de77ae\"], [0.3, \"#f1b6da\"], [0.4, \"#fde0ef\"], [0.5, \"#f7f7f7\"], [0.6, \"#e6f5d0\"], [0.7, \"#b8e186\"], [0.8, \"#7fbc41\"], [0.9, \"#4d9221\"], [1, \"#276419\"]], \"sequential\": [[0.0, \"#0d0887\"], [0.1111111111111111, \"#46039f\"], [0.2222222222222222, \"#7201a8\"], [0.3333333333333333, \"#9c179e\"], [0.4444444444444444, \"#bd3786\"], [0.5555555555555556, \"#d8576b\"], [0.6666666666666666, \"#ed7953\"], [0.7777777777777778, \"#fb9f3a\"], [0.8888888888888888, \"#fdca26\"], [1.0, \"#f0f921\"]], \"sequentialminus\": [[0.0, \"#0d0887\"], [0.1111111111111111, \"#46039f\"], [0.2222222222222222, \"#7201a8\"], [0.3333333333333333, \"#9c179e\"], [0.4444444444444444, \"#bd3786\"], [0.5555555555555556, \"#d8576b\"], [0.6666666666666666, \"#ed7953\"], [0.7777777777777778, \"#fb9f3a\"], [0.8888888888888888, \"#fdca26\"], [1.0, \"#f0f921\"]]}, \"colorway\": [\"#636efa\", \"#EF553B\", \"#00cc96\", \"#ab63fa\", \"#FFA15A\", \"#19d3f3\", \"#FF6692\", \"#B6E880\", \"#FF97FF\", \"#FECB52\"], \"font\": {\"color\": \"#2a3f5f\"}, \"geo\": {\"bgcolor\": \"white\", \"lakecolor\": \"white\", \"landcolor\": \"#E5ECF6\", \"showlakes\": true, \"showland\": true, \"subunitcolor\": \"white\"}, \"hoverlabel\": {\"align\": \"left\"}, \"hovermode\": \"closest\", \"mapbox\": {\"style\": \"light\"}, \"paper_bgcolor\": \"white\", \"plot_bgcolor\": \"#E5ECF6\", \"polar\": {\"angularaxis\": {\"gridcolor\": \"white\", \"linecolor\": \"white\", \"ticks\": \"\"}, \"bgcolor\": \"#E5ECF6\", \"radialaxis\": {\"gridcolor\": \"white\", \"linecolor\": \"white\", \"ticks\": \"\"}}, \"scene\": {\"xaxis\": {\"backgroundcolor\": \"#E5ECF6\", \"gridcolor\": \"white\", \"gridwidth\": 2, \"linecolor\": \"white\", \"showbackground\": true, \"ticks\": \"\", \"zerolinecolor\": \"white\"}, \"yaxis\": {\"backgroundcolor\": \"#E5ECF6\", \"gridcolor\": \"white\", \"gridwidth\": 2, \"linecolor\": \"white\", \"showbackground\": true, \"ticks\": \"\", \"zerolinecolor\": \"white\"}, \"zaxis\": {\"backgroundcolor\": \"#E5ECF6\", \"gridcolor\": \"white\", \"gridwidth\": 2, \"linecolor\": \"white\", \"showbackground\": true, \"ticks\": \"\", \"zerolinecolor\": \"white\"}}, \"shapedefaults\": {\"line\": {\"color\": \"#2a3f5f\"}}, \"ternary\": {\"aaxis\": {\"gridcolor\": \"white\", \"linecolor\": \"white\", \"ticks\": \"\"}, \"baxis\": {\"gridcolor\": \"white\", \"linecolor\": \"white\", \"ticks\": \"\"}, \"bgcolor\": \"#E5ECF6\", \"caxis\": {\"gridcolor\": \"white\", \"linecolor\": \"white\", \"ticks\": \"\"}}, \"title\": {\"x\": 0.05}, \"xaxis\": {\"automargin\": true, \"gridcolor\": \"white\", \"linecolor\": \"white\", \"ticks\": \"\", \"zerolinecolor\": \"white\", \"zerolinewidth\": 2}, \"yaxis\": {\"automargin\": true, \"gridcolor\": \"white\", \"linecolor\": \"white\", \"ticks\": \"\", \"zerolinecolor\": \"white\", \"zerolinewidth\": 2}}}, \"title\": {\"text\": \"Optimization History Plot\"}, \"xaxis\": {\"title\": {\"text\": \"Trial\"}}, \"yaxis\": {\"title\": {\"text\": \"Objective Value\"}}},\n",
+       "                        {\"responsive\": true}\n",
+       "                    ).then(function(){\n",
+       "                            \n",
+       "var gd = document.getElementById('d5ac79e2-2338-488c-88b6-858816b8692f');\n",
+       "var x = new MutationObserver(function (mutations, observer) {{\n",
+       "        var display = window.getComputedStyle(gd).display;\n",
+       "        if (!display || display === 'none') {{\n",
+       "            console.log([gd, 'removed!']);\n",
+       "            Plotly.purge(gd);\n",
+       "            observer.disconnect();\n",
+       "        }}\n",
+       "}});\n",
+       "\n",
+       "// Listen for the removal of the full notebook cells\n",
+       "var notebookContainer = gd.closest('#notebook-container');\n",
+       "if (notebookContainer) {{\n",
+       "    x.observe(notebookContainer, {childList: true});\n",
+       "}}\n",
+       "\n",
+       "// Listen for the clearing of the current output cell\n",
+       "var outputEl = gd.closest('.output');\n",
+       "if (outputEl) {{\n",
+       "    x.observe(outputEl, {childList: true});\n",
+       "}}\n",
+       "\n",
+       "                        })\n",
+       "                };\n",
+       "                });\n",
+       "            </script>\n",
+       "        </div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from optuna.visualization import plot_optimization_history\n",
+    "\n",
+    "plot_optimization_history(study)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/optuna/visualization.py
+++ b/optuna/visualization.py
@@ -117,7 +117,8 @@ def plot_optimization_history(study):
 
     Args:
         study:
-            A :class:`~optuna.study.Study` object whose trials are plotted for their objective values.
+            A :class:`~optuna.study.Study` object whose trials are plotted for their objective
+            values.
     """
 
     _check_plotly_availability()

--- a/optuna/visualization.py
+++ b/optuna/visualization.py
@@ -8,8 +8,6 @@ logger = get_logger(__name__)
 if type_checking.TYPE_CHECKING:
     from typing import List  # NOQA
 
-logger = get_logger(__name__)
-
 try:
     import plotly.graph_objs as go
     from plotly.graph_objs._figure import Figure  # NOQA

--- a/optuna/visualization.py
+++ b/optuna/visualization.py
@@ -144,7 +144,7 @@ def _get_optimization_history_plot(study):
             trial_value = trial.value
         else:
             raise ValueError(
-                'Trial{} has COMPLETE state, but its value is non-numeric.'.formate(trial.number)
+                'Trial{} has COMPLETE state, but its value is non-numeric.'.format(trial.number))
         if study.direction == StudyDirection.MINIMIZE:
             best_values.append(min(best_values[-1], trial_value))
         else:

--- a/optuna/visualization.py
+++ b/optuna/visualization.py
@@ -22,7 +22,7 @@ except ImportError as e:
 
 def plot_intermediate_values(study):
     # type: (Study) -> None
-    """Inside Jupyter notebook, plot intermediate values of all trials in a study.
+    """Plot intermediate values of all trials in a study.
 
     Example:
 
@@ -95,7 +95,7 @@ def _get_intermediate_plot(study):
 
 def plot_optimization_history(study):
     # type: (Study) -> None
-    """Inside Jupyter notebook, plot optimization history of all trials in a study.
+    """Plot optimization history of all trials in a study.
 
     Example:
 
@@ -130,7 +130,7 @@ def _get_optimization_history_plot(study):
 
     layout = go.Layout(
         title='Optimization History Plot',
-        xaxis={'title': 'Trial'},
+        xaxis={'title': 'Number of Trial'},
         yaxis={'title': 'Objective Value'},
     )
 
@@ -143,8 +143,8 @@ def _get_optimization_history_plot(study):
         elif isinstance(trial.value, float):
             trial_value = trial.value
         else:
-            logger.warning('Your study has a non-numeric value.')
-            return go.Figure(data=[], layout=layout)
+            raise ValueError(
+                'Trial{} has COMPLETE state, but its value is non-numeric.'.formate(trial.number)
         if study.direction == StudyDirection.MINIMIZE:
             best_values.append(min(best_values[-1], trial_value))
         else:

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -7,9 +7,8 @@ from optuna.visualization import _get_optimization_history_plot
 def test_get_intermediate_plot():
     # type: () -> None
 
+    # Test with no trial
     study = create_study()
-
-    # Test with no trial.
     figure = _get_intermediate_plot(study)
     assert len(figure.data) == 0
 
@@ -22,6 +21,7 @@ def test_get_intermediate_plot():
         return 0.0
 
     # Test with a trial with intermediate values.
+    study = create_study()
     study.optimize(lambda t: objective(t, True), n_trials=1)
     figure = _get_intermediate_plot(study)
     assert len(figure.data) == 1
@@ -29,9 +29,12 @@ def test_get_intermediate_plot():
     assert tuple(figure.data[0].y) == (1.0, 2.0)
 
     # Test with trials, one of which contains no intermediate value.
+    study = create_study()
     study.optimize(lambda t: objective(t, False), n_trials=1)
     figure = _get_intermediate_plot(study)
     assert len(figure.data) == 1
+    assert len(figure.data[0].x) == 0
+    assert len(figure.data[0].y) == 0
 
     # Ignore failed trials.
     def fail_objective(_):
@@ -39,37 +42,37 @@ def test_get_intermediate_plot():
 
         raise ValueError
 
+    study = create_study()
     study.optimize(fail_objective, n_trials=1)
     figure = _get_intermediate_plot(study)
-    assert len(figure.data) == 1
+    assert len(figure.data) == 0
 
 
 def test_get_optimization_history_plot():
     # type: () -> None
 
-    study = create_study()
-
     # Test with no trial.
+    study = create_study()
     figure = _get_optimization_history_plot(study)
     assert len(figure.data[0].x) == 0
     assert len(figure.data[0].y) == 0
     assert len(figure.data[1].x) == 0
     assert len(figure.data[1].y) == 0
 
-    def objective(trial, n_iterate):
-        # type: (Trial, int) -> float
+    def objective(trial):
+        # type: (Trial) -> float
 
-        if n_iterate == 0:
+        if trial.number == 0:
             return 1.0
-        elif n_iterate == 1:
+        elif trial.number == 1:
             return 2.0
-        elif n_iterate == 2:
+        elif trial.number == 2:
             return 0.0
         return 0.0
 
     # Test with a trial
-    for i in range(3):
-        study.optimize(lambda t: objective(t, i), n_trials=1)
+    study = create_study()
+    study.optimize(objective, n_trials=3)
     figure = _get_optimization_history_plot(study)
     assert len(figure.data) == 2
     assert tuple(figure.data[0].x) == (0, 1, 2)
@@ -83,5 +86,7 @@ def test_get_optimization_history_plot():
 
         raise ValueError
 
+    study = create_study()
     study.optimize(fail_objective, n_trials=1)
+    figure = _get_optimization_history_plot(study)
     assert len(figure.data) == 2

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -1,7 +1,7 @@
 from optuna.study import create_study
 from optuna.trial import Trial  # NOQA
-from optuna.visualization import _get_optimization_history_plot
 from optuna.visualization import _get_intermediate_plot
+from optuna.visualization import _get_optimization_history_plot
 
 
 def test_get_intermediate_plot():
@@ -29,7 +29,8 @@ def test_get_intermediate_plot():
     assert tuple(figure.data[0].y) == (1.0, 2.0)
 
     # Test with trials, one of which contains no intermediate value.
-    figure = study.optimize(lambda t: objective(t, False), n_trials=1)
+    study.optimize(lambda t: objective(t, False), n_trials=1)
+    figure = _get_intermediate_plot(study)
     assert len(figure.data) == 1
 
     # Ignore failed trials.
@@ -38,7 +39,8 @@ def test_get_intermediate_plot():
 
         raise ValueError
 
-    figure = study.optimize(fail_objective, n_trials=1)
+    study.optimize(fail_objective, n_trials=1)
+    figure = _get_intermediate_plot(study)
     assert len(figure.data) == 1
 
 

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -1,5 +1,6 @@
 from optuna.study import create_study
 from optuna.trial import Trial  # NOQA
+from optuna.visualization import _get_optimization_history_plot
 from optuna.visualization import _get_intermediate_plot
 
 
@@ -28,7 +29,7 @@ def test_get_intermediate_plot():
     assert tuple(figure.data[0].y) == (1.0, 2.0)
 
     # Test with trials, one of which contains no intermediate value.
-    study.optimize(lambda t: objective(t, False), n_trials=1)
+    figure = study.optimize(lambda t: objective(t, False), n_trials=1)
     assert len(figure.data) == 1
 
     # Ignore failed trials.
@@ -37,5 +38,48 @@ def test_get_intermediate_plot():
 
         raise ValueError
 
-    study.optimize(fail_objective, n_trials=1)
+    figure = study.optimize(fail_objective, n_trials=1)
     assert len(figure.data) == 1
+
+
+def test_get_optimization_history_plot():
+    # type: () -> None
+
+    study = create_study()
+
+    # Test with no trial.
+    figure = _get_optimization_history_plot(study)
+    assert len(figure.data[0].x) == 0
+    assert len(figure.data[0].y) == 0
+    assert len(figure.data[1].x) == 0
+    assert len(figure.data[1].y) == 0
+
+    def objective(trial, n_iterate):
+        # type: (Trial, int) -> float
+
+        if n_iterate == 0:
+            return 1.0
+        elif n_iterate == 1:
+            return 2.0
+        elif n_iterate == 2:
+            return 0.0
+        return 0.0
+
+    # Test with a trial
+    for i in range(3):
+        study.optimize(lambda t: objective(t, i), n_trials=1)
+    figure = _get_optimization_history_plot(study)
+    assert len(figure.data) == 2
+    assert tuple(figure.data[0].x) == (0, 1, 2)
+    assert tuple(figure.data[0].y) == (1.0, 2.0, 0.0)
+    assert tuple(figure.data[1].x) == (0, 1, 2)
+    assert tuple(figure.data[1].y) == (1.0, 1.0, 0.0)
+
+    # Ignore failed trials.
+    def fail_objective(_):
+        # type: (Trial) -> float
+
+        raise ValueError
+
+    study.optimize(fail_objective, n_trials=1)
+    assert len(figure.data) == 2


### PR DESCRIPTION
Add `plot_optimization_history` for optimization history visualization.
It makes possible for us to plot optimization history.

As example:

<img width="1307" alt="スクリーンショット 2019-09-12 17 57 07" src="https://user-images.githubusercontent.com/26019402/64770029-567f5f00-d587-11e9-9567-6b3687c31be2.png">
