### PR TITLE
Remove `TrialModel.where_study_id`.

### DIFF
--- a/optuna/storages/rdb/models.py
+++ b/optuna/storages/rdb/models.py
@@ -182,14 +182,6 @@ class TrialModel(BaseModel):
         return trials
 
     @classmethod
-    def where_study_id(cls, study_id, session):
-        # type: (int, orm.Session) -> List[TrialModel]
-
-        trials = session.query(cls).filter(cls.study_id == study_id).all()
-
-        return trials
-
-    @classmethod
     def count(cls, session, study=None, state=None):
         # type: (orm.Session, Optional[StudyModel], Optional[TrialState]) -> int
 

--- a/tests/storages_tests/rdb_tests/test_models.py
+++ b/tests/storages_tests/rdb_tests/test_models.py
@@ -143,12 +143,12 @@ class TestTrialModel(object):
         session.add(study)
         session.commit()
 
-        assert 2 == len(TrialModel.where_study_id(study_id, session))
+        assert 2 == len(TrialModel.where_study(study, session))
 
         session.delete(study)
         session.commit()
 
-        assert 0 == len(TrialModel.where_study_id(study_id, session))
+        assert 0 == len(TrialModel.where_study(study, session))
 
 
 class TestTrialUserAttributeModel(object):


### PR DESCRIPTION
This is a follow-up PR of #631.
This PR removes `optuna.storages.rdb.models.TrialModel.where study_id`. This is partly because the functionality of `TrialModel.where_study_id` is duplicated with `TrialModel.where_study` and partly because it is only used in test code.

Currently, some models in `optuna.storages.rdb.models` have `where_study`, but the others have `where_study_id`. I think it is helpful for developers if all the models have the same method.