### PR TITLE
Make study returns an empty dataframe if no trials

### DIFF
--- a/optuna/study.py
+++ b/optuna/study.py
@@ -334,6 +334,10 @@ class Study(BaseStudy):
         """
         _check_pandas_availability()
 
+        # If no trials, return an empty dataframe.
+        if not len(self.trials):
+            return pd.DataFrame()
+
         # column_agg is an aggregator of column names.
         # Keys of column agg are attributes of FrozenTrial such as 'trial_id' and 'params'.
         # Values are dataframe columns such as ('trial_id', '') and ('params', 'n_layers').

--- a/tests/test_study.py
+++ b/tests/test_study.py
@@ -408,6 +408,13 @@ def test_study_pickle():
     assert len(study_2.trials) == 20
 
 
+def test_study_trials_dataframe_with_no_trials():
+    # type: () -> None
+    study_with_no_trials = optuna.create_study()
+    trials_df = study_with_no_trials.trials_dataframe()
+    assert trials_df.empty
+
+
 @pytest.mark.parametrize('storage_mode', STORAGE_MODES)
 @pytest.mark.parametrize('cache_mode', CACHE_MODES)
 @pytest.mark.parametrize('include_internal_fields', [True, False])

--- a/tests/test_study.py
+++ b/tests/test_study.py
@@ -410,6 +410,7 @@ def test_study_pickle():
 
 def test_study_trials_dataframe_with_no_trials():
     # type: () -> None
+
     study_with_no_trials = optuna.create_study()
     trials_df = study_with_no_trials.trials_dataframe()
     assert trials_df.empty


### PR DESCRIPTION
Currently, `study.trials_dataframe()` raises an error when it has no
trial records.

resolves #563.