### PR TITLE
Quick fix for TensorFlow 2.0.

### DIFF
--- a/optuna/integration/tensorflow.py
+++ b/optuna/integration/tensorflow.py
@@ -7,7 +7,7 @@ if optuna.type_checking.TYPE_CHECKING:
 
 try:
     import tensorflow as tf
-    from tensorflow.train import SessionRunHook
+    from tensorflow.estimator import SessionRunHook
     from tensorflow_estimator.python.estimator.early_stopping import read_eval_metrics
     _available = True
 except ImportError as e:
@@ -63,7 +63,7 @@ class TensorFlowPruningHook(SessionRunHook):
         self.current_summary_step = -1
         self.metric = metric
         self.global_step_tensor = None
-        self.timer = tf.train.SecondOrStepTimer(every_secs=None, every_steps=run_every_steps)
+        self.timer = tf.estimator.SecondOrStepTimer(every_secs=None, every_steps=run_every_steps)
 
         if is_higher_better is not None:
             raise ValueError('Please do not use is_higher_better argument of '
@@ -73,16 +73,16 @@ class TensorFlowPruningHook(SessionRunHook):
     def begin(self):
         # type: () -> None
 
-        self.global_step_tensor = tf.train.get_global_step()
+        self.global_step_tensor = tf.compat.v1.train.get_global_step()
 
     def before_run(self, run_context):
-        # type: (tf.train.SessionRunContext) -> tf.train.SessionRunArgs
+        # type: (tf.estimator.SessionRunContext) -> tf.estimator.SessionRunArgs
 
         del run_context
-        return tf.train.SessionRunArgs(self.global_step_tensor)
+        return tf.estimator.SessionRunArgs(self.global_step_tensor)
 
     def after_run(self, run_context, run_values):
-        # type: (tf.train.SessionRunContext, tf.train.SessionRunValues) -> None
+        # type: (tf.estimator.SessionRunContext, tf.estimator.SessionRunValues) -> None
 
         global_step = run_values.results
         # Get eval metrics every n steps.

--- a/tests/integration_tests/test_tensorflow.py
+++ b/tests/integration_tests/test_tensorflow.py
@@ -21,7 +21,7 @@ def fixed_value_input_fn():
     y_train = np.zeros(16)
     dataset = tf.data.Dataset.from_tensor_slices((x_train, y_train))
     dataset = dataset.repeat().batch(8)
-    iterator = dataset.make_one_shot_iterator()
+    iterator = tf.compat.v1.data.make_one_shot_iterator(dataset)
     features, labels = iterator.get_next()
     return {"x": features}, labels
 

--- a/tests/integration_tests/test_tfkeras.py
+++ b/tests/integration_tests/test_tfkeras.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pkg_resources
 import pytest
 import tensorflow as tf
 
@@ -17,12 +18,18 @@ def test_tfkeras_pruning_callback():
         model = tf.keras.Sequential()
         model.add(tf.keras.layers.Dense(1, activation='sigmoid', input_dim=20))
         model.compile(optimizer='rmsprop', loss='binary_crossentropy', metrics=['accuracy'])
+
+        # TODO(Yanase): Unify the metric with 'accuracy' after stopping TensorFlow 1.x support.
+        callback_metric_name = 'accuracy'
+        if pkg_resources.parse_version(tf.__version__) < pkg_resources.parse_version('2.0.0'):
+            callback_metric_name = 'acc'
+
         model.fit(
             np.zeros((16, 20), np.float32),
             np.zeros((16, ), np.int32),
             batch_size=1,
             epochs=1,
-            callbacks=[TFKerasPruningCallback(trial, 'accuracy')],
+            callbacks=[TFKerasPruningCallback(trial, callback_metric_name)],
             verbose=0
         )
 

--- a/tests/integration_tests/test_tfkeras.py
+++ b/tests/integration_tests/test_tfkeras.py
@@ -22,7 +22,7 @@ def test_tfkeras_pruning_callback():
             np.zeros((16, ), np.int32),
             batch_size=1,
             epochs=1,
-            callbacks=[TFKerasPruningCallback(trial, 'acc')],
+            callbacks=[TFKerasPruningCallback(trial, 'accuracy')],
             verbose=0
         )
 


### PR DESCRIPTION
TensorFlow 2.0.0 was released today, and some test cases related to TensorFlow integration failed.
In this PR, I fixed the methods which are renamed/removed in TensorFlow 2.0.