### PR TITLE
Add datetime_start property to FixedTrial.

### DIFF
--- a/optuna/trial.py
+++ b/optuna/trial.py
@@ -1,4 +1,5 @@
 import abc
+from datetime import datetime
 import decimal
 import six
 import warnings
@@ -8,7 +9,6 @@ from optuna import logging
 from optuna import type_checking
 
 if type_checking.TYPE_CHECKING:
-    from datetime import datetime  # NOQA
     from typing import Any  # NOQA
     from typing import Dict  # NOQA
     from typing import Optional  # NOQA
@@ -617,6 +617,7 @@ class FixedTrial(BaseTrial):
         self._distributions = {}  # type: Dict[str, BaseDistribution]
         self._user_attrs = {}  # type: Dict[str, Any]
         self._system_attrs = {}  # type: Dict[str, Any]
+        self._datetime_start = datetime.now()
 
     def suggest_uniform(self, name, low, high):
         # type: (str, float, float) -> float
@@ -710,6 +711,12 @@ class FixedTrial(BaseTrial):
         # type: () -> Dict[str, Any]
 
         return self._system_attrs
+
+    @property
+    def datetime_start(self):
+        # type: () -> Optional[datetime]
+
+        return self._datetime_start
 
 
 def _adjust_discrete_uniform_high(name, low, high, q):

--- a/tests/test_trial.py
+++ b/tests/test_trial.py
@@ -317,6 +317,14 @@ def test_fixed_trial_should_prune():
     assert FixedTrial({}).should_prune(1) is False
 
 
+def test_fixed_trial_datetime_start():
+    # type: () -> None
+
+    params = {'x': 1}
+    trial = FixedTrial(params)
+    assert trial.datetime_start is not None
+
+
 @parametrize_storage
 def test_relative_parameters(storage_init_func):
     # type: (typing.Callable[[], storages.BaseStorage]) -> None


### PR DESCRIPTION
This PR is a follow-up for #533. 
`BaseTrial` has `datetime_start` property but the `FixedTrial` does not implement it.
The lack of property causes errors when users pass `FixedTrial` instances to objective functions which refer to `trial.datetime_start`.

This PR implements `FixedTrial.datetime_start` which returns the time when the `FixedTrial` instance is created.