### PR TITLE
Pruning callback for tf.keras

### DIFF
--- a/docs/source/reference/integration.rst
+++ b/docs/source/reference/integration.rst
@@ -29,6 +29,9 @@ Integration
 .. autoclass:: TensorFlowPruningHook
     :members:
 
+.. autoclass:: TFKerasPruningCallback
+    :members:
+
 .. autoclass:: XGBoostPruningCallback
     :members:
 

--- a/docs/source/tutorial/pruning.rst
+++ b/docs/source/tutorial/pruning.rst
@@ -80,6 +80,7 @@ To implement pruning mechanism in much simpler forms, Optuna provides integratio
 - Chainer: :class:`optuna.integration.ChainerPruningExtension`
 - Keras: :class:`optuna.integration.KerasPruningCallback`
 - TensorFlow :class:`optuna.integration.TensorFlowPruningHook`
+- tf.keras :class:`optuna.integration.TFKerasPruningCallback`
 - MXNet :class:`optuna.integration.MXNetPruningCallback`
 
 For example, :class:`~optuna.integration.XGBoostPruningCallback` introduces pruning without directly changing the logic of training iteration.

--- a/examples/pruning/tfkeras_integration.py
+++ b/examples/pruning/tfkeras_integration.py
@@ -49,7 +49,7 @@ def eval_dataset():
 
 def create_model(trial):
 
-    # Hyper parameters to be tuned by Optuna.
+    # Hyperparameters to be tuned by Optuna.
     lr = trial.suggest_loguniform('lr', 1e-4, 1e-1)
     momentum = trial.suggest_uniform('momentum', 0.0, 1.0)
     units = trial.suggest_categorical('units', [32, 64, 128, 256, 512])

