### PR TITLE
Add EPS to resolve ValueError in LightGBMTuner

### DIFF
--- a/optuna/integration/lightgbm_tuner/optimize.py
+++ b/optuna/integration/lightgbm_tuner/optimize.py
@@ -494,7 +494,7 @@ class LightGBMTuner(BaseTuner):
         study = optuna.create_study(
             direction='maximize' if self.higher_is_better() else 'minimize',
             sampler=sampler)
-        study.optimize(objective, n_trials=n_trials)
+        study.optimize(objective, n_trials=n_trials, catch=())
 
         pbar.close()
         del pbar

--- a/optuna/integration/lightgbm_tuner/optimize.py
+++ b/optuna/integration/lightgbm_tuner/optimize.py
@@ -210,7 +210,7 @@ class OptunaObjective(BaseTuner):
             self.lgbm_params['num_leaves'] = trial.suggest_int(
                 'num_leaves', 2, 2 ** max_depth)
         if 'feature_fraction' in self.target_param_names:
-            param_value = min(trial.suggest_uniform('feature_fraction', 0.4, 1.0 + EPS), 1.0)
+            param_value = min(trial.suggest_uniform('feature_fraction', 0.4 - EPS, 1.0 + EPS), 1.0)
             self.lgbm_params['feature_fraction'] = param_value
         if 'bagging_fraction' in self.target_param_names:
             param_value = min(trial.suggest_uniform('bagging_fraction', 0.4, 1.0 + EPS), 1.0)
@@ -454,7 +454,7 @@ class LightGBMTuner(BaseTuner):
             self.lgbm_params[param_name] - 0.08,
             self.lgbm_params[param_name] + 0.08,
             n_trials))
-        param_values = [val for val in param_values if val >= 0.0 and val <= 1.0]
+        param_values = [val for val in param_values if val >= 0.4 and val <= 1.0]
         sampler = _GridSamplerUniform1D(param_name, param_values)
         self.tune_params([param_name], len(param_values), sampler)
 

--- a/optuna/integration/lightgbm_tuner/optimize.py
+++ b/optuna/integration/lightgbm_tuner/optimize.py
@@ -32,6 +32,9 @@ if type_checking.TYPE_CHECKING:
 # Default time budget for tuning `learning_rate`.
 DEFAULT_TIME_BUDGET_FOR_TUNING_LR = 4 * 60 * 60
 
+# EPS is used to ensure that a sampled parameter value is in pre-defined value range.
+EPS = 1e-12
+
 
 class _GridSamplerUniform1D(optuna.samplers.BaseSampler):
 
@@ -207,15 +210,15 @@ class OptunaObjective(BaseTuner):
             self.lgbm_params['num_leaves'] = trial.suggest_int(
                 'num_leaves', 2, 2 ** max_depth)
         if 'feature_fraction' in self.target_param_names:
-            param_value = trial.suggest_uniform('feature_fraction', 0.4, 1.0)
+            param_value = min(trial.suggest_uniform('feature_fraction', 0.4, 1.0 + EPS), 1.0)
             self.lgbm_params['feature_fraction'] = param_value
         if 'bagging_fraction' in self.target_param_names:
-            param_value = trial.suggest_uniform('bagging_fraction', 0.4, 1.0)
+            param_value = min(trial.suggest_uniform('bagging_fraction', 0.4, 1.0 + EPS), 1.0)
             self.lgbm_params['bagging_fraction'] = param_value
         if 'bagging_freq' in self.target_param_names:
             self.lgbm_params['bagging_freq'] = trial.suggest_int('bagging_freq', 1, 7)
         if 'min_child_samples' in self.target_param_names:
-            param_value = int(trial.suggest_uniform('min_child_samples', 5, 100))
+            param_value = int(trial.suggest_uniform('min_child_samples', 5, 100 + EPS))
             self.lgbm_params['min_child_samples'] = param_value
 
         with _timer() as t:

--- a/optuna/integration/lightgbm_tuner/optimize.py
+++ b/optuna/integration/lightgbm_tuner/optimize.py
@@ -210,14 +210,20 @@ class OptunaObjective(BaseTuner):
             self.lgbm_params['num_leaves'] = trial.suggest_int(
                 'num_leaves', 2, 2 ** max_depth)
         if 'feature_fraction' in self.target_param_names:
-            param_value = min(trial.suggest_uniform('feature_fraction', 0.4 - EPS, 1.0 + EPS), 1.0)
+            # `_GridSamplerUniform1D` is used for sampling feature_fraction value.
+            # The value 1.0 for the hyperparameter is always sampled.
+            param_value = min(trial.suggest_uniform('feature_fraction', 0.4, 1.0 + EPS), 1.0)
             self.lgbm_params['feature_fraction'] = param_value
         if 'bagging_fraction' in self.target_param_names:
