### PR TITLE
Add visualization functions to API reference doc.

### DIFF
--- a/docs/source/reference/visualization.rst
+++ b/docs/source/reference/visualization.rst
@@ -4,5 +4,12 @@
 Visualization
 =============
 
+.. autofunction:: plot_contour
+
 .. autofunction:: plot_intermediate_values
 
+.. autofunction:: plot_optimization_history
+
+.. autofunction:: plot_parallel_coordinate
+
+.. autofunction:: plot_slice


### PR DESCRIPTION
This PR adds the documents of visualization functions to the API reference of Optuna.

Before (current stable doc)
------------------------------

![image](https://user-images.githubusercontent.com/181413/66992883-92b55a80-f105-11e9-903f-2770287a73af.png)

After
------

![image](https://user-images.githubusercontent.com/181413/66992897-9c3ec280-f105-11e9-8879-3bc006106a88.png)