--- a/examples/pruning/tfkeras_integration.py
+++ b/examples/pruning/tfkeras_integration.py
@@ -11,9 +11,10 @@ You can run this example as follows:
 
 """
 
-import optuna
 import tensorflow as tf
 import tensorflow_datasets as tfds
+
+import optuna
 from optuna.integration import TFKerasPruningCallback
 
 
@@ -100,7 +101,7 @@ def objective(trial):
         callbacks=callbacks,
     )
 
-    # TODO: Investigate why the logger below is called twice.
+    # TODO(@sfujiwara): Investigate why the logger here is called twice.
     # tf.logging.info(history.history[monitor][-1])
 
     return history.history[monitor][-1]

--- a/examples/pruning/tfkeras_integration.py
+++ b/examples/pruning/tfkeras_integration.py
@@ -135,7 +135,7 @@ def main():
         pruner=optuna.pruners.MedianPruner(n_startup_trials=2)
     )
 
-    study.optimize(objective, n_trials=25, timeout=600
+    study.optimize(objective, n_trials=25, timeout=600)
 
     show_result(study)
 

--- a/examples/pruning/tfkeras_integration.py
+++ b/examples/pruning/tfkeras_integration.py
@@ -50,18 +50,18 @@ def eval_dataset():
 def create_model(trial):
     # type: (optuna.trial) -> tf.keras.Model
 
-    # Hyper parameters to be tuned by Optuna
+    # Hyper parameters to be tuned by Optuna.
     lr = trial.suggest_loguniform('lr', 1e-4, 1e-1)
     momentum = trial.suggest_uniform('momentum', 0.0, 1.0)
     units = trial.suggest_categorical('units', [32, 64, 128, 256, 512])
 
-    # Compose neural network with one hidden layer
+    # Compose neural network with one hidden layer.
     model = tf.keras.Sequential()
     model.add(tf.keras.layers.Flatten())
     model.add(tf.keras.layers.Dense(units=units, activation=tf.nn.relu))
     model.add(tf.keras.layers.Dense(CLASSES, activation=tf.nn.softmax))
 
-    # Compile model
+    # Compile model.
     model.compile(
         optimizer=tf.keras.optimizers.SGD(lr=lr, momentum=momentum, nesterov=True),
         loss='sparse_categorical_crossentropy',
@@ -100,7 +100,7 @@ def objective(trial):
         callbacks=callbacks,
     )
 
-    # TODO: Investigate why the logger below is called twice
+    # TODO: Investigate why the logger below is called twice.
     # tf.logging.info(history.history[monitor][-1])
 
     return history.history[monitor][-1]

--- a/examples/pruning/tfkeras_integration.py
+++ b/examples/pruning/tfkeras_integration.py
@@ -76,7 +76,10 @@ def objective(trial):
     # type: (optuna.Trial) -> float
 
     # Metrics to be monitored by Optuna.
-    monitor = 'val_acc'
+    if tf.__version__ >= '2':
+        monitor = 'val_accuracy'
+    else:
+        monitor = 'val_acc'
 
     # Create tf.keras model instance.
     model = create_model(trial)
@@ -87,7 +90,7 @@ def objective(trial):
 
     # Create callbacks for early stopping and pruning.
     callbacks = [
-        tf.keras.callbacks.EarlyStopping(monitor=monitor, patience=3),
+        tf.keras.callbacks.EarlyStopping(patience=3),
         TFKerasPruningCallback(trial, monitor)
     ]
 
@@ -102,7 +105,8 @@ def objective(trial):
     )
 
     # TODO(@sfujiwara): Investigate why the logger here is called twice.
-    # tf.logging.info(history.history[monitor][-1])
+    # tf.compat.v1.logging.set_verbosity(tf.compat.v1.logging.DEBUG)
+    # tf.compat.v1.logging.info('hello optuna')
 
     return history.history[monitor][-1]
 
@@ -130,13 +134,10 @@ def show_result(study):
 
 def main():
 
-    tf.logging.set_verbosity(tf.logging.DEBUG)
-
     study = optuna.create_study(
         direction='maximize',
         pruner=optuna.pruners.MedianPruner(n_startup_trials=2)
     )
-    tf.logging.info('study is created')
 
     study.optimize(objective, n_trials=10)
 

--- a/examples/pruning/tfkeras_integration.py
+++ b/examples/pruning/tfkeras_integration.py
@@ -135,7 +135,7 @@ def main():
         pruner=optuna.pruners.MedianPruner(n_startup_trials=2)
     )
 
-    study.optimize(objective, n_trials=10)
+    study.optimize(objective, n_trials=25, timeout=600
 
     show_result(study)
 

--- a/examples/pruning/tfkeras_integration.py
+++ b/examples/pruning/tfkeras_integration.py
@@ -1,0 +1,146 @@
+"""
+Optuna example that demonstrates a pruner for tf.keras.
+
+In this example, we optimize the validation accuracy of hand-written digit recognition using
+Keras and MNIST, where the architecture of the neural network and the learning rate of optimizer
+is optimized. Throughout the training of neural networks, a pruner observes intermediate
+results and stops unpromising trials.
+
+You can run this example as follows:
+    $ python tfkeras_integration.py
+
+"""
+
+import optuna
+import tensorflow as tf
+import tensorflow_datasets as tfds
+from optuna.integration import TFKerasPruningCallback
+
+
+BATCHSIZE = 128
+CLASSES = 10
+EPOCHS = 20
+N_TRAIN_EXAMPLES = 60000
+STEPS_PER_EPOCH = int(N_TRAIN_EXAMPLES / BATCHSIZE / 10)
+VALIDATION_STEPS = 30
+
+
+def train_dataset():
+    # type: () -> tf.data.Dataset
+
+    ds = tfds.load('mnist', split=tfds.Split.TRAIN, shuffle_files=True)
+    ds = ds.map(lambda x: (tf.cast(x['image'], tf.float32)/255., x['label']))
+    ds = ds.repeat().shuffle(1024).batch(BATCHSIZE)
+    ds = ds.prefetch(tf.data.experimental.AUTOTUNE)
+
+    return ds
+
+
+def eval_dataset():
+    # type: () -> tf.data.Dataset
+
+    ds = tfds.load('mnist', split=tfds.Split.TEST, shuffle_files=False)
+    ds = ds.map(lambda x: (tf.cast(x['image'], tf.float32)/255., x['label']))
+    ds = ds.repeat().batch(BATCHSIZE)
+    ds = ds.prefetch(tf.data.experimental.AUTOTUNE)
+
+    return ds
+
+
+def create_model(trial):
+    # type: (optuna.trial) -> tf.keras.Model
+
+    # Hyper parameters to be tuned by Optuna
+    lr = trial.suggest_loguniform('lr', 1e-4, 1e-1)
+    momentum = trial.suggest_uniform('momentum', 0.0, 1.0)
+    units = trial.suggest_categorical('units', [32, 64, 128, 256, 512])
+
+    # Compose neural network with one hidden layer
+    model = tf.keras.Sequential()
+    model.add(tf.keras.layers.Flatten())
+    model.add(tf.keras.layers.Dense(units=units, activation=tf.nn.relu))
+    model.add(tf.keras.layers.Dense(CLASSES, activation=tf.nn.softmax))
+
+    # Compile model
+    model.compile(
+        optimizer=tf.keras.optimizers.SGD(lr=lr, momentum=momentum, nesterov=True),
+        loss='sparse_categorical_crossentropy',
+        metrics=['accuracy'],
+    )
+
+    return model
+
+
+def objective(trial):
+    # type: (optuna.Trial) -> float
+
+    # Metrics to be monitored by Optuna.
+    monitor = 'val_acc'
+
+    # Create tf.keras model instance.
+    model = create_model(trial)
+
+    # Create dataset instance.
+    ds_train = train_dataset()
+    ds_eval = eval_dataset()
+
+    # Create callbacks for early stopping and pruning.
+    callbacks = [
+        tf.keras.callbacks.EarlyStopping(monitor=monitor, patience=3),
+        TFKerasPruningCallback(trial, monitor)
+    ]
+
+    # Train model.
+    history = model.fit(
+        ds_train,
+        epochs=EPOCHS,
+        steps_per_epoch=STEPS_PER_EPOCH,
+        validation_data=ds_eval,
+        validation_steps=VALIDATION_STEPS,
+        callbacks=callbacks,
+    )
+
+    # TODO: Investigate why the logger below is called twice
+    # tf.logging.info(history.history[monitor][-1])
+
+    return history.history[monitor][-1]
+
+
+def show_result(study):
+    # type: (optuna.Study) -> None
+
+    pruned_trials = [t for t in study.trials if t.state == optuna.structs.TrialState.PRUNED]
+    complete_trials = [t for t in study.trials if t.state == optuna.structs.TrialState.COMPLETE]
+
+    print('Study statistics: ')
+    print('  Number of finished trials: ', len(study.trials))
+    print('  Number of pruned trials: ', len(pruned_trials))
+    print('  Number of complete trials: ', len(complete_trials))
+
+    print('Best trial:')
+    trial = study.best_trial
+
+    print('  Value: ', trial.value)
+
+    print('  Params: ')
+    for key, value in trial.params.items():
+        print('    {}: {}'.format(key, value))
+
+
+def main():
+
+    tf.logging.set_verbosity(tf.logging.DEBUG)
+
+    study = optuna.create_study(
+        direction='maximize',
+        pruner=optuna.pruners.MedianPruner(n_startup_trials=2)
+    )
+    tf.logging.info('study is created')
+
+    study.optimize(objective, n_trials=10)
+
+    show_result(study)
+
+
+if __name__ == '__main__':
+    main()

--- a/examples/pruning/tfkeras_integration.py
+++ b/examples/pruning/tfkeras_integration.py
@@ -1,10 +1,11 @@
 """
 Optuna example that demonstrates a pruner for tf.keras.
 