+            # `TPESampler` is used for sampling bagging_fraction value.
+            # The value 1.0 for the hyperparameter might by sampled.
             param_value = min(trial.suggest_uniform('bagging_fraction', 0.4, 1.0 + EPS), 1.0)
             self.lgbm_params['bagging_fraction'] = param_value
         if 'bagging_freq' in self.target_param_names:
             self.lgbm_params['bagging_freq'] = trial.suggest_int('bagging_freq', 1, 7)
         if 'min_child_samples' in self.target_param_names:
+            # `_GridSamplerUniform1D` is used for sampling min_child_samples value.
+            # The value 1.0 for the hyperparameter is always sampled.
             param_value = int(trial.suggest_uniform('min_child_samples', 5, 100 + EPS))
             self.lgbm_params['min_child_samples'] = param_value
 

--- a/tests/integration_tests/lightgbm_tuner_tests/test_optimize.py
+++ b/tests/integration_tests/lightgbm_tuner_tests/test_optimize.py
@@ -316,7 +316,7 @@ class TestLightGBMTuner(object):
             runner.tune_feature_fraction()
 
             assert runner.lgbm_params['feature_fraction'] != unexpected_value
-            assert len(runner.tuning_history) > 0
+            assert len(runner.tuning_history) == 7
 
     def test_tune_num_leaves(self):
         # type: () -> None
@@ -334,7 +334,7 @@ class TestLightGBMTuner(object):
             runner.tune_num_leaves()
 
             assert runner.lgbm_params['num_leaves'] != unexpected_value
-            assert len(runner.tuning_history) > 0
+            assert len(runner.tuning_history) == 20
 
     def test_tune_bagging(self):
         # type: () -> None
@@ -352,24 +352,25 @@ class TestLightGBMTuner(object):
             runner.tune_bagging()
 
             assert runner.lgbm_params['bagging_fraction'] != unexpected_value
-            assert len(runner.tuning_history) > 0
+            assert len(runner.tuning_history) == 10
 
     def test_tune_feature_fraction_stage2(self):
         # type: () -> None
 
-        unexpected_value = 1.1  # out of scope.
+        unexpected_value = 0.5
 
         with turnoff_train():
             runner = self._helper_get_minimum_runner(params=dict(
-                feature_fraction=unexpected_value,  # set default as unexpected value.
+                feature_fraction=unexpected_value,
             ), kwargs_options=dict(
                 tuning_history=[],
                 best_params={},
             ))
             assert len(runner.tuning_history) == 0
-            runner.tune_feature_fraction()
+            runner.tune_feature_fraction_stage2()
 
-            assert len(runner.tuning_history) > 0
+            assert runner.lgbm_params['feature_fraction'] != unexpected_value
+            assert len(runner.tuning_history) == 6
 
     def test_tune_regularization_factors(self):
         # type: () -> None
@@ -387,7 +388,7 @@ class TestLightGBMTuner(object):
             runner.tune_regularization_factors()
 
             assert runner.lgbm_params['lambda_l1'] != unexpected_value
-            assert len(runner.tuning_history) > 0
+            assert len(runner.tuning_history) == 20
 
     def test_tune_min_data_in_leaf(self):
         # type: () -> None
@@ -405,4 +406,4 @@ class TestLightGBMTuner(object):
             runner.tune_min_data_in_leaf()
 
             assert runner.lgbm_params['min_child_samples'] != unexpected_value
-            assert len(runner.tuning_history) > 0
+            assert len(runner.tuning_history) == 5


### PR DESCRIPTION
I found that LightGBMTuner raises `ValueError` (as below) whenever it tries to tune `feature_fraction`. This PR resolves this issue.

```
tune_feature_fraction, val_score: 0.215008:  86%|##############################################################5          | 6/7 [00:01<00:00,  3.94it/s]
Setting status of trial#6 as TrialState.FAIL because of the following error:
ValueError('Suggest method is called for an invalid parameter: feature_frac
tion.')
Traceback (most recent call last):
  File "/home/ozaki/anaconda/lib/python3.7/site-packages/optuna/study.py", line 504, in _run_trial
    result = func(trial)
  File "/home/ozaki/anaconda/lib/python3.7/site-packages/optuna/integration/lightgbm_tuner/optimize.py", line 210, in __call__
    param_value = trial.suggest_uniform('feature_fraction', 0.4, 1.0)
  File "/home/ozaki/anaconda/lib/python3.7/site-packages/optuna/trial.py", line 187, in suggest_uniform
    return self._suggest(name, distribution)
  File "/home/ozaki/anaconda/lib/python3.7/site-packages/optuna/trial.py", line 461, in _suggest
    self.study, trial, name, distribution)
  File "/home/ozaki/anaconda/lib/python3.7/site-packages/optuna/integration/lightgbm_tuner/optimize.py", line 58, in sample_independent
    'Suggest method is called for an invalid parameter: {}.'.format(param_name))
ValueError: Suggest method is called for an invalid parameter: feature_fraction.
```

This error causes when `_GridSamplerUniform1D`, a subclass of BaseSampler, calls `sample_independent()` unexpectedly.

* [x] TODO: I will add a test case to detect this issue related to numerical precision.