### PR TITLE
Fix a bug that `LightGBMTuner` doesn't update `tuning_history` or `best_params`.

### DIFF
--- a/optuna/integration/lightgbm_tuner/optimize.py
+++ b/optuna/integration/lightgbm_tuner/optimize.py
@@ -299,8 +299,8 @@ class LightGBMTuner(BaseTuner):
         self.best_booster = None
 
         self.best_score = -np.inf if self.higher_is_better() else np.inf
-        self.best_params = best_params or {}
-        self.tuning_history = tuning_history or []
+        self.best_params = {} if best_params is None else best_params
+        self.tuning_history = [] if tuning_history is None else tuning_history
 
         if early_stopping_rounds is None:
             self._suggest_early_stopping_rounds()

--- a/tests/integration_tests/lightgbm_tuner_tests/test_optimize.py
+++ b/tests/integration_tests/lightgbm_tuner_tests/test_optimize.py
@@ -17,6 +17,7 @@ if type_checking.TYPE_CHECKING:
     from typing import Any  # NOQA
     from typing import Dict  # NOQA
     from typing import Generator  # NOQA
+    from typing import List  # NOQA
 
 
 @contextlib.contextmanager
@@ -281,8 +282,8 @@ class TestLightGBMTuner(object):
         unexpected_value = 1.1  # out of scope.
 
         with turnoff_train():
