### PR TITLE
Fix the learning rate in the `LightGBMTuner`

### DIFF
--- a/optuna/integration/lightgbm_tuner/alias.py
+++ b/optuna/integration/lightgbm_tuner/alias.py
@@ -10,48 +10,39 @@ ALIAS_GROUP_LIST = [
     {
         'param_name': 'bagging_fraction',
         'alias_names': ['sub_row', 'subsample', 'bagging'],
-        'default_value': None,
     },
     {
         'param_name': 'learning_rate',
         'alias_names': ['shrinkage_rate', 'eta'],
-        'default_value': None,
     },
     {
         'param_name': 'min_data_in_leaf',
         'alias_names': ['min_data_per_leaf', 'min_data', 'min_child_samples'],
-        'default_value': None,
     },
     {
         'param_name': 'min_sum_hessian_in_leaf',
         'alias_names': ['min_sum_hessian_per_leaf', 'min_sum_hessian',
                         'min_hessian', 'min_child_weight'],
-        'default_value': None,
     },
     {
         'param_name': 'bagging_freq',
         'alias_names': ['subsample_freq'],
-        'default_value': None,
     },
     {
         'param_name': 'feature_fraction',
         'alias_names': ['sub_feature', 'colsample_bytree'],
-        'default_value': None,
     },
     {
         'param_name': 'lambda_l1',
         'alias_names': ['reg_alpha'],
-        'default_value': None,
     },
     {
         'param_name': 'lambda_l2',
         'alias_names': ['reg_lambda', 'lambda'],
-        'default_value': None,
     },
     {
         'param_name': 'min_gain_to_split',
         'alias_names': ['min_split_gain'],
-        'default_value': None,
     },
 ]  # type: List[Dict[str, Any]]
 
@@ -62,14 +53,9 @@ def _handling_alias_parameters(lgbm_params):
 
     for alias_group in ALIAS_GROUP_LIST:
         param_name = alias_group['param_name']
-        default_value = alias_group['default_value']
         alias_names = alias_group['alias_names']
 
         for alias_name in alias_names:
             if alias_name in lgbm_params:
                 lgbm_params[param_name] = lgbm_params[alias_name]
                 del lgbm_params[alias_name]
-
-        # user-supplied argument is used. if it doesn't exist, default value is used.
-        if (default_value is not None) and (param_name not in lgbm_params):
-            lgbm_params.update({param_name: default_value})

--- a/optuna/integration/lightgbm_tuner/alias.py
+++ b/optuna/integration/lightgbm_tuner/alias.py
@@ -15,7 +15,7 @@ ALIAS_GROUP_LIST = [
     {
         'param_name': 'learning_rate',
         'alias_names': ['shrinkage_rate', 'eta'],
-        'default_value': 0.1,  # Start from large `learning_rate` value.
+        'default_value': None,
     },
     {
         'param_name': 'min_data_in_leaf',

--- a/tests/integration_tests/lightgbm_tuner_tests/test_alias.py
+++ b/tests/integration_tests/lightgbm_tuner_tests/test_alias.py
@@ -34,9 +34,11 @@ def test_handling_alias_parameter_with_default_value():
     }
     _handling_alias_parameters(params)
 
-    assert 'eta' not in params
-    assert 'learning_rate' in params
-    assert params['learning_rate'] == 0.1
+    # We currently do not have parameters with default values so the `params` dictionary should not
+    # contain additional entries.
+    assert len(params) == 2
+    assert params['num_boost_round'] == 5
+    assert params['early_stopping_rounds'] == 2
 
 
 def test_handling_alias_parameter():

--- a/tests/integration_tests/lightgbm_tuner_tests/test_alias.py
+++ b/tests/integration_tests/lightgbm_tuner_tests/test_alias.py
@@ -25,22 +25,6 @@ def test_handling_alias_parameter_with_user_supplied_param():
     assert params['learning_rate'] == 0.5
 
 
-def test_handling_alias_parameter_with_default_value():
-    # type: () -> None
-
-    params = {
-        'num_boost_round': 5,
-        'early_stopping_rounds': 2,
-    }
-    _handling_alias_parameters(params)
-
-    # We currently do not have parameters with default values so the `params` dictionary should not
-    # contain additional entries.
-    assert len(params) == 2
-    assert params['num_boost_round'] == 5
-    assert params['early_stopping_rounds'] == 2
-
-
 def test_handling_alias_parameter():
     # type: () -> None
 


### PR DESCRIPTION
Fixes the learning rate in the `LightGBMTuner` as it does not have to be optimized and should be provided by the called (or else, having set the default value of that of LightGBM).

#### Note
I tried to verify this change using the example in https://github.com/pfnet/optuna/pull/549 (thanks @smly!) but it fails on an error which I think is addressed by this ongoing PR https://github.com/pfnet/optuna/pull/619, so maybe it's better to merge #619 first.