### PR TITLE
Add a PyTorch Ignite handler for pruning.

### DIFF
--- a/docs/source/reference/integration.rst
+++ b/docs/source/reference/integration.rst
@@ -13,6 +13,9 @@ Integration
     :members:
     :exclude-members: infer_relative_search_space, sample_relative, sample_independent
 
+.. autoclass:: IgnitePruningHandler
+    :members:
+
 .. autoclass:: KerasPruningCallback
     :members:
 

--- a/docs/source/tutorial/pruning.rst
+++ b/docs/source/tutorial/pruning.rst
@@ -82,6 +82,7 @@ To implement pruning mechanism in much simpler forms, Optuna provides integratio
 - TensorFlow :class:`optuna.integration.TensorFlowPruningHook`
 - tf.keras :class:`optuna.integration.TFKerasPruningCallback`
 - MXNet :class:`optuna.integration.MXNetPruningCallback`
+- PyTorch Ignite :class:`optuna.integration.IgnitePruningHandler`
 
 For example, :class:`~optuna.integration.XGBoostPruningCallback` introduces pruning without directly changing the logic of training iteration.
 (See also `example <https://github.com/pfnet/optuna/blob/master/examples/pruning/xgboost_integration.py>`_ for the entire script.)

--- a/optuna/integration/__init__.py
+++ b/optuna/integration/__init__.py
@@ -10,6 +10,7 @@ _import_structure = {
     'chainer': ['ChainerPruningExtension'],
     'chainermn': ['ChainerMNStudy'],
     'cma': ['CmaEsSampler'],
+    'ignite': ["IgnitePruningHandler"],
     'keras': ['KerasPruningCallback'],
     'lightgbm': ['LightGBMPruningCallback'],
     'sklearn': ['OptunaSearchCV'],
@@ -28,6 +29,7 @@ if sys.version_info[0] == 2 or TYPE_CHECKING:
     from optuna.integration.chainer import ChainerPruningExtension  # NOQA
     from optuna.integration.chainermn import ChainerMNStudy  # NOQA
     from optuna.integration.cma import CmaEsSampler  # NOQA
+    from optuna.integration.ignite import IgnitePruningHandler  # NOQA
     from optuna.integration.keras import KerasPruningCallback  # NOQA
     from optuna.integration.lightgbm import LightGBMPruningCallback  # NOQA
     from optuna.integration.mxnet import MXNetPruningCallback  # NOQA

--- a/optuna/integration/ignite.py
+++ b/optuna/integration/ignite.py
@@ -14,6 +14,34 @@ except ImportError as e:
 
 
 class IgnitePruningHandler(object):
+    """PyTorch Ignite handler to prune unpromising trials.
+
+    Example:
+
+        Add a pruning handler which observes validation accuracy.
+
+        .. code::
+
+                evaluator = create_supervised_evaluator(model,
+                                                        metrics={'accuracy': Accuracy()},
+                                                        device=device)
+                handler = PyTorchIgnitePruningHandler(trial, 'accuracy', trainer)
+                evaluator.add_event_handler(Events.COMPLETED, handler)
+
+                @trainer.on(Events.EPOCH_COMPLETED)
+                def log_validation_results(engine):
+                    evaluator.run(val_loader)
+
+    Args:
+        trial:
+            A :class:`~optuna.trial.Trial` corresponding to the current evaluation of the
+            objective function.
+        metric:
+            A name of metric for pruning, e.g., ``accuracy`` and ``loss``.
+        trainer:
+            A trainer engine of PyTorch Ignite. Please refer to `ignite.engine.Engine reference
+            <https://pytorch.org/ignite/engine.html#ignite.engine.Engine>`_ for further details.
+    """
 
     def __init__(self, trial, metric, trainer):
         # type: (Trial, str, Engine) -> None

--- a/optuna/integration/ignite.py
+++ b/optuna/integration/ignite.py
@@ -56,7 +56,6 @@ class IgnitePruningHandler(object):
         score = engine.state.metrics[self.metric]
         self.trial.report(score, engine.state.epoch)
         if self.trial.should_prune():
-            self.trainer.terminate()
             message = "Trial was pruned at {} epoch.".format(engine.state.epoch)
             raise optuna.structs.TrialPruned(message)
 

--- a/optuna/integration/ignite.py
+++ b/optuna/integration/ignite.py
@@ -1,0 +1,44 @@
+import optuna
+from optuna import type_checking
+
+if type_checking.TYPE_CHECKING:
+    from optuna.trial import Trial  # NOQA
+
+try:
+    from ignite.engine import Engine  # NOQA
+    _available = True
+except ImportError as e:
+    _import_error = e
+    # IgnitePruningHandler is disabled because pytorch-ignite is not available.
+    _available = False
+
+
+class IgnitePruningHandler(object):
+
+    def __init__(self, trial, metric, trainer):
+        # type: (Trial, str, Engine) -> None
+
+        self.trial = trial
+        self.metric = metric
+        self.trainer = trainer
+
+    def __call__(self, engine):
+        # type: (Engine) -> None
+
+        score = engine.state.metrics[self.metric]
+        self.trial.report(score, engine.state.epoch)
+        if self.trial.should_prune():
+            self.trainer.terminate()
+            message = "Trial was pruned at {} epoch.".format(engine.state.epoch)
+            raise optuna.structs.TrialPruned(message)
+
+
+def _check_pytorch_ignite_availability():
+    # type: () -> None
+
+    if not _available:
+        raise ImportError(
+            'PyTorch Ignite is not available. Please install PyTorch Ignite to use this feature. '
+            'PyTorch Ignite can be installed by executing `$ pip install pytorch-ignite`. '
+            'For further information, please refer to the installation guide of PyTorch Ignite. '
+            '(The actual import error is as follows: ' + str(_import_error) + ')')

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,8 @@ def get_extras_require():
         'testing': [
             'bokeh', 'chainer>=5.0.0', 'cma', 'keras', 'lightgbm', 'mock',
             'mpi4py', 'mxnet', 'pandas', 'plotly>=4.0.0', 'pytest', 'scikit-optimize',
-            'tensorflow', 'tensorflow-datasets', 'xgboost', 'scikit-learn>=0.19.0',
+            'tensorflow', 'tensorflow-datasets', 'xgboost', 'scikit-learn>=0.19.0', 'torch',
+            'pytorch-ignite'
         ],
         'example': [
             'chainer', 'keras', 'catboost', 'lightgbm', 'scikit-learn',

--- a/tests/integration_tests/test_ignite.py
+++ b/tests/integration_tests/test_ignite.py
@@ -12,7 +12,7 @@ if type_checking.TYPE_CHECKING:
     from typing import Iterable  # NOQA
 
 
-def test__ignite_pruning_handler():
+def test_ignite_pruning_handler():
     # type: () -> None
 
     def update(engine, batch):

--- a/tests/integration_tests/test_ignite.py
+++ b/tests/integration_tests/test_ignite.py
@@ -31,7 +31,7 @@ def test_ignite_pruning_handler():
         with pytest.raises(optuna.structs.TrialPruned):
             handler(trainer)
 
-    # # The pruner is not activated.
+    # The pruner is not activated.
     study = optuna.create_study(pruner=DeterministicPruner(False))
     trial = create_running_trial(study, 1.0)
 

--- a/tests/integration_tests/test_ignite.py
+++ b/tests/integration_tests/test_ignite.py
@@ -1,0 +1,40 @@
+from ignite.engine import Engine
+from mock import Mock
+from mock import patch
+import pytest
+
+import optuna
+from optuna.testing.integration import create_running_trial
+from optuna.testing.integration import DeterministicPruner
+from optuna import type_checking
+
+if type_checking.TYPE_CHECKING:
+    from typing import Iterable  # NOQA
+
+
+def test__ignite_pruning_handler():
+    # type: () -> None
+
+    def update(engine, batch):
+        # type: (Engine, Iterable) -> None
+
+        pass
+
+    trainer = Engine(update)
+
+    # The pruner is activated.
+    study = optuna.create_study(pruner=DeterministicPruner(True))
+    trial = create_running_trial(study, 1.0)
+
+    handler = optuna.integration.IgnitePruningHandler(trial, 'accuracy', trainer)
+    with patch.object(trainer, 'state', epoch=Mock(return_value=1), metrics={'accuracy': 1}):
+        with pytest.raises(optuna.structs.TrialPruned):
+            handler(trainer)
+
+    # # The pruner is not activated.
+    study = optuna.create_study(pruner=DeterministicPruner(False))
+    trial = create_running_trial(study, 1.0)
+
+    handler = optuna.integration.IgnitePruningHandler(trial, 'accuracy', trainer)
+    with patch.object(trainer, 'state', epoch=Mock(return_value=1), metrics={'accuracy': 1}):
+        handler(trainer)


### PR DESCRIPTION
This PR adds a pruning handler to prune unpromising trials. The implementation is inspired by [this early stopping handler](https://github.com/pytorch/ignite/blob/master/ignite/handlers/early_stopping.py).