### PR TITLE
Make lightgbm examples more practical

### DIFF
--- a/examples/lightgbm_simple.py
+++ b/examples/lightgbm_simple.py
@@ -47,7 +47,7 @@ def objective(trial):
         'feature_fraction': min(trial.suggest_uniform('feature_fraction', 0.4, 1.0 + EPS), 1.0),
         'bagging_fraction': min(trial.suggest_uniform('bagging_fraction', 0.4, 1.0 + EPS), 1.0),
         'bagging_freq': trial.suggest_int('bagging_freq', 1, 7),
-        'min_child_samples': int(trial.suggest_uniform('min_child_samples', 5, 100 + EPS)),
+        'min_child_samples': trial.suggest_int('min_child_samples', 5, 100),
     }
 
     gbm = lgb.train(param, dtrain)

--- a/examples/lightgbm_simple.py
+++ b/examples/lightgbm_simple.py
@@ -26,6 +26,9 @@ from sklearn.model_selection import train_test_split
 import optuna
 
 
+EPS = 1e-12
+
+
 # FYI: Objective functions can take additional arguments
 # (https://optuna.readthedocs.io/en/stable/faq.html#objective-func-additional-args).
 def objective(trial):
@@ -37,17 +40,15 @@ def objective(trial):
         'objective': 'binary',
         'metric': 'binary_logloss',
         'verbosity': -1,
-        'boosting_type': trial.suggest_categorical('boosting', ['gbdt', 'dart', 'goss']),
-        'num_leaves': trial.suggest_int('num_leaves', 10, 1000),
-        'learning_rate': trial.suggest_loguniform('learning_rate', 1e-8, 1.0)
+        'boosting_type': 'gbdt',
+        'lambda_l1': trial.suggest_loguniform('lambda_l1', 1e-8, 10.0),
+        'lambda_l2': trial.suggest_loguniform('lambda_l2', 1e-8, 10.0),
+        'num_leaves': trial.suggest_int('num_leaves', 2, 256),
+        'feature_fraction': min(trial.suggest_uniform('feature_fraction', 0.4, 1.0 + EPS), 1.0),
+        'bagging_fraction': min(trial.suggest_uniform('bagging_fraction', 0.4, 1.0 + EPS), 1.0),
+        'bagging_freq': trial.suggest_int('bagging_freq', 1, 7),
+        'min_child_samples': int(trial.suggest_uniform('min_child_samples', 5, 100 + EPS)),
     }
-
-    if param['boosting_type'] == 'dart':
-        param['drop_rate'] = trial.suggest_loguniform('drop_rate', 1e-8, 1.0)
-        param['skip_drop'] = trial.suggest_loguniform('skip_drop', 1e-8, 1.0)
-    if param['boosting_type'] == 'goss':
-        param['top_rate'] = trial.suggest_uniform('top_rate', 0.0, 1.0)
-        param['other_rate'] = trial.suggest_uniform('other_rate', 0.0, 1.0 - param['top_rate'])
 
     gbm = lgb.train(param, dtrain)
     preds = gbm.predict(test_x)

--- a/examples/pruning/lightgbm_integration.py
+++ b/examples/pruning/lightgbm_integration.py
@@ -40,7 +40,7 @@ def objective(trial):
         'feature_fraction': min(trial.suggest_uniform('feature_fraction', 0.4, 1.0 + EPS), 1.0),
         'bagging_fraction': min(trial.suggest_uniform('bagging_fraction', 0.4, 1.0 + EPS), 1.0),
         'bagging_freq': trial.suggest_int('bagging_freq', 1, 7),
-        'min_child_samples': int(trial.suggest_uniform('min_child_samples', 5, 100 + EPS)),
+        'min_child_samples': trial.suggest_int('min_child_samples', 5, 100),
     }
 
     # Add a callback for pruning.


### PR DESCRIPTION
Tuning `boosting_type` and `drop_rate` is helpful to understand the usage/advantage of define-by-run. However, practically, these parameters are not important for accuracy. This PR makes LightGBM examples more practical.