### PR TITLE
Add PyTorch Lightning example

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -230,10 +230,18 @@ jobs:
           name: examples
           command: |
             . venv/bin/activate
-            for file in `find examples -name '*.py' -not -name 'chainermn_*.py' -not -name 'dask_ml*.py'`
+            for file in `find examples -name '*.py' -not -name 'chainermn_*.py' -not -name 'dask_ml*.py' -not -name 'pytorch_lightning_simple.py'`
             do
                python $file
             done
+          environment:
+            OMP_NUM_THREADS: 1
+
+      - run: &examples-pytorch-lightning
+          name: examples-pytorch-lightning
+          command: |
+            . venv/bin/activate
+            python examples/pytorch_lightning_simple.py
           environment:
             OMP_NUM_THREADS: 1
 
@@ -263,7 +271,7 @@ jobs:
     docker:
       - image: circleci/python:3.6
     steps:
-      [checkout, run: *install, run: *install-examples, run: *examples, run: *examples-mn, run: *examples-dask-ml]
+      [checkout, run: *install, run: *install-examples, run: *examples, run: *examples-pytorch-lightning, run: *examples-mn, run: *examples-dask-ml]
 
   examples-python35:
     docker:

--- a/examples/README.md
+++ b/examples/README.md
@@ -18,6 +18,7 @@ This page contains a list of example codes written with Optuna.
 * [MXNet](./mxnet_simple.py)
 * [PyTorch](./pytorch_simple.py)
 * [PyTorch Ignite](./ignite_simple.py)
+* [PyTorch Lightning](./pytorch_lightning_simple.py)
 * [XGBoost](./xgboost_simple.py)
 * [Tensorflow](./tensorflow_estimator_simple.py)
 * [Tensorflow(eager)](./tensorflow_eager_simple.py)

--- a/examples/pytorch_lightning_simple.py
+++ b/examples/pytorch_lightning_simple.py
@@ -53,9 +53,7 @@ class DictLogger(pl.logging.LightningLoggerBase):
         self.metrics.append(metric)
 
 
-# The code for `Net` is taken from `pytorch_simple.py`.
 class Net(nn.Module):
-    # Constructor for trial network.
     def __init__(self, trial):
         super(Net, self).__init__()
         self.layers = []
@@ -81,7 +79,6 @@ class Net(nn.Module):
         for idx, dropout in enumerate(self.dropouts):
             setattr(self, 'drop{}'.format(idx), dropout)
 
-    # Forward pass computation function.
     def forward(self, data):
         data = data.view(-1, 28 * 28)
         for layer, dropout in zip(self.layers, self.dropouts):

--- a/examples/pytorch_lightning_simple.py
+++ b/examples/pytorch_lightning_simple.py
@@ -163,7 +163,7 @@ def objective(trial):
     # Generate the model.
     model = Net(trial)
 
-    # Generate the optimizers.
+    # Sample optimizer parameters.
     optimizer_name = trial.suggest_categorical('optimizer', ['Adam', 'RMSprop', 'SGD'])
     lr = trial.suggest_uniform('lr', 1e-5, 1e-1)
 

--- a/examples/pytorch_lightning_simple.py
+++ b/examples/pytorch_lightning_simple.py
@@ -165,7 +165,7 @@ def objective(trial):
 
     # Sample optimizer parameters.
     optimizer_name = trial.suggest_categorical('optimizer', ['Adam', 'RMSprop', 'SGD'])
-    lr = trial.suggest_uniform('lr', 1e-5, 1e-1)
+    lr = trial.suggest_loguniform('lr', 1e-5, 1e-1)
 
     # Generate the PyTorch Lightning model.
     model = LightningNet(model, optimizer_name, lr)

--- a/examples/pytorch_lightning_simple.py
+++ b/examples/pytorch_lightning_simple.py
@@ -22,6 +22,7 @@ from __future__ import division
 from __future__ import print_function
 
 import os
+import shutil
 
 import pytorch_lightning as pl
 import torch
@@ -40,6 +41,7 @@ BATCHSIZE = 128
 CLASSES = 10
 EPOCHS = 10
 DIR = os.getcwd()
+MODEL_DIR = os.path.join(DIR, 'result')
 
 
 class DictLogger(pl.logging.LightningLoggerBase):
@@ -137,7 +139,7 @@ def objective(trial):
     # PyTorch Lightning will try to restore model parameters from previous trials if checkpoint
     # filenames match. Therefore, the filenames for each trial must be made unique.
     checkpoint_callback = pl.callbacks.ModelCheckpoint(
-        os.path.join(DIR, 'results', 'trial_{}'.format(trial.number)))
+        os.path.join(MODEL_DIR, 'trial_{}'.format(trial.number)))
 
     # The default logger in PyTorch Lightining writes to event files to be consumed by
     # TensorBoard. We create a simple logger instead that holds the log in memory so that the