-In this example, we optimize the validation accuracy of hand-written digit recognition using
-Keras and MNIST, where the architecture of the neural network and the learning rate of optimizer
-is optimized. Throughout the training of neural networks, a pruner observes intermediate
-results and stops unpromising trials.
+In this example, we optimize the validation accuracy of hand-written digit recognition
+using tf.keras and MNIST, where the architecture of the neural network
+and the parameters of optimizer are optimized.
+Throughout the training of neural networks,
+a pruner observes intermediate results and stops unpromising trials.
 
 You can run this example as follows:
     $ python tfkeras_integration.py

--- a/examples/pruning/tfkeras_integration.py
+++ b/examples/pruning/tfkeras_integration.py
@@ -28,7 +28,6 @@ VALIDATION_STEPS = 30
 
 
 def train_dataset():
-    # type: () -> tf.data.Dataset
 
     ds = tfds.load('mnist', split=tfds.Split.TRAIN, shuffle_files=True)
     ds = ds.map(lambda x: (tf.cast(x['image'], tf.float32)/255., x['label']))
@@ -39,7 +38,6 @@ def train_dataset():
 
 
 def eval_dataset():
-    # type: () -> tf.data.Dataset
 
     ds = tfds.load('mnist', split=tfds.Split.TEST, shuffle_files=False)
     ds = ds.map(lambda x: (tf.cast(x['image'], tf.float32)/255., x['label']))
