### PR TITLE
Fix type hints for mypy==0.730.

### DIFF
--- a/optuna/storages/base.py
+++ b/optuna/storages/base.py
@@ -105,7 +105,7 @@ class BaseStorage(object):
 
     @abc.abstractmethod
     def create_new_trial(self, study_id, template_trial=None):
-        # type: (int, Optional[structs.FronzenTrial]) -> int
+        # type: (int, Optional[structs.FrozenTrial]) -> int
 
         raise NotImplementedError
 

--- a/optuna/storages/rdb/storage.py
+++ b/optuna/storages/rdb/storage.py
@@ -337,7 +337,7 @@ class RDBStorage(BaseStorage):
         return study_sumarries
 
     def create_new_trial(self, study_id, template_trial=None):
-        # type: (int, Optional[structs.FronzenTrial]) -> int
+        # type: (int, Optional[structs.FrozenTrial]) -> int
 
         session = self.scoped_session()
 

--- a/tests/samplers_tests/test_samplers.py
+++ b/tests/samplers_tests/test_samplers.py
@@ -11,6 +11,7 @@ from optuna.samplers import BaseSampler
 
 if optuna.type_checking.TYPE_CHECKING:
     import typing  # NOQA
+    from typing import Any  # NOQA
     from typing import Dict  # NOQA
 
     from optuna.distributions import BaseDistribution  # NOQA
@@ -149,7 +150,7 @@ def _create_new_trial(study):
 
 class FixedSampler(BaseSampler):
     def __init__(self, relative_search_space, relative_params, unknown_param_value):
-        # type: (Dict[str, BaseDistribution], Dict[str, float], float) -> None
+        # type: (Dict[str, BaseDistribution], Dict[str, Any], Any) -> None
 
         self.relative_search_space = relative_search_space
         self.relative_params = relative_params
@@ -161,12 +162,12 @@ class FixedSampler(BaseSampler):
         return self.relative_search_space
 
     def sample_relative(self, study, trial, search_space):
-        # type: (Study, FrozenTrial, Dict[str, BaseDistribution]) -> Dict[str, float]
+        # type: (Study, FrozenTrial, Dict[str, BaseDistribution]) -> Dict[str, Any]
 
         return self.relative_params
 
     def sample_independent(self, study, trial, param_name, param_distribution):
-        # type: (Study, FrozenTrial, str, BaseDistribution) -> float
+        # type: (Study, FrozenTrial, str, BaseDistribution) -> Any
 
         return self.unknown_param_value
 
@@ -178,7 +179,7 @@ def test_sample_relative():
         'a': UniformDistribution(low=0, high=5),
         'b': CategoricalDistribution(choices=('foo', 'bar', 'baz')),
         'c': IntUniformDistribution(low=20, high=50),  # Not exist in `relative_params`.
-    }
+    }  # type: Dict[str, BaseDistribution]
     relative_params = {
         'a': 3.2,
         'b': 'baz',


### PR DESCRIPTION
Mypy was updated from 0.720 to 0.730 today (see [this blog post](http://mypy-lang.blogspot.com/2019/09/mypy-730-released.html) for further details), and mypy==0.730 newly found some errors. This PR fixes them.