### PR TITLE
Align CircleCI `install-examples` step name to anchor

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -239,7 +239,7 @@ jobs:
       - run: *install
 
       - run: &install-examples
-          name: install
+          name: install-examples
           command: |
             . venv/bin/activate
             pip install $(ls dist/*.tar.gz)[example]


### PR DESCRIPTION
A cosmetic fix but aligns the name of a CircleCI step to its anchor, for consistency with the other steps.