### PR TITLE
Add links to nbviewer

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -50,4 +50,6 @@ In addition, integration modules are available for the following libraries, prov
 
 ### Examples of Visualization
 
-* [plotting learning curves](./visualization/plot_intermediate_values.ipynb)
+* [plotting learning curves](https://nbviewer.jupyter.org/github/pfnet/optuna/blob/master/examples/visualization/plot_intermediate_values.ipynb)
+
+* [plotting optimization history](https://nbviewer.jupyter.org/github/pfnet/optuna/blob/master/examples/visualization/plot_optimization_history.ipynb)

--- a/examples/README.md
+++ b/examples/README.md
@@ -51,5 +51,4 @@ In addition, integration modules are available for the following libraries, prov
 ### Examples of Visualization
 
 * [plotting learning curves](https://nbviewer.jupyter.org/github/pfnet/optuna/blob/master/examples/visualization/plot_intermediate_values.ipynb)
-
 * [plotting optimization history](https://nbviewer.jupyter.org/github/pfnet/optuna/blob/master/examples/visualization/plot_optimization_history.ipynb)


### PR DESCRIPTION
Add links to nbviewer (refs #577 )

<img width="357" alt="スクリーンショット 2019-10-11 14 23 17" src="https://user-images.githubusercontent.com/31459778/66626300-b6befa80-ec32-11e9-88c6-66efe03b6d2b.png">

- [x] add "plotting optimization history"
- [x] change links from github to nbviewer

There is one option as follows. I believe that such format is a little noisy.
```
- plotting learning curves ([GitHub](./visualization/plot_intermediate_values.ipynb), [nbviewer](https://nbviewer.jupyter.org/github/pfnet/optuna/blob/master/examples/visualization/plot_intermediate_values.ipynb))
```