### PR TITLE
Fix an example for tensorflow==1.15.0.

### DIFF
--- a/examples/tensorflow_eager_simple.py
+++ b/examples/tensorflow_eager_simple.py
@@ -19,7 +19,6 @@ We have the following two ways to execute this example:
 """
 
 import tensorflow as tf
-import tensorflow.contrib.eager as tfe
 from tensorflow.keras.datasets import mnist
 
 N_TRAIN_EXAMPLES = 3000
@@ -68,7 +67,7 @@ def create_optimizer(trial):
 
 
 def learn(model, optimizer, dataset, mode='eval'):
-    accuracy = tfe.metrics.Accuracy('accuracy', dtype=tf.float32)
+    accuracy = tf.contrib.eager.metrics.Accuracy('accuracy', dtype=tf.float32)
 
     for batch, (images, labels) in enumerate(dataset):
         with tf.GradientTape() as tape:


### PR DESCRIPTION
`examples/tensorflow_eager_simple.py` fails in Python 2.7 and 3.7 since `tensorflow==1.15.0` has been released.

```console
[W 2019-10-17 15:12:58,389] Setting status of trial#0 as TrialState.FAIL because of the following error: AttributeError("'module' object has no attribute 'metrics'",)
Traceback (most recent call last):
  File "/home/circleci/project/venv/lib/python2.7/site-packages/optuna/study.py", line 503, in _run_trial
    result = func(trial)
  File "examples/tensorflow_eager_simple.py", line 118, in objective
    learn(model, optimizer, train_ds, 'train')
  File "examples/tensorflow_eager_simple.py", line 71, in learn
    accuracy = tfe.metrics.Accuracy('accuracy', dtype=tf.float32)
AttributeError: 'module' object has no attribute 'metrics'
WARNING:tensorflow:From examples/tensorflow_eager_simple.py:66: The name tf.train.AdamOptimizer is deprecated. Please use tf.compat.v1.train.AdamOptimizer instead.
``` 

I'm not sure but the cause seems to be the change of the package structure related to `tensorflow.contrib`. When I change the way to import `tensorflow.contrib.eager`, `examples/tensorflow_eager_simple.py` can be successfully executed.