@@ -174,3 +176,5 @@ if __name__ == '__main__':
     print('  Params: ')
     for key, value in trial.params.items():
         print('    {}: {}'.format(key, value))
+
+    shutil.rmtree(MODEL_DIR)

--- a/examples/pytorch_lightning_simple.py
+++ b/examples/pytorch_lightning_simple.py
@@ -1,0 +1,190 @@
+"""
+Optuna example that optimizes multi-layer perceptrons using PyTorch Lightning.
+
+In this example, we optimize the validation accuracy of hand-written digit recognition using
+PyTorch Lightning, and MNIST. We optimize the neural network architecture as well as the optimizer
+configuration. As it is too time consuming to use the whole MNIST dataset, we here use a small
+subset of it.
+
+We have the following two ways to execute this example:
+
+(1) Execute this code directly.
+    $ python pytorch_lightning_simple.py
+
+
+(2) Execute through CLI.
+    $ STUDY_NAME=`optuna create-study --direction maximize --storage sqlite:///example.db`
+    $ optuna study optimize pytorch_lightning_simple.py objective --n-trials=100 --study \
+      $STUDY_NAME --storage sqlite:///example.db
+
+"""
+
+from __future__ import division
+from __future__ import print_function
+
+import os
+
+import pytorch_lightning as pl
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+import torch.optim as optim
+import torch.utils.data
+from torchvision import datasets
+from torchvision import transforms
+
+import optuna
+
+PERCENT_TRAIN_EXAMPLES = 0.1
+PERCENT_TEST_EXAMPLES = 0.1
+BATCHSIZE = 128
+CLASSES = 10
+EPOCHS = 10
+DIR = os.getcwd()
+
+
+class DictLogger(pl.logging.LightningLoggerBase):
+    """PyTorch Lightning `dict` logger."""
+
+    def __init__(self):
+        super(DictLogger, self).__init__()
+        self.metrics = []
+
+    def log_metrics(self, metric, step_num=None):
+        self.metrics.append(metric)
+
+
+# The code for `Net` is taken from `pytorch_simple.py`.
+class Net(nn.Module):
+    # Constructor for trial network.
+    def __init__(self, trial):
+        super(Net, self).__init__()
+        self.layers = []
+        self.dropouts = []
+
+        # We optimize the number of layers, hidden untis in each layer and drouputs.
+        n_layers = trial.suggest_int('n_layers', 1, 3)
+        dropout = trial.suggest_uniform('dropout', 0.2, 0.5)
+        input_dim = 28 * 28
+        for i in range(n_layers):
+            output_dim = int(trial.suggest_loguniform('n_units_l{}'.format(i), 4, 128))
+            self.layers.append(nn.Linear(input_dim, output_dim))
+            self.dropouts.append(nn.Dropout(dropout))
+            input_dim = output_dim
+
+        self.layers.append(nn.Linear(input_dim, CLASSES))
+
+        # Assigning the layers as class variables (PyTorch requirement).
+        for idx, layer in enumerate(self.layers):
+            setattr(self, 'fc{}'.format(idx), layer)
+
+        # Assigning the dropouts as class variables (PyTorch requirement).
+        for idx, dropout in enumerate(self.dropouts):
+            setattr(self, 'drop{}'.format(idx), dropout)
+
+    # Forward pass computation function.
+    def forward(self, data):
+        data = data.view(-1, 28 * 28)
+        for layer, dropout in zip(self.layers, self.dropouts):
+            data = F.relu(layer(data))
+            data = dropout(data)
+        return F.log_softmax(self.layers[-1](data), dim=1)
+
+
+class LightningNet(pl.LightningModule):
+
+    def __init__(self, model, optimizer_name, lr):
+        super(LightningNet, self).__init__()
+
+        # Be careful not to overwrite `pl.LightningModule` attributes such as `self.model`.
+        self._model = model
+        self._optimizer_name = optimizer_name
+        self._lr = lr
+
+    def forward(self, data):
+        return self._model(data)
+
+    def training_step(self, batch, batch_nb):
+        data, target = batch
+        output = self.forward(data)
+        loss = F.nll_loss(output, target)
+        return {'loss': loss}
+
+    def validation_step(self, batch, batch_nb):
+        data, target = batch
+        output = self.forward(data)
+        pred = output.argmax(dim=1, keepdim=True)
+        correct = pred.eq(target.view_as(pred)).sum().item()
+        accuracy = correct / data.size(0)
+        return {'validation_accuracy': accuracy}
+
+    def validation_end(self, outputs):
+        accuracy = sum(x['validation_accuracy'] for x in outputs) / len(outputs)
+        # Pass the accuracy to the `DictLogger` via the `'log'` key.
+        return {'log': {'accuracy': accuracy}}
+
+    def configure_optimizers(self):
+        return getattr(optim, self._optimizer_name)(self._model.parameters(), lr=self._lr)
+
+    @pl.data_loader
+    def train_dataloader(self):
+        return torch.utils.data.DataLoader(
+            datasets.MNIST(DIR, train=True, download=True, transform=transforms.ToTensor()),
+            batch_size=BATCHSIZE, shuffle=True)
+
+    @pl.data_loader
+    def val_dataloader(self):
+        return torch.utils.data.DataLoader(
+            datasets.MNIST(DIR, train=False, download=True, transform=transforms.ToTensor()),
+            batch_size=BATCHSIZE, shuffle=False)
+
+
+def objective(trial):
+    # PyTorch Lightning will try to restore model parameters from previous trials if checkpoint
+    # filenames match. Therefore, the filenames for each trial must be made unique.
+    checkpoint_callback = pl.callbacks.ModelCheckpoint(
+        os.path.join(DIR, 'results', 'trial_{}'.format(trial.number)))
+
+    # The default logger in PyTorch Lightining writes to event files to be consumed by
+    # TensorBoard. We create a simple logger instead that holds the log in memory so that the
+    # final accuracy can be obtained after optimization. When using the default logger, the
+    # final accuracy could be stored in an attribute of the `Trainer` instead.
+    logger = DictLogger()
+
+    trainer = pl.Trainer(
+        logger=logger,
+        train_percent_check=PERCENT_TRAIN_EXAMPLES,
+        val_percent_check=PERCENT_TEST_EXAMPLES,
+        checkpoint_callback=checkpoint_callback,
+        max_nb_epochs=EPOCHS,
+        gpus=0 if torch.cuda.is_available() else None,
+    )
+
+    # Generate the model.
+    model = Net(trial)
+
+    # Generate the optimizers.
+    optimizer_name = trial.suggest_categorical('optimizer', ['Adam', 'RMSprop', 'SGD'])
+    lr = trial.suggest_uniform('lr', 1e-5, 1e-1)
+
+    # Generate the PyTorch Lightning model.
+    model = LightningNet(model, optimizer_name, lr)
+    trainer.fit(model)
+
+    return logger.metrics[-1]['accuracy']
+
+
+if __name__ == '__main__':
+    study = optuna.create_study(direction='maximize')
+    study.optimize(objective, n_trials=100)
+
+    print('Number of finished trials: {}'.format(len(study.trials)))
+
+    print('Best trial:')
+    trial = study.best_trial
+
+    print('  Value: {}'.format(trial.value))
+
+    print('  Params: ')
+    for key, value in trial.params.items():
+        print('    {}: {}'.format(key, value))

