### PR TITLE
Make distribution classes single inheritance.

### DIFF
--- a/optuna/distributions.py
+++ b/optuna/distributions.py
@@ -104,7 +104,7 @@ class BaseDistribution(object):
     def __repr__(self):
         # type: () -> str
 
-        kwargs = ', '.join('{}={}'.format(k, v) for k, v in self.__dict__.items())
+        kwargs = ', '.join('{}={}'.format(k, v) for k, v in sorted(self.__dict__.items()))
         return '{}({})'.format(self.__class__.__name__, kwargs)
 
 

--- a/optuna/distributions.py
+++ b/optuna/distributions.py
@@ -86,7 +86,7 @@ class BaseDistribution(object):
     def __eq__(self, other):
         # type: (Any) -> bool
 
-        if type(self) != type(other):
+        if not isinstance(other, type(self)):
             return False
 
         return self.__dict__ == other.__dict__

--- a/optuna/distributions.py
+++ b/optuna/distributions.py
@@ -99,7 +99,7 @@ class BaseDistribution(object):
     def __hash__(self):
         # type: () -> int
 
-        return hash(tuple([self.__class__] + sorted(self.__dict__.items())))
+        return hash(tuple(sorted(self.__dict__.items())))
 
     def __repr__(self):
         # type: () -> str

--- a/optuna/distributions.py
+++ b/optuna/distributions.py
@@ -101,6 +101,12 @@ class BaseDistribution(object):
 
         return hash(tuple(sorted(self.__dict__.items())))
 
+    def __repr__(self):
+        # type: () -> str
+
+        kwargs = ', '.join('{}={}'.format(k, v) for k, v in self.__dict__.items())
+        return '{}({})'.format(self.__class__.__name__, kwargs)
+
 
 class UniformDistribution(BaseDistribution):
     """A uniform distribution in the linear domain.

--- a/optuna/distributions.py
+++ b/optuna/distributions.py
@@ -99,7 +99,8 @@ class BaseDistribution(object):
     def __hash__(self):
         # type: () -> int
 
-        return hash(tuple(sorted(self.__dict__.items())))
+
+        return hash(tuple([self.__class__] + sorted(self.__dict__.items())))
 
     def __repr__(self):
         # type: () -> str

--- a/optuna/distributions.py
+++ b/optuna/distributions.py
@@ -99,7 +99,6 @@ class BaseDistribution(object):
     def __hash__(self):
         # type: () -> int
 
-
         return hash(tuple([self.__class__] + sorted(self.__dict__.items())))
 
     def __repr__(self):

--- a/optuna/distributions.py
+++ b/optuna/distributions.py
@@ -99,7 +99,7 @@ class BaseDistribution(object):
     def __hash__(self):
         # type: () -> int
 
-        return hash(self.__dict__)
+        return hash(tuple(sorted(self.__dict__.items())))
 
 
 class UniformDistribution(BaseDistribution):

--- a/optuna/distributions.py
+++ b/optuna/distributions.py
@@ -86,7 +86,7 @@ class BaseDistribution(object):
     def __eq__(self, other):
         # type: (Any) -> bool
 
-        if other is None or type(self) != type(other):
+        if type(self) != type(other):
             return False
 
         return self.__dict__ == other.__dict__
@@ -99,7 +99,7 @@ class BaseDistribution(object):
     def __hash__(self):
         # type: () -> int
 
-        return self.__dict__.__hash__()
+        return hash(self.__dict__)
 
 
 class UniformDistribution(BaseDistribution):

--- a/optuna/distributions.py
+++ b/optuna/distributions.py
@@ -1,15 +1,14 @@
 import abc
 import json
 import six
-from typing import NamedTuple
-from typing import Tuple
-from typing import Union
 
 from optuna import type_checking
 
 if type_checking.TYPE_CHECKING:
     from typing import Any  # NOQA
     from typing import Dict  # NOQA
+    from typing import Tuple  # NOQA
+    from typing import Union  # NOQA
 
 
 @six.add_metaclass(abc.ABCMeta)
@@ -79,16 +78,31 @@ class BaseDistribution(object):
 
         raise NotImplementedError
 
-    @abc.abstractmethod
     def _asdict(self):
         # type: () -> Dict
 
-        raise NotImplementedError
+        return self.__dict__
+
+    def __eq__(self, other):
+        # type: (Any) -> bool
+
+        if other is None or type(self) != type(other):
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        # type: (Any) -> bool
+
+        return not self.__eq__(other)
+
+    def __hash__(self):
+        # type: () -> int
+
+        return self.__dict__.__hash__()
 
 
-class UniformDistribution(
-        NamedTuple('_BaseUniformDistribution', [('low', float), ('high', float)]),
-        BaseDistribution):
+class UniformDistribution(BaseDistribution):
     """A uniform distribution in the linear domain.
 
     This object is instantiated by :func:`~optuna.trial.Trial.suggest_uniform`, and passed to
