### PR TITLE
Use TensorFlow v1 for examples-x jobs of CI tentatively.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,8 +60,9 @@ def get_extras_require():
         ],
         'example': [
             'chainer', 'keras', 'catboost', 'lightgbm', 'scikit-learn',
-            'tensorflow', 'mxnet', 'xgboost', 'torch', 'torchvision',
-            'dask-ml', 'dask[dataframe]'
+            'mxnet', 'xgboost', 'torch', 'torchvision', 'dask-ml', 'dask[dataframe]',
+            # TODO(Yanase): Update examples to support TensorFlow 2.0.
+            'tensorflow<2.0.0'
         ],
         'document': ['sphinx', 'sphinx_rtd_theme'],
         'codecov': ['pytest-cov', 'codecov'],

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,7 @@ def get_extras_require():
             'chainer', 'keras', 'catboost', 'lightgbm', 'scikit-learn',
             'mxnet', 'xgboost', 'torch', 'torchvision', 'dask-ml', 'dask[dataframe]',
             # TODO(Yanase): Update examples to support TensorFlow 2.0.
+            # See https://github.com/pfnet/optuna/issues/565 for further details.
             'tensorflow<2.0.0'
         ],
         'document': ['sphinx', 'sphinx_rtd_theme'],


### PR DESCRIPTION
This PR is a tentative fix of `examples-x` jobs of CI.
Current TensorFlow examples do not work with TensorFlow v2 because a number of TensorFlow's methods were renamed or removed. Due to those changes, it may be difficult to support both v1 and v2 with a single example, and I think we need to re-design examples. 
So, I would like to freeze the TensorFlow version as a workaround.