### PR TITLE
.gitignore files related to examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,12 @@
+# Ignore files that examples create
+t10k-images-idx3-ubyte*
+t10k-labels-idx1-ubyte*
+train-images-idx3-ubyte*
+train-labels-idx1-ubyte*
+training.pt
+test.pt
+catboost_info
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ train-images-idx3-ubyte*
 train-labels-idx1-ubyte*
 training.pt
 test.pt
-catboost_info
+catboost_info/
 
 # Byte-compiled / optimized / DLL files
 __pycache__/


### PR DESCRIPTION
This PR aims at ignoring files downloaded/generated by examples.

Instead of updating `.gitignore`, I'm considering creating `examples/.gitignore`.