--- a/examples/pytorch_simple.py
+++ b/examples/pytorch_simple.py
@@ -101,7 +101,7 @@ def objective(trial):
 
     # Generate the optimizers.
     optimizer_name = trial.suggest_categorical('optimizer', ['Adam', 'RMSprop', 'SGD'])
-    lr = trial.suggest_uniform('lr', 1e-5, 1e-1)
+    lr = trial.suggest_loguniform('lr', 1e-5, 1e-1)
     optimizer = getattr(optim, optimizer_name)(model.parameters(), lr=lr)
 
     # Get the MNIST dataset.

--- a/examples/pytorch_simple.py
+++ b/examples/pytorch_simple.py
@@ -101,7 +101,7 @@ def objective(trial):
 
     # Generate the optimizers.
     optimizer_name = trial.suggest_categorical('optimizer', ['Adam', 'RMSprop', 'SGD'])
-    lr = trial.suggest_loguniform('lr', 1e-5, 1e-1)
+    lr = trial.suggest_uniform('lr', 1e-5, 1e-1)
     optimizer = getattr(optim, optimizer_name)(model.parameters(), lr=lr)
 
     # Get the MNIST dataset.

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ def get_extras_require():
         'example': [
             'chainer', 'keras', 'catboost', 'lightgbm', 'scikit-learn',
             'mxnet', 'xgboost', 'torch', 'torchvision', 'pytorch-ignite',
-            'dask-ml', 'dask[dataframe]',
+            'pytorch-lightning', 'dask-ml', 'dask[dataframe]',
             # TODO(Yanase): Update examples to support TensorFlow 2.0.
             # See https://github.com/pfnet/optuna/issues/565 for further details.
             'tensorflow<2.0.0'


### PR DESCRIPTION
Adds an example of [PyTorch Lightning](https://github.com/williamFalcon/pytorch-lightning). 

The example tries to be minimal, however
- a custom logger `DictLogger` is defined and used to obtain the final accuracy in the `objective` function (without e.g. introducing additional "accuracy" attributes to the `Trainer`) since the default logger writes to `TensorBoard` even files and metrics are seemingly not kept in memory.
- an explicit callback checkpoint `ModelCheckpoint` is instantiated per trial to ensure that checkpoint file names are unique. If they're not, PyTorch Lightning will try to restore model parameters which will fail since model architectures will vary across trials.

_The model/optimizer sampling logic is copied (without being refactored, assuming tests should be independent) from the already existing [pytorch_simple.py](https://github.com/pfnet/optuna/blob/master/examples/pytorch_simple.py)._