-            tuning_history = []
-            best_params = {}
+            tuning_history = []  # type: List[Dict[str, float]]
+            best_params = {}  # type: Dict[str, Any]
 
             runner = self._get_tuner_object(params=dict(
                 feature_fraction=unexpected_value,  # set default as unexpected value.
@@ -304,7 +305,7 @@ class TestLightGBMTuner(object):
         unexpected_value = 1  # out of scope.
 
         with turnoff_train():
-            tuning_history = []
+            tuning_history = []  # type: List[Dict[str, float]]
 
             runner = self._get_tuner_object(params=dict(
                 num_leaves=unexpected_value,
@@ -324,7 +325,7 @@ class TestLightGBMTuner(object):
         unexpected_value = 1  # out of scope.
 
         with turnoff_train():
-            tuning_history = []
+            tuning_history = []  # type: List[Dict[str, float]]
 
             runner = self._get_tuner_object(params=dict(
                 bagging_fraction=unexpected_value,
@@ -344,7 +345,7 @@ class TestLightGBMTuner(object):
         unexpected_value = 0.5
 
         with turnoff_train():
-            tuning_history = []
+            tuning_history = []  # type: List[Dict[str, float]]
 
             runner = self._get_tuner_object(params=dict(
                 feature_fraction=unexpected_value,
@@ -364,7 +365,7 @@ class TestLightGBMTuner(object):
         unexpected_value = 20  # out of scope.
 
         with turnoff_train():
-            tuning_history = []
+            tuning_history = []  # type: List[Dict[str, float]]
 
             runner = self._get_tuner_object(params=dict(
                 lambda_l1=unexpected_value,  # set default as unexpected value.
@@ -384,7 +385,7 @@ class TestLightGBMTuner(object):
         unexpected_value = 1  # out of scope.
 
         with turnoff_train():
-            tuning_history = []
+            tuning_history = []  # type: List[Dict[str, float]]
 
             runner = self._get_tuner_object(params=dict(
                 min_child_samples=unexpected_value,  # set default as unexpected value.

--- a/tests/integration_tests/lightgbm_tuner_tests/test_optimize.py
+++ b/tests/integration_tests/lightgbm_tuner_tests/test_optimize.py
@@ -200,7 +200,7 @@ class TestBaseTuner(object):
 
 class TestLightGBMTuner(object):
 
-    def _helper_get_minimum_runner(self, params={}, train_set=None, kwargs_options={}):
+    def _get_tuner_object(self, params={}, train_set=None, kwargs_options={}):
         # type: (Dict[str, Any], lgb.Dataset, Dict[str, Any]) -> lgb.LightGBMTuner
 
         # Required keyword arguments.
@@ -233,7 +233,7 @@ class TestLightGBMTuner(object):
     def test_with_minimum_required_args(self):
         # type: () -> None
 
-        runner = self._helper_get_minimum_runner()
+        runner = self._get_tuner_object()
         assert 'num_boost_round' in runner.lgbm_kwargs
         assert 'num_boost_round' not in runner.auto_options
         assert runner.lgbm_kwargs['num_boost_round'] == 5
@@ -266,8 +266,8 @@ class TestLightGBMTuner(object):
         X_trn = np.random.uniform(10, size=50).reshape((10, 5))
         y_trn = np.random.randint(2, size=10)
         train_dataset = lgb.Dataset(X_trn, label=y_trn)
-        runner = self._helper_get_minimum_runner(train_set=train_dataset,
-                                                 kwargs_options=dict(sample_size=sample_size))
+        runner = self._get_tuner_object(train_set=train_dataset,
+                                        kwargs_options=dict(sample_size=sample_size))
         runner.sample_train_set()
 
         # Workaround for mypy.
@@ -281,17 +281,22 @@ class TestLightGBMTuner(object):
         unexpected_value = 1.1  # out of scope.
 
         with turnoff_train():
-            runner = self._helper_get_minimum_runner(params=dict(
+            tuning_history = []
+            best_params = {}
+
+            runner = self._get_tuner_object(params=dict(
                 feature_fraction=unexpected_value,  # set default as unexpected value.
             ), kwargs_options=dict(
-                tuning_history=[],
-                best_params={},
+                tuning_history=tuning_history,
+                best_params=best_params,
             ))
-            assert len(runner.tuning_history) == 0
+            assert len(tuning_history) == 0
+            assert len(best_params) == 0
             runner.tune_feature_fraction()
 
             assert runner.lgbm_params['feature_fraction'] != unexpected_value
-            assert len(runner.tuning_history) == 7
+            assert len(tuning_history) == 7
+            assert len(best_params) == 1
 
     def test_tune_num_leaves(self):
         # type: () -> None
@@ -299,17 +304,19 @@ class TestLightGBMTuner(object):
         unexpected_value = 1  # out of scope.
 
         with turnoff_train():
-            runner = self._helper_get_minimum_runner(params=dict(
+            tuning_history = []
+
+            runner = self._get_tuner_object(params=dict(
                 num_leaves=unexpected_value,
             ), kwargs_options=dict(
-                tuning_history=[],
+                tuning_history=tuning_history,
                 best_params={},
             ))
-            assert len(runner.tuning_history) == 0
+            assert len(tuning_history) == 0
             runner.tune_num_leaves()
 
             assert runner.lgbm_params['num_leaves'] != unexpected_value
-            assert len(runner.tuning_history) == 20
+            assert len(tuning_history) == 20
 
     def test_tune_bagging(self):
         # type: () -> None
@@ -317,17 +324,19 @@ class TestLightGBMTuner(object):
         unexpected_value = 1  # out of scope.
 
         with turnoff_train():
-            runner = self._helper_get_minimum_runner(params=dict(
+            tuning_history = []
+
+            runner = self._get_tuner_object(params=dict(
                 bagging_fraction=unexpected_value,
             ), kwargs_options=dict(
-                tuning_history=[],
+                tuning_history=tuning_history,
                 best_params={},
             ))
-            assert len(runner.tuning_history) == 0
+            assert len(tuning_history) == 0
             runner.tune_bagging()
 
             assert runner.lgbm_params['bagging_fraction'] != unexpected_value
-            assert len(runner.tuning_history) == 10
+            assert len(tuning_history) == 10
 
     def test_tune_feature_fraction_stage2(self):
         # type: () -> None
@@ -335,17 +344,19 @@ class TestLightGBMTuner(object):
         unexpected_value = 0.5
 
         with turnoff_train():
-            runner = self._helper_get_minimum_runner(params=dict(
+            tuning_history = []
+
+            runner = self._get_tuner_object(params=dict(
                 feature_fraction=unexpected_value,
             ), kwargs_options=dict(
-                tuning_history=[],
+                tuning_history=tuning_history,
                 best_params={},
             ))
-            assert len(runner.tuning_history) == 0
+            assert len(tuning_history) == 0
             runner.tune_feature_fraction_stage2()
 
             assert runner.lgbm_params['feature_fraction'] != unexpected_value
-            assert len(runner.tuning_history) == 6
+            assert len(tuning_history) == 6
 
     def test_tune_regularization_factors(self):
         # type: () -> None
@@ -353,17 +364,19 @@ class TestLightGBMTuner(object):
         unexpected_value = 20  # out of scope.
 
         with turnoff_train():
-            runner = self._helper_get_minimum_runner(params=dict(
+            tuning_history = []
+
+            runner = self._get_tuner_object(params=dict(
                 lambda_l1=unexpected_value,  # set default as unexpected value.
             ), kwargs_options=dict(
-                tuning_history=[],
+                tuning_history=tuning_history,
                 best_params={},
             ))
-            assert len(runner.tuning_history) == 0
+            assert len(tuning_history) == 0
             runner.tune_regularization_factors()
 
             assert runner.lgbm_params['lambda_l1'] != unexpected_value
-            assert len(runner.tuning_history) == 20
+            assert len(tuning_history) == 20
 
     def test_tune_min_data_in_leaf(self):
         # type: () -> None
@@ -371,14 +384,16 @@ class TestLightGBMTuner(object):
         unexpected_value = 1  # out of scope.
 
         with turnoff_train():
-            runner = self._helper_get_minimum_runner(params=dict(
+            tuning_history = []
+
+            runner = self._get_tuner_object(params=dict(
                 min_child_samples=unexpected_value,  # set default as unexpected value.
             ), kwargs_options=dict(
-                tuning_history=[],
+                tuning_history=tuning_history,
                 best_params={},
             ))
-            assert len(runner.tuning_history) == 0
+            assert len(tuning_history) == 0
             runner.tune_min_data_in_leaf()
 
             assert runner.lgbm_params['min_child_samples'] != unexpected_value
-            assert len(runner.tuning_history) == 5
+            assert len(tuning_history) == 5


### PR DESCRIPTION
This PR fixes the problem that `LightGBMTuner` doesn't update `tuning_history` or `best_params` when the given object for `tuning_history` or `best_params` is an empty `list` or `dict`.