@@ -50,7 +48,6 @@ def eval_dataset():
 
 
 def create_model(trial):
-    # type: (optuna.trial) -> tf.keras.Model
 
     # Hyper parameters to be tuned by Optuna.
     lr = trial.suggest_loguniform('lr', 1e-4, 1e-1)
@@ -74,7 +71,6 @@ def create_model(trial):
 
 
 def objective(trial):
-    # type: (optuna.Trial) -> float
 
     # Metrics to be monitored by Optuna.
     if tf.__version__ >= '2':
@@ -113,7 +109,6 @@ def objective(trial):
 
 
 def show_result(study):
-    # type: (optuna.Study) -> None
 
     pruned_trials = [t for t in study.trials if t.state == optuna.structs.TrialState.PRUNED]
     complete_trials = [t for t in study.trials if t.state == optuna.structs.TrialState.COMPLETE]

--- a/optuna/integration/__init__.py
+++ b/optuna/integration/__init__.py
@@ -15,6 +15,7 @@ _import_structure = {
     'mxnet': ['MXNetPruningCallback'],
     'skopt': ['SkoptSampler'],
     'tensorflow': ['TensorFlowPruningHook'],
+    'tfkeras': ['TFKerasPruningCallback'],
     'xgboost': ['XGBoostPruningCallback'],
 }
 
@@ -31,6 +32,7 @@ if sys.version_info[0] == 2 or TYPE_CHECKING:
     from optuna.integration.mxnet import MXNetPruningCallback  # NOQA
     from optuna.integration.skopt import SkoptSampler  # NOQA
     from optuna.integration.tensorflow import TensorFlowPruningHook  # NOQA
+    from optuna.integration.tfkeras import TFKerasPruningCallback  # NOQA
     from optuna.integration.xgboost import XGBoostPruningCallback  # NOQA
 else:
     class _IntegrationModule(ModuleType):

--- a/optuna/integration/tfkeras.py
+++ b/optuna/integration/tfkeras.py
@@ -55,7 +55,7 @@ class TFKerasPruningCallback(Callback):
         if current_score is None:
             return
 
-        # Report current score and epoch to Optuna's trial
+        # Report current score and epoch to Optuna's trial.
         self.trial.report(current_score, step=epoch)
 
         # Prune trial if needed

