### PR TITLE
Follow-up of #526.

### DIFF
--- a/examples/pruning/chainer_integration.py
+++ b/examples/pruning/chainer_integration.py
@@ -66,7 +66,7 @@ def objective(trial):
 
     # Add Chainer extension for pruners.
     trainer.extend(
-        optuna.integration.ChainerPruningExtension(trial, 'validation/main/loss',
+        optuna.integration.ChainerPruningExtension(trial, 'validation/main/accuracy',
                                                    (PRUNER_INTERVAL, 'epoch')))
 
     trainer.extend(chainer.training.extensions.Evaluator(test_iter, model))
@@ -89,11 +89,11 @@ def objective(trial):
     for key, value in log_last.items():
         trial.set_user_attr(key, value)
 
-    return log_report_extension.log[-1]['validation/main/loss']
+    return log_report_extension.log[-1]['validation/main/accuracy']
 
 
 if __name__ == '__main__':
-    study = optuna.create_study(pruner=optuna.pruners.MedianPruner())
+    study = optuna.create_study(direction='maximize', pruner=optuna.pruners.MedianPruner())
     study.optimize(objective, n_trials=100)
     pruned_trials = [t for t in study.trials if t.state == optuna.structs.TrialState.PRUNED]
     complete_trials = [t for t in study.trials if t.state == optuna.structs.TrialState.COMPLETE]

--- a/examples/pruning/chainermn_integration.py
+++ b/examples/pruning/chainermn_integration.py
@@ -78,7 +78,7 @@ def objective(trial, comm):
 
     # Add Chainer extension for pruners.
     trainer.extend(
-        optuna.integration.ChainerPruningExtension(trial, 'main/accuracy',
+        optuna.integration.ChainerPruningExtension(trial, 'validation/main/accuracy',
                                                    (PRUNER_INTERVAL, 'epoch')))
     evaluator = chainer.training.extensions.Evaluator(test_iter, model)
     trainer.extend(chainermn.create_multi_node_evaluator(evaluator, comm))

--- a/examples/pruning/chainermn_integration.py
+++ b/examples/pruning/chainermn_integration.py
@@ -107,10 +107,7 @@ if __name__ == '__main__':
     study_name = sys.argv[1]
     storage_url = sys.argv[2]
 
-    study = optuna.load_study(
-        study_name,
-        storage_url,
-        pruner=optuna.pruners.MedianPruner())
+    study = optuna.load_study(study_name, storage_url, pruner=optuna.pruners.MedianPruner())
     comm = chainermn.create_communicator('naive')
     if comm.rank == 0:
         print('Study name:', study_name)

--- a/examples/pruning/lightgbm_integration.py
+++ b/examples/pruning/lightgbm_integration.py
@@ -54,9 +54,8 @@ def objective(trial):
 
 
 if __name__ == '__main__':
-    study = optuna.create_study(
-        pruner=optuna.pruners.MedianPruner(n_warmup_steps=10),
-        direction='maximize')
+    study = optuna.create_study(pruner=optuna.pruners.MedianPruner(n_warmup_steps=10),
+                                direction='maximize')
     study.optimize(objective, n_trials=100)
 
     print('Number of finished trials: {}'.format(len(study.trials)))

--- a/examples/pruning/tfkeras_integration.py
+++ b/examples/pruning/tfkeras_integration.py
@@ -132,10 +132,8 @@ def show_result(study):
 
 def main():
 
-    study = optuna.create_study(
-        direction='maximize',
-        pruner=optuna.pruners.MedianPruner(n_startup_trials=2)
-    )
+    study = optuna.create_study(direction='maximize',
+                                pruner=optuna.pruners.MedianPruner(n_startup_trials=2))
 
     study.optimize(objective, n_trials=25, timeout=600)
 

--- a/examples/pruning/xgboost_integration.py
+++ b/examples/pruning/xgboost_integration.py
@@ -59,8 +59,7 @@ def objective(trial):
 
 
 if __name__ == '__main__':
-    study = optuna.create_study(
-        pruner=optuna.pruners.MedianPruner(n_warmup_steps=5),
-        direction='maximize')
+    study = optuna.create_study(pruner=optuna.pruners.MedianPruner(n_warmup_steps=5),
+                                direction='maximize')
     study.optimize(objective, n_trials=100)
     print(study.best_trial)


### PR DESCRIPTION
This PR contains the following changes:
- Apply `yapf` formatter to pruning examples
- Use validation accuracy as the optimization metric of Chainer and ChainerMN examples