### PR TITLE
Fix `test_keras_pruning_callback` to be compatible with `keras==2.3.0`.

### DIFF
--- a/tests/integration_tests/test_keras.py
+++ b/tests/integration_tests/test_keras.py
@@ -23,7 +23,7 @@ def test_keras_pruning_callback():
             np.zeros((16, ), np.int32),
             batch_size=1,
             epochs=1,
-            callbacks=[KerasPruningCallback(trial, 'acc')],
+            callbacks=[KerasPruningCallback(trial, 'accuracy')],
             verbose=0)
 
         return 1.0


### PR DESCRIPTION
This PR fixes [the failing build](https://circleci.com/workflow-run/be4f1036-f1d8-4cb8-bb62-3829ae15dba4) caused by [the Keras update](https://github.com/keras-team/keras/releases/tag/2.3.0).

Since `keras==2.3.0`, the name of reported metric and that of monitored value are supposed to be  exactly the same, i.e., both should be  `acc` or both should be `accuracy` in `test_keras_pruning_callback`.

Therefore, the second argument of `KerasPruningCallback` is renamed to `accuracy`.