--- a/optuna/integration/tfkeras.py
+++ b/optuna/integration/tfkeras.py
@@ -1,0 +1,75 @@
+from __future__ import absolute_import
+
+import optuna
+from optuna import type_checking
+
+if type_checking.TYPE_CHECKING:
+    from typing import Dict  # NOQA
+    from typing import Any  # NOQA
+
+try:
+    from tensorflow.keras.callbacks import Callback
+    _available = True
+except ImportError as e:
+    _import_error = e
+    # TFKerasPruningCallback is disabled because TensorFlow is not available.
+    _available = False
+    Callback = object
+
+
+class TFKerasPruningCallback(Callback):
+    """tf.keras callback to prune unpromising trials.
+
+    Example:
+
+        Add a pruning callback which observes validation losses.
+
+        .. code::
+
+            model.fit(x, y, callbacks=TFKerasPruningCallback(trial, 'val_loss'))
+
+    Args:
+        trial:
+            A :class: `~optuna.trial.Trial` corresponding to the current evaluation of the
+            objective function.
+        monitor:
+            An evaluation metric for pruning, e.g., ``val_loss`` or ``val_acc``.
+    """
+
+    def __init__(self, trial, monitor):
+        # type: (optuna.trial.Trial, str) -> None
+
+        super(TFKerasPruningCallback, self).__init__()
+
+        _check_tensorflow_availability()
+
+        self.trial = trial
+        self.monitor = monitor
+
+    def on_epoch_end(self, epoch, logs=None):
+        # type: (int, Dict[str, Any]) -> None
+
+        logs = logs or {}
+        current_score = logs.get(self.monitor)
+
+        if current_score is None:
+            return
+
+        # Report current score and epoch to Optuna's trial
+        self.trial.report(current_score, step=epoch)
+
+        # Prune trial if needed
+        if self.trial.should_prune():
+            message = "Trial was pruned at epoch {}.".format(epoch)
+            raise optuna.structs.TrialPruned(message)
+
+
+def _check_tensorflow_availability():
+    # type: () -> None
+
+    if not _available:
+        raise ImportError(
+            'TensorFlow is not available. Please install TensorFlow to use this feature. '
+            'TensorFlow can be installed by executing `$ pip install tensorflow`. '
+            'For further information, please refer to the installation guide of TensorFlow. '
+            '(The actual import error is as follows: ' + str(_import_error) + ')')

--- a/optuna/integration/tfkeras.py
+++ b/optuna/integration/tfkeras.py
@@ -19,6 +19,7 @@ except ImportError as e:
 
 class TFKerasPruningCallback(Callback):
     """tf.keras callback to prune unpromising trials.
+
     This callback is intend to be compatible for TensorFlow v1 and v2,
     but only tested with TensorFlow v1.
 

--- a/optuna/integration/tfkeras.py
+++ b/optuna/integration/tfkeras.py
@@ -26,7 +26,7 @@ class TFKerasPruningCallback(Callback):
 
         .. code::
 
-            model.fit(x, y, callbacks=TFKerasPruningCallback(trial, 'val_loss'))
+            model.fit(x, y, callbacks=[TFKerasPruningCallback(trial, 'val_loss')])
 
     Args:
         trial:

--- a/optuna/integration/tfkeras.py
+++ b/optuna/integration/tfkeras.py
@@ -19,6 +19,8 @@ except ImportError as e:
 
 class TFKerasPruningCallback(Callback):
     """tf.keras callback to prune unpromising trials.
+    This callback is intend to be compatible for TensorFlow v1 and v2,
+    but only tested with TensorFlow v1.
 
     Example:
 

--- a/optuna/integration/tfkeras.py
+++ b/optuna/integration/tfkeras.py
@@ -33,7 +33,7 @@ class TFKerasPruningCallback(Callback):
 
     Args:
         trial:
-            A :class: `~optuna.trial.Trial` corresponding to the current evaluation of the
+            A :class:`~optuna.trial.Trial` corresponding to the current evaluation of the
             objective function.
         monitor:
             An evaluation metric for pruning, e.g., ``val_loss`` or ``val_acc``.

