### PR TITLE
Add document about stepwise tuning for LightGBM.

### DIFF
--- a/docs/source/reference/integration.rst
+++ b/docs/source/reference/integration.rst
@@ -22,6 +22,8 @@ Integration
 .. autoclass:: LightGBMPruningCallback
     :members:
 
+.. autofunction:: optuna.integration.lightgbm.train
+
 .. autoclass:: MXNetPruningCallback
     :members:
 

--- a/optuna/integration/lightgbm_tuner/__init__.py
+++ b/optuna/integration/lightgbm_tuner/__init__.py
@@ -11,9 +11,11 @@ if type_checking.TYPE_CHECKING:
 
 def train(*args, **kwargs):
     # type: (List[Any], Optional[Dict[Any, Any]]) -> Any
-    """Wrapper function of LightGBM API: train()
+    """Wrapper function of LightGBM API: train() to tune hyperparameters.
 
-    Arguments and keyword arguments for `lightgbm.train()` can be passed.
+    It tunes important hyperparameters (e.g., `min_child_samples` and `feature_fraction`) in a
+    stepwise manner. Arguments and keyword arguments for `lightgbm.train()
+    <https://lightgbm.readthedocs.io/en/latest/pythonapi/lightgbm.train.html>`_ can be passed.
     """
 
     auto_booster = LightGBMTuner(*args, **kwargs)

--- a/optuna/integration/lightgbm_tuner/__init__.py
+++ b/optuna/integration/lightgbm_tuner/__init__.py
@@ -15,7 +15,7 @@ def train(*args, **kwargs):
 
     .. warning::
 
-        This feature is experimental. The interface can be changed in the future.
+        This feature is experimental. The interface may be changed in the future.
 
     It tunes important hyperparameters (e.g., `min_child_samples` and `feature_fraction`) in a
     stepwise manner. Arguments and keyword arguments for `lightgbm.train()

--- a/optuna/integration/lightgbm_tuner/__init__.py
+++ b/optuna/integration/lightgbm_tuner/__init__.py
@@ -15,7 +15,7 @@ def train(*args, **kwargs):
 
     .. warning::
 
-        This feature is experimental. The interface can change in the future.
+        This feature is experimental. The interface can be changed in the future.
 
     It tunes important hyperparameters (e.g., `min_child_samples` and `feature_fraction`) in a
     stepwise manner. Arguments and keyword arguments for `lightgbm.train()

--- a/optuna/integration/lightgbm_tuner/__init__.py
+++ b/optuna/integration/lightgbm_tuner/__init__.py
@@ -11,7 +11,11 @@ if type_checking.TYPE_CHECKING:
 
 def train(*args, **kwargs):
     # type: (List[Any], Optional[Dict[Any, Any]]) -> Any
-    """Wrapper function of LightGBM API: train() to tune hyperparameters.
+    """Wrapper of LightGBM Training API to tune hyperparameters.
+
+    .. warning::
+
+        This feature is experimental. The interface can change in the future.
 
     It tunes important hyperparameters (e.g., `min_child_samples` and `feature_fraction`) in a
     stepwise manner. Arguments and keyword arguments for `lightgbm.train()


### PR DESCRIPTION
This PR adds a document of `optuna.integration.lightgbm.train`.

![image](https://user-images.githubusercontent.com/3255979/67459112-c0a11e80-f672-11e9-81e1-f0a0f17acf72.png)