### PR TITLE
Fix the module of type variables.

### DIFF
--- a/optuna/integration/lightgbm_tuner/__init__.py
+++ b/optuna/integration/lightgbm_tuner/__init__.py
@@ -3,14 +3,11 @@ from optuna.integration.lightgbm_tuner.optimize import LightGBMTuner
 from optuna import type_checking
 
 if type_checking.TYPE_CHECKING:
-    from type_checking import Any  # NOQA
-    from type_checking import Dict  # NOQA
-    from type_checking import List  # NOQA
-    from type_checking import Optional  # NOQA
+    from typing import Any  # NOQA
 
 
 def train(*args, **kwargs):
-    # type: (List[Any], Optional[Dict[Any, Any]]) -> Any
+    # type: (Any, Any) -> Any
     """Wrapper function of LightGBM API: train()
 
     Arguments and keyword arguments for `lightgbm.train()` can be passed.

--- a/optuna/integration/lightgbm_tuner/optimize.py
+++ b/optuna/integration/lightgbm_tuner/optimize.py
@@ -12,14 +12,14 @@ from optuna import type_checking
 
 
 if type_checking.TYPE_CHECKING:
-    from type_checking import Any  # NOQA
-    from type_checking import Callable  # NOQA
-    from type_checking import Dict  # NOQA
-    from type_checking import Generator  # NOQA
-    from type_checking import List  # NOQA
-    from type_checking import Optional  # NOQA
-    from type_checking import Tuple  # NOQA
-    from type_checking import Union  # NOQA
+    from typing import Any  # NOQA
+    from typing import Callable  # NOQA
+    from typing import Dict  # NOQA
+    from typing import Generator  # NOQA
+    from typing import List  # NOQA
+    from typing import Optional  # NOQA
+    from typing import Tuple  # NOQA
+    from typing import Union  # NOQA
 
     from optuna.distributions import BaseDistribution  # NOQA
     from optuna.structs import FrozenTrial  # NOQA
@@ -122,7 +122,7 @@ class BaseTuner(object):
         elif type(valid_sets) is lgb.Dataset:
             valid_name = 'valid_0'
 
-        elif type(valid_sets) in [list, tuple] and len(valid_sets) > 0:
+        elif isinstance(valid_sets, (list, tuple)) and len(valid_sets) > 0:
             valid_set_idx = len(valid_sets) - 1
             valid_name = 'valid_{}'.format(valid_set_idx)
 
@@ -261,8 +261,8 @@ class LightGBMTuner(BaseTuner):
             num_boost_round=1000,  # type: int
             valid_sets=None,  # type: Optional[VALID_SET_TYPE]
             valid_names=None,  # type: Optional[Any]
-            fobj=None,  # type: Optional[Callable[Any, Any]]
-            feval=None,  # type: Optional[Callable[Any, Any]]
+            fobj=None,  # type: Optional[Callable[..., Any]]
+            feval=None,  # type: Optional[Callable[..., Any]]
             feature_name='auto',  # type: str
             categorical_feature='auto',  # type: str
             early_stopping_rounds=None,  # type: Optional[int]
@@ -270,7 +270,7 @@ class LightGBMTuner(BaseTuner):
             verbose_eval=True,  # type: Optional[bool]
             learning_rates=None,  # type: Optional[List[float]]
             keep_training_booster=False,  # type: Optional[bool]
-            callbacks=None,  # type: Optional[List[Callable[Any, Any]]]
+            callbacks=None,  # type: Optional[List[Callable[..., Any]]]
             time_budget=None,  # type: Optional[int]
             sample_size=None,  # type: Optional[int]
             best_params=None,  # type: Optional[Dict[str, Any]]
@@ -315,7 +315,7 @@ class LightGBMTuner(BaseTuner):
         return params
 
     def _parse_args(self, *args, **kwargs):
-        # type: (List[Any], Dict[str, Any]) -> None
+        # type: (Any, Any) -> None
 
         self.auto_options = {
             option_name: kwargs.get(option_name)

--- a/optuna/integration/lightgbm_tuner/sklearn.py
+++ b/optuna/integration/lightgbm_tuner/sklearn.py
@@ -6,16 +6,9 @@ from optuna import type_checking
 
 
 if type_checking.TYPE_CHECKING:
-    from type_checking import Any  # NOQA
-    from type_checking import Callable  # NOQA
-    from type_checking import Dict  # NOQA
-    from type_checking import List  # NOQA
-    from type_checking import Optional  # NOQA
-    from type_checking import Tuple  # NOQA
-    from type_checking import Union  # NOQA
-
-    import numpy as np  # NOQA
-    from scipy.sparse.compressed import _cs_matrix  # NOQA
+    from typing import Any  # NOQA
+    from typing import Dict  # NOQA
+    from typing import List  # NOQA
 
 
 class LGBMModel(lgb.LGBMModel):

--- a/tests/integration_tests/lightgbm_tuner_tests/test_optimize.py
+++ b/tests/integration_tests/lightgbm_tuner_tests/test_optimize.py
@@ -1,5 +1,4 @@
 import contextlib
-import sys
 
 import mock
 import numpy as np
@@ -15,33 +14,9 @@ from optuna import type_checking
 
 
 if type_checking.TYPE_CHECKING:
-    from type_checking import Any  # NOQA
-    from type_checking import Dict  # NOQA
-    from type_checking import Generator  # NOQA
-    from type_checking import List  # NOQA
-    from type_checking import Tuple  # NOQA
-
-if sys.version_info >= (3, 5):
-    from contextlib import ExitStack
-
-
-@contextlib.contextmanager
-def turnoff_tuner():
-    # type: () -> Generator[None, None, None]
-
-    fqn_prefix = 'optuna.integration.lightgbm_tuner.LightGBMTuner'
-    mock_pairs = [
-        (fqn_prefix + '.__init__', None),
-        (fqn_prefix + '.run', True),
-        (fqn_prefix + '._parse_args', None),
-        (fqn_prefix + '._get_params', {}),
-    ]  # type: List[Tuple[str, Any]]
-
-    if sys.version_info >= (3, 5):
-        with ExitStack() as stack:
-            for fqn, return_value in mock_pairs:
-                stack.enter_context(mock.patch(fqn, return_value=return_value))
-            yield
+    from typing import Any  # NOQA
+    from typing import Dict  # NOQA
+    from typing import Generator  # NOQA
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
Some files in `optuna/integration/lightgbm_tuner` use type variables like `Any` and `List` in  `optuna.type_checking`, but actually such variables do not exist (see [type_checking.py](https://github.com/pfnet/optuna/blob/master/optuna/type_checking.py)). This PR fixes the module of type variables.

Please note that `turnoff_tuner` in `tests/integration_tests/lightgbm_tuner_tests/test_optimize.py` was removed because it was not unused by any functions or classes.