--- a/optuna/integration/tfkeras.py
+++ b/optuna/integration/tfkeras.py
@@ -4,8 +4,8 @@ import optuna
 from optuna import type_checking
 
 if type_checking.TYPE_CHECKING:
-    from typing import Dict  # NOQA
     from typing import Any  # NOQA
+    from typing import Dict  # NOQA
 
 try:
     from tensorflow.keras.callbacks import Callback

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ def get_extras_require():
         'testing': [
             'bokeh', 'chainer>=5.0.0', 'cma', 'keras', 'lightgbm', 'mock',
             'mpi4py', 'mxnet', 'plotly>=4.0.0', 'pytest', 'scikit-optimize',
-            'tensorflow', 'xgboost',
+            'tensorflow', 'tensorflow-datasets', 'xgboost',
         ],
         'document': ['sphinx', 'sphinx_rtd_theme'],
         'codecov': ['pytest-cov', 'codecov'],

--- a/tests/integration_tests/test_tfkeras.py
+++ b/tests/integration_tests/test_tfkeras.py
@@ -1,0 +1,52 @@
+import numpy as np
+import pytest
+import tensorflow as tf
+
+import optuna
+from optuna.integration import TFKerasPruningCallback
+from optuna.testing.integration import create_running_trial
+from optuna.testing.integration import DeterministicPruner
+
+
+def test_tfkeras_pruning_callback():
+    # type: () -> None
+
+    def objective(trial):
+        # type: (optuna.trial.Trial) -> float
+
+        model = tf.keras.Sequential()
+        model.add(tf.keras.layers.Dense(1, activation='sigmoid', input_dim=20))
+        model.compile(optimizer='rmsprop', loss='binary_crossentropy', metrics=['accuracy'])
+        model.fit(
+            np.zeros((16, 20), np.float32),
+            np.zeros((16, ), np.int32),
+            batch_size=1,
+            epochs=1,
+            callbacks=[TFKerasPruningCallback(trial, 'acc')],
+            verbose=0
+        )
+
+        return 1.0
+
+    study = optuna.create_study(pruner=DeterministicPruner(True))
+    study.optimize(objective, n_trials=1)
+    assert study.trials[0].state == optuna.structs.TrialState.PRUNED
+
+    study = optuna.create_study(pruner=DeterministicPruner(False))
+    study.optimize(objective, n_trials=1)
+    assert study.trials[0].state == optuna.structs.TrialState.COMPLETE
+    assert study.trials[0].value == 1.0
+
+
+def test_tfkeras_pruning_callback_observation_isnan():
+    # type: () -> None
+
+    study = optuna.create_study(pruner=DeterministicPruner(True))
+    trial = create_running_trial(study, 1.0)
+    callback = TFKerasPruningCallback(trial, 'loss')
+
+    with pytest.raises(optuna.structs.TrialPruned):
+        callback.on_epoch_end(0, {'loss': 1.0})
+
+    with pytest.raises(optuna.structs.TrialPruned):
+        callback.on_epoch_end(0, {'loss': float('nan')})


### PR DESCRIPTION
I implemented `TFKerasPruningCallback` for #490.

* `tfkeras.py`
  * Implementation of `TFKerasPruningCallback`
* `tfkeras_integration.py`
  * An example of `TFKerasPruningCallback`
* `test_tfkeras.py`
  * Unit tests for `TFKerasPruningCallback`

The implementation is similar to [`KerasPruningCallback`](https://optuna.readthedocs.io/en/latest/reference/integration.html#optuna.integration.KerasPruningCallback).
It report the score to the trial every epoch.

## Maybe future works but out of scope for this PR

* This callback is intended to be compatible for TensorFlow v1 and v2, but tested only with v1
  * We need large modification to the config of CircleCI
* It's better to report score every n batch
  * Currently report only every epoch