@@ -101,14 +115,15 @@ class UniformDistribution(
             Upper endpoint of the range of the distribution. ``high`` is excluded from the range.
     """
 
-    def __new__(cls, low, high):
-        # type: (float, float) -> UniformDistribution
+    def __init__(self, low, high):
+        # type: (float, float) -> None
 
         if low > high:
             raise ValueError("The `low` value must be smaller than or equal to the `high` value "
                              "(low={}, high={}).".format(low, high))
 
-        return super(UniformDistribution, cls).__new__(cls, low, high)
+        self.low = low
+        self.high = high
 
     def single(self):
         # type: () -> bool
@@ -125,9 +140,7 @@ class UniformDistribution(
             return self.low <= value and value < self.high
 
 
-class LogUniformDistribution(
-        NamedTuple('_BaseLogUniformDistribution', [('low', float), ('high', float)]),
-        BaseDistribution):
+class LogUniformDistribution(BaseDistribution):
     """A uniform distribution in the log domain.
 
     This object is instantiated by :func:`~optuna.trial.Trial.suggest_loguniform`, and passed to
@@ -140,14 +153,15 @@ class LogUniformDistribution(
             Upper endpoint of the range of the distribution. ``high`` is excluded from the range.
     """
 
-    def __new__(cls, low, high):
-        # type: (float, float) -> LogUniformDistribution
+    def __init__(self, low, high):
+        # type: (float, float) -> None
 
         if low > high:
             raise ValueError("The `low` value must be smaller than or equal to the `high` value "
                              "(low={}, high={}).".format(low, high))
 
-        return super(LogUniformDistribution, cls).__new__(cls, low, high)
+        self.low = low
+        self.high = high
 
     def single(self):
         # type: () -> bool
@@ -164,9 +178,7 @@ class LogUniformDistribution(
             return self.low <= value and value < self.high
 
 
-class DiscreteUniformDistribution(
-        NamedTuple('_BaseDiscreteUniformDistribution', [('low', float), ('high', float),
-                                                        ('q', float)]), BaseDistribution):
+class DiscreteUniformDistribution(BaseDistribution):
     """A discretized uniform distribution in the linear domain.
 
     This object is instantiated by :func:`~optuna.trial.Trial.suggest_discrete_uniform`, and passed
@@ -181,14 +193,16 @@ class DiscreteUniformDistribution(
             A discretization step.
     """
 
-    def __new__(cls, low, high, q):
-        # type: (float, float, float) -> DiscreteUniformDistribution
+    def __init__(self, low, high, q):
+        # type: (float, float, float) -> None
 
         if low > high:
             raise ValueError("The `low` value must be smaller than or equal to the `high` value "
                              "(low={}, high={}, q={}).".format(low, high, q))
 
-        return super(DiscreteUniformDistribution, cls).__new__(cls, low, high, q)
+        self.low = low
+        self.high = high
+        self.q = q
 
     def single(self):
         # type: () -> bool
@@ -202,9 +216,7 @@ class DiscreteUniformDistribution(
         return self.low <= value and value <= self.high
 
 
-class IntUniformDistribution(
-        NamedTuple('_BaseIntUniformDistribution', [('low', int), ('high', int)]),
-        BaseDistribution):
+class IntUniformDistribution(BaseDistribution):
     """A uniform distribution on integers.
 
     This object is instantiated by :func:`~optuna.trial.Trial.suggest_int`, and passed to
@@ -217,14 +229,15 @@ class IntUniformDistribution(
             Upper endpoint of the range of the distribution. ``high`` is included in the range.
     """
 
-    def __new__(cls, low, high):
-        # type: (int, int) -> IntUniformDistribution
+    def __init__(self, low, high):
+        # type: (int, int) -> None
 
         if low > high:
             raise ValueError("The `low` value must be smaller than or equal to the `high` value "
                              "(low={}, high={}).".format(low, high))
 
-        return super(IntUniformDistribution, cls).__new__(cls, low, high)
+        self.low = low
+        self.high = high
 
     def to_external_repr(self, param_value_in_internal_repr):
         # type: (float) -> int
@@ -248,9 +261,7 @@ class IntUniformDistribution(
         return self.low <= value and value <= self.high
 
 
-class CategoricalDistribution(
-        NamedTuple('_BaseCategoricalDistribution', [('choices', Tuple[Union[float, str], ...])]),
-        BaseDistribution):
+class CategoricalDistribution(BaseDistribution):
     """A categorical distribution.
 
     This object is instantiated by :func:`~optuna.trial.Trial.suggest_categorical`, and
@@ -261,13 +272,13 @@ class CategoricalDistribution(
             Candidates of parameter values.
     """
 
-    def __new__(cls, choices):
-        # type: (Tuple[Union[float, str], ...]) -> CategoricalDistribution
+    def __init__(self, choices):
+        # type: (Tuple[Union[float, str], ...]) -> None
 
         if len(choices) == 0:
             raise ValueError("The `choices` must contains one or more elements.")
 
-        return super(CategoricalDistribution, cls).__new__(cls, choices)
+        self.choices = choices
 
     def to_external_repr(self, param_value_in_internal_repr):
         # type: (float) -> Union[float, str]

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -187,6 +187,7 @@ def test_empty_distribution():
     with pytest.raises(ValueError):
         distributions.CategoricalDistribution(choices=()),
 
+
 def test_eq_ne_hash():
     # type: () -> None
 
@@ -210,7 +211,7 @@ def test_repr():
 
     # The following variable is needed to apply `eval` to distribution
     # instances that contain `float('inf')` as a field value.
-    inf = float('inf')
+    inf = float('inf')  # NOQA
 
     for d in EXAMPLE_DISTRIBUTIONS.values():
         assert d == eval('distributions.' + repr(d))

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -205,7 +205,9 @@ def test_eq_ne_hash():
     # Different classes.
     d2 = distributions.IntUniformDistribution(low=1, high=2)
     assert d0 != d2
-    assert hash(d0) != hash(d2)
+
+    # In the implementation of `__hash__`, only attributes are considered.
+    assert hash(d0) == hash(d2)
 
 
 def test_repr():

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -200,10 +200,12 @@ def test_eq_ne_hash():
     d0 = distributions.UniformDistribution(low=1, high=2)
     d1 = distributions.UniformDistribution(low=1, high=3)
     assert d0 != d1
+    assert hash(d0) != hash(d1)
 
     # Different classes.
     d2 = distributions.IntUniformDistribution(low=1, high=2)
     assert d0 != d2
+    assert hash(d0) != hash(d2)
 
 
 def test_repr():

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -200,3 +200,14 @@ def test_eq_ne_hash():
 
     d2 = distributions.IntUniformDistribution(low=1, high=2)
     assert d0 != d2
+
+
+def test_repr():
+    # type: () -> None
+
+    # The following variable is needed to apply `eval` to distribution
+    # instances that contain `float('inf')` as a field value.
+    inf = float('inf')
+
+    for d in EXAMPLE_DISTRIBUTIONS.values():
+        assert d == eval('distributions.' + repr(d))

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -190,14 +190,17 @@ def test_empty_distribution():
 def test_eq_ne_hash():
     # type: () -> None
 
+    # Two instances of a class are regarded as equivalent if the fields have the same values.
     for d in EXAMPLE_DISTRIBUTIONS.values():
         assert d == copy.deepcopy(d)
         assert hash(d) == hash(copy.deepcopy(d))
 
+    # Different field values.
     d0 = distributions.UniformDistribution(low=1, high=2)
     d1 = distributions.UniformDistribution(low=1, high=3)
     assert d0 != d1
 
+    # Different classes.
     d2 = distributions.IntUniformDistribution(low=1, high=2)
     assert d0 != d2
 

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -1,3 +1,4 @@
+import copy
 import json
 import pytest
 
@@ -185,3 +186,17 @@ def test_empty_distribution():
 
     with pytest.raises(ValueError):
         distributions.CategoricalDistribution(choices=()),
+
+def test_eq_ne_hash():
+    # type: () -> None
+
+    for d in EXAMPLE_DISTRIBUTIONS.values():
+        assert d == copy.deepcopy(d)
+        assert hash(d) == hash(copy.deepcopy(d))
+
+    d0 = distributions.UniformDistribution(low=1, high=2)
+    d1 = distributions.UniformDistribution(low=1, high=3)
+    assert d0 != d1
+
+    d2 = distributions.IntUniformDistribution(low=1, high=2)
+    assert d0 != d2

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -64,19 +64,19 @@ def test_check_distribution_compatibility():
     # test dynamic value range (CategoricalDistribution)
     pytest.raises(
         ValueError, lambda: distributions.check_distribution_compatibility(
-            EXAMPLE_DISTRIBUTIONS['c2'], EXAMPLE_DISTRIBUTIONS['c2']._replace(
-                choice=('Roppongi', 'Akasaka'))))
+            EXAMPLE_DISTRIBUTIONS['c2'],
+            distributions.CategoricalDistribution(choices=('Roppongi', 'Akasaka'))))
 
     # test dynamic value range (except CategoricalDistribution)
     distributions.check_distribution_compatibility(
-        EXAMPLE_DISTRIBUTIONS['u'], EXAMPLE_DISTRIBUTIONS['u']._replace(low=-1.0, high=-2.0))
+        EXAMPLE_DISTRIBUTIONS['u'], distributions.UniformDistribution(low=-3.0, high=-2.0))
     distributions.check_distribution_compatibility(
-        EXAMPLE_DISTRIBUTIONS['l'], EXAMPLE_DISTRIBUTIONS['l']._replace(low=-0.1, high=1.0))
+        EXAMPLE_DISTRIBUTIONS['l'], distributions.LogUniformDistribution(low=-0.1, high=1.0))
     distributions.check_distribution_compatibility(
-        EXAMPLE_DISTRIBUTIONS['du'], EXAMPLE_DISTRIBUTIONS['du']._replace(
-            low=-1.0, high=10.0, q=3.))
+        EXAMPLE_DISTRIBUTIONS['du'],
+        distributions.DiscreteUniformDistribution(low=-1.0, high=10.0, q=3.))
     distributions.check_distribution_compatibility(
-        EXAMPLE_DISTRIBUTIONS['iu'], EXAMPLE_DISTRIBUTIONS['iu']._replace(low=-1, high=1))
+        EXAMPLE_DISTRIBUTIONS['iu'], distributions.IntUniformDistribution(low=-1, high=1))
 
 
 def test_contains():


### PR DESCRIPTION
This PR removes `NamedTuple` from the base classes of `optuna.distributions.XxxDistribution`.

Resolves #571 and #677.