### PR TITLE
Fix  plot_optimization_history

### DIFF
--- a/optuna/storages/rdb/models.py
+++ b/optuna/storages/rdb/models.py
@@ -175,7 +175,9 @@ class TrialModel(BaseModel):
     def where_study(cls, study, session):
         # type: (StudyModel, orm.Session) -> List[TrialModel]
 
-        trials = session.query(cls).filter(cls.study_id == study.study_id).all()
+        trials = session.query(cls) \
+            .filter(cls.study_id == study.study_id) \
+            .order_by(cls.trial_id).all()
 
         return trials
 
@@ -217,7 +219,9 @@ class TrialModel(BaseModel):
     def get_all_trial_ids_where_study(cls, study, session):
         # type: (StudyModel, orm.Session) -> List[int]
 
-        trials = session.query(cls.trial_id).filter(cls.study_id == study.study_id).all()
+        trials = session.query(cls.trial_id) \
+            .filter(cls.study_id == study.study_id) \
+            .order_by(cls.trial_id).all()
 
         return [t.trial_id for t in trials]
 

--- a/optuna/visualization.py
+++ b/optuna/visualization.py
@@ -141,6 +141,7 @@ def _get_optimization_history_plot(study):
     )
 
     trials = [t for t in study.trials if t.state == TrialState.COMPLETE]
+    trials = sorted(trials, key=lambda t: t.number)
 
     if len(trials) == 0:
         logger.warning('Study instance does not contain trials.')

--- a/optuna/visualization.py
+++ b/optuna/visualization.py
@@ -141,7 +141,6 @@ def _get_optimization_history_plot(study):
     )
 
     trials = [t for t in study.trials if t.state == TrialState.COMPLETE]
-    trials = sorted(trials, key=lambda t: t.number)
 
     if len(trials) == 0:
         logger.warning('Study instance does not contain trials.')


### PR DESCRIPTION
The plot of `plot_optimization_history` was broken when I used PostgreSQL as a backend database of optuna and distributedly ran an optimization.

![image](https://user-images.githubusercontent.com/6898958/67309012-1f14b280-f536-11e9-9ac3-23e95281a20d.png)

In general, the order of `trials` may not be guaranteed in RDBMS without explicit designation.
Thus it should be sorted by `trial.number` before plotting.
This fix resolves this problem like below:
![image](https://user-images.githubusercontent.com/6898958/67309329-a104db80-f536-11e9-990a-9b36a123f85e.png)

I'm sorry, I have no idea to write tests because I couldn't reproduce this problem with SQLite and I couldn't find any tests depending on such differences between databases.