### PR TITLE
Change class to use for type checking.

### DIFF
--- a/optuna/trial.py
+++ b/optuna/trial.py
@@ -455,7 +455,7 @@ class Trial(BaseTrial):
         return self._set_new_param_or_get_existing(name, param_value, distribution)
 
     def _set_new_param_or_get_existing(self, name, param_value, distribution):
-        # type: (str, Any, distributions.BaseDistribution) -> Any
+        # type: (str, Any, BaseDistribution) -> Any
 
         param_value_in_internal_repr = distribution.to_internal_repr(param_value)
         set_success = self.storage.set_trial_param(self._trial_id, name,


### PR DESCRIPTION
One method did type checking as `# type: (str, Any, distributions.BaseDistribution) -> Any`.
But, at top of the code, did `from optuna.distributions import BaseDistribution  # NOQA` for type checking.
Therefor, we shoud do type checking as `# type: (str, Any, BaseDistribution) -> Any`.

Sorry for the small change...