### PR TITLE
Fix package of TracebackType.

### DIFF
--- a/optuna/testing/storage.py
+++ b/optuna/testing/storage.py
@@ -4,7 +4,7 @@ import optuna
 from optuna import type_checking
 
 if type_checking.TYPE_CHECKING:
-    from type_checking import TracebackType  # NOQA
+    from types import TracebackType  # NOQA
     from typing import Any  # NOQA
     from typing import IO  # NOQA
     from typing import Optional  # NOQA

--- a/tests/integration_tests/test_chainermn.py
+++ b/tests/integration_tests/test_chainermn.py
@@ -19,7 +19,7 @@ from optuna.trial import Trial
 from optuna import type_checking
 
 if type_checking.TYPE_CHECKING:
-    from type_checking import TracebackType  # NOQA
+    from types import TracebackType  # NOQA
     from typing import Any  # NOQA
     from typing import Callable  # NOQA
     from typing import Dict  # NOQA

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -16,7 +16,7 @@ from optuna.trial import Trial  # NOQA
 from optuna import type_checking
 
 if type_checking.TYPE_CHECKING:
-    from type_checking import TracebackType  # NOQA
+    from types import TracebackType  # NOQA
     from typing import Any  # NOQA
     from typing import IO  # NOQA
     from typing import List  # NOQA


### PR DESCRIPTION
`optuna.type_checking` does not have `TracebackType`.
I think these lines were changed by mistake in PR (#492).