### PR TITLE
Update `BaseStudy.trials` doc to specify order constraint.

### DIFF
--- a/optuna/study.py
+++ b/optuna/study.py
@@ -102,6 +102,8 @@ class BaseStudy(object):
         # type: () -> List[structs.FrozenTrial]
         """Return all trials in the study.
 
+        The returned trials are ordered by trial number.
+
         Returns:
             A list of :class:`~optuna.structs.FrozenTrial` objects.
         """


### PR DESCRIPTION
The current document of `BaseStudy.trials` doesn't mention about the order of returned trials.
This PR adds a description of the order constraint to the document.
I think that this addition is useful because it allows users and developers to write code that assumes the trials are in ascending order.

Related issue: #631 