### PR TITLE
Catch no exceptions in `optimize` by default

### DIFF
--- a/optuna/integration/chainermn.py
+++ b/optuna/integration/chainermn.py
@@ -119,7 +119,7 @@ class ChainerMNStudy(object):
             func,  # type: Callable[[ChainerMNTrial, CommunicatorBase], float]
             n_trials=None,  # type: Optional[int]
             timeout=None,  # type: Optional[float]
-            catch=(Exception, ),  # type: Union[Tuple[()], Tuple[Type[Exception]]]
+            catch=(),  # type: Union[Tuple[()], Tuple[Type[Exception]]]
     ):
         # type: (...) -> None
         """Optimize an objective function.

--- a/optuna/study.py
+++ b/optuna/study.py
@@ -238,7 +238,7 @@ class Study(BaseStudy):
             catch:
                 A study continues to run even when a trial raises one of the exceptions specified
                 in this argument. Default is an empty tuple, i.e. the study will stop for any
-                exception.
+                exception except for :class:`structs.TrialPruned`.
             callbacks:
                 List of callback functions that are invoked at the end of each trial.
         """

--- a/optuna/study.py
+++ b/optuna/study.py
@@ -213,7 +213,7 @@ class Study(BaseStudy):
             n_trials=None,  # type: Optional[int]
             timeout=None,  # type: Optional[float]
             n_jobs=1,  # type: int
-            catch=(Exception, ),  # type: Union[Tuple[()], Tuple[Type[Exception]]]
+            catch=(),  # type: Union[Tuple[()], Tuple[Type[Exception]]]
             callbacks=None  # type: Optional[List[Callable[[Study, structs.FrozenTrial], None]]]
     ):
         # type: (...) -> None
@@ -236,10 +236,9 @@ class Study(BaseStudy):
                 The number of parallel jobs. If this argument is set to :obj:`-1`, the number is
                 set to CPU counts.
             catch:
-                A study continues to run even when a trial raises one of exceptions specified in
-                this argument. Default is (`Exception <https://docs.python.org/3/library/
-                exceptions.html#Exception>`_,), where all non-exit exceptions are handled
-                by this logic.
+                A study continues to run even when a trial raises one of the exceptions specified
+                in this argument. Default is an empty tuple, i.e. the study will stop for any
+                exception.
             callbacks:
                 List of callback functions that are invoked at the end of each trial.
         """

--- a/optuna/study.py
+++ b/optuna/study.py
@@ -239,7 +239,7 @@ class Study(BaseStudy):
             catch:
                 A study continues to run even when a trial raises one of the exceptions specified
                 in this argument. Default is an empty tuple, i.e. the study will stop for any
-                exception except for :class:`structs.TrialPruned`.
+                exception except for :class:`~structs.TrialPruned`.
             callbacks:
                 List of callback functions that are invoked at the end of each trial.
             gc_after_trial:

--- a/tests/samplers_tests/test_samplers.py
+++ b/tests/samplers_tests/test_samplers.py
@@ -237,7 +237,7 @@ def test_intersection_search_space():
         trial.suggest_uniform('z', 0, 1)
         raise exception
 
-    study.optimize(lambda t: objective(t, RuntimeError()), n_trials=1)
+    study.optimize(lambda t: objective(t, RuntimeError()), n_trials=1, catch=(RuntimeError,))
     study.optimize(lambda t: objective(t, optuna.structs.TrialPruned()), n_trials=1)
     assert optuna.samplers.intersection_search_space(study) == {
         'y': UniformDistribution(low=-3, high=3)
@@ -277,7 +277,7 @@ def test_product_search_space():
         trial.suggest_uniform('z', 0, 1)
         raise exception
 
-    study.optimize(lambda t: objective(t, RuntimeError()), n_trials=1)
+    study.optimize(lambda t: objective(t, RuntimeError()), n_trials=1, catch=(RuntimeError,))
     study.optimize(lambda t: objective(t, optuna.structs.TrialPruned()), n_trials=1)
     assert optuna.samplers.product_search_space(study) == {
         'y': UniformDistribution(low=-3, high=3)

--- a/tests/samplers_tests/tpe_tests/test_sampler.py
+++ b/tests/samplers_tests/tpe_tests/test_sampler.py
@@ -39,7 +39,7 @@ def test_get_observation_pairs():
 
     # direction=minimize.
     study = optuna.create_study(direction='minimize')
-    study.optimize(objective, n_trials=5)
+    study.optimize(objective, n_trials=5, catch=(RuntimeError,))
     study._storage.create_new_trial(study.study_id)  # Create a running trial.
 
     assert tpe.sampler._get_observation_pairs(study, 'x') == (

--- a/tests/test_study.py
+++ b/tests/test_study.py
@@ -230,6 +230,10 @@ def test_optimize_with_catch(storage_mode, cache_mode):
 
             raise ValueError
 
+        # Test default exceptions.
+        with pytest.raises(ValueError):
+            study.optimize(func_value_error, n_trials=20)
+
         # Test acceptable exception.
         study.optimize(func_value_error, n_trials=20, catch=(ValueError, ))
 
@@ -481,7 +485,7 @@ def test_trials_dataframe_with_failure(storage_mode, cache_mode):
 
     with StorageSupplier(storage_mode, cache_mode) as storage:
         study = optuna.create_study(storage=storage)
-        study.optimize(f, n_trials=3)
+        study.optimize(f, n_trials=3, catch=(ValueError,))
         df = study.trials_dataframe()
         # Change index to access rows via trial number.
         df.set_index(('number', ''), inplace=True, drop=False)
@@ -664,7 +668,9 @@ def test_callbacks(n_jobs):
     # callbacks are invoked.
     states = []
     callbacks = [lambda study, trial: states.append(trial.state)]
-    study.optimize(lambda t: 1/0, callbacks=callbacks, n_trials=10, n_jobs=n_jobs)
+    study.optimize(
+        lambda t: 1/0, callbacks=callbacks, n_trials=10, n_jobs=n_jobs,
+        catch=(ZeroDivisionError,))
     assert states == [optuna.structs.TrialState.FAIL] * 10
 
     # NOTE: Because `Study.optimize` blocks forever if `n_jobs` is more than `1` and

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -49,7 +49,7 @@ def test_get_intermediate_plot():
         raise ValueError
 
     study = create_study()
-    study.optimize(fail_objective, n_trials=1)
+    study.optimize(fail_objective, n_trials=1, catch=(ValueError,))
     figure = _get_intermediate_plot(study)
     assert len(figure.data) == 0
 
@@ -90,7 +90,7 @@ def test_get_optimization_history_plot():
         raise ValueError
 
     study = create_study()
-    study.optimize(fail_objective, n_trials=1)
+    study.optimize(fail_objective, n_trials=1, catch=(ValueError,))
     figure = _get_optimization_history_plot(study)
     assert len(figure.data) == 0
 
@@ -164,7 +164,7 @@ def test_get_contour_plot():
         raise ValueError
 
     study = create_study()
-    study.optimize(fail_objective, n_trials=1)
+    study.optimize(fail_objective, n_trials=1, catch=(ValueError,))
     figure = _get_contour_plot(study)
     assert len(figure.data) == 0
 
@@ -239,7 +239,7 @@ def test_get_parallel_coordinate_plot():
         raise ValueError
 
     study = create_study()
-    study.optimize(fail_objective, n_trials=1)
+    study.optimize(fail_objective, n_trials=1, catch=(ValueError,))
     figure = _get_parallel_coordinate_plot(study)
     assert len(figure.data) == 0
 
@@ -305,6 +305,6 @@ def test_get_slice_plot():
         raise ValueError
 
     study = create_study()
-    study.optimize(fail_objective, n_trials=1)
+    study.optimize(fail_objective, n_trials=1, catch=(ValueError,))
     figure = _get_slice_plot(study)
     assert len(figure.data) == 0


### PR DESCRIPTION
This PR changes the default behavior from catching every `Exception` in `optimize` to catch nothing, favoring explicit errors over "silenced errors".

It is a bit risky to catch all exceptions by default, considering the fact that the usage of this argument is not obvious at first sight and quite a few users might not be aware of this argument. 