### PR TITLE
Skip XGBoost tests and examples with Python 2.7 in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -269,7 +269,7 @@ jobs:
           name: examples
           command: |
             . venv/bin/activate
-            for file in `find examples -name '*.py' -not -name 'chainermn_*.py'`
+            for file in `find examples -name '*.py' | grep -vE "$IGNORES"`
             do
                python $file
                if grep -e '\-\-pruning' $file > /dev/null; then
@@ -278,6 +278,7 @@ jobs:
             done
           environment:
             OMP_NUM_THREADS: 1
+            IGNORES: chainermn_.*
 
       - run: &examples-mn
           name: examples-mn
@@ -310,15 +311,9 @@ jobs:
 
       - run:
           <<: *examples
-          command: |
-            . venv/bin/activate
-            for file in `find examples -name '*.py' -not -name 'chainermn_*.py' -not -name 'pytorch_lightning_simple.py'`
-            do
-               python $file
-               if grep -e '\-\-pruning' $file > /dev/null; then
-                  python $file --pruning
-               fi
-            done
+          environment:
+            OMP_NUM_THREADS: 1
+            IGNORES: chainermn_.*|pytorch_lightning.*
 
       - run: *examples-mn
 
@@ -334,14 +329,8 @@ jobs:
 
       - run:
           <<: *examples
-          command: |
-            . venv/bin/activate
-            for file in `find examples -name '*.py' -not -name 'chainermn_*.py' -not -name 'pytorch_lightning_*.py' -not -name 'xgboost_*.py'`
-            do
-               python $file
-               if grep -e '\-\-pruning' $file > /dev/null; then
-                  python $file --pruning
-               fi
-            done
+          environment:
+            OMP_NUM_THREADS: 1
+            IGNORES: chainermn_.*|pytorch_lightning.*|xgboost_.*
 
       - run: *examples-mn

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,15 +114,7 @@ jobs:
           name: tests
           command: |
             . venv/bin/activate
-            pytest tests --ignore tests/integration_tests/test_pytorch_lightning.py
-          environment:
-            OMP_NUM_THREADS: 1
-
-      - run: &tests-pytorch-lightning
-          name: tests-pytorch-lightning
-          command: |
-            . venv/bin/activate
-            pytest tests/integration_tests/test_pytorch_lightning.py
+            pytest tests
           environment:
             OMP_NUM_THREADS: 1
 
@@ -138,23 +130,39 @@ jobs:
     docker:
       - image: circleci/python:3.6
     steps:
-      - checkout
-      - run: *install
-      - run: *tests
-      - run: *tests-pytorch-lightning
-      - run: *tests-mn
+      [checkout, run: *install, run: *tests, run: *tests-mn]
 
   tests-python35:
     docker:
       - image: circleci/python:3.5
     steps:
-      [checkout, run: *install, run: *tests, run: *tests-mn]
+      - checkout
+
+      - run: *install
+
+      - run:
+          <<: *tests
+          command: |
+            . venv/bin/activate
+            pytest tests --ignore tests/integration_tests/test_pytorch_lightning.py
+
+      - run: *tests-mn
 
   tests-python27:
     docker:
       - image: circleci/python:2.7
     steps:
-      [checkout, run: *install, run: *tests, run: *tests-mn]
+      - checkout
+
+      - run: *install
+
+      - run:
+          <<: *tests
+          command: |
+            . venv/bin/activate
+            pytest tests --ignore tests/integration_tests/test_pytorch_lightning.py --ignore tests/integration_tests/test_xgboost.py
+
+      - run: *tests-mn
 
   tests-python37-full:
     docker:
@@ -163,29 +171,17 @@ jobs:
       - checkout
 
       - run: *install
-      - run: &tests-full
-          name: tests-full
-          command: |
-            . venv/bin/activate
-            pytest tests --ignore tests/integration_tests/test_pytorch_lightning.py
-          environment:
-            OMP_NUM_THREADS: 1
-            INCLUDE_SLOW_TESTS: 1
 
-      - run: &tests-pytorch-lightning-full
-          name: tests-pytorch-lightning-full
-          command: |
-            . venv/bin/activate
-            pytest tests/integration_tests/test_pytorch_lightning.py
+      - run: &tests-full
+          <<: *tests
+          name: tests-full
           environment:
             OMP_NUM_THREADS: 1
             INCLUDE_SLOW_TESTS: 1
 
       - run: &tests-mn-full
+          <<: *tests-mn
           name: tests-mn-full
-          command: |
-            . venv/bin/activate
-            mpirun -n 2 -- pytest tests/integration_tests/test_chainermn.py
           environment:
             OMP_NUM_THREADS: 1
             INCLUDE_SLOW_TESTS: 1
@@ -194,19 +190,39 @@ jobs:
     docker:
       - image: circleci/python:3.6
     steps:
-      [checkout, run: *install, run: *tests-full, run: *tests-pytorch-lightning-full, run: *tests-mn-full]
+      [checkout, run: *install, run: *tests-full, run: *tests-mn-full]
 
   tests-python35-full:
     docker:
       - image: circleci/python:3.5
     steps:
-      [checkout, run: *install, run: *tests-full, run: *tests-mn-full]
+      - checkout
+
+      - run: *install
+
+      - run:
+          <<: *tests-full
+          command: |
+            . venv/bin/activate
+            pytest tests --ignore tests/integration_tests/test_pytorch_lightning.py
+
+      - run: *tests-mn-full
 
   tests-python27-full:
     docker:
       - image: circleci/python:2.7
     steps:
-      [checkout, run: *install, run: *tests-full, run: *tests-mn-full]
+      - checkout
+
+      - run: *install
+
+      - run:
+          <<: *tests-full
+          command: |
+            . venv/bin/activate
+            pytest tests --ignore tests/integration_tests/test_pytorch_lightning.py --ignore tests/integration_tests/test_xgboost.py
+
+      - run: *tests-mn-full
 
   codecov:
     docker:
@@ -253,21 +269,13 @@ jobs:
           name: examples
           command: |
             . venv/bin/activate
-            for file in `find examples -name '*.py' -not -name 'chainermn_*.py' -not -name 'dask_ml*.py' -not -name 'pytorch_lightning_simple.py'`
+            for file in `find examples -name '*.py' -not -name 'chainermn_*.py'`
             do
                python $file
                if grep -e '\-\-pruning' $file > /dev/null; then
                   python $file --pruning
                fi
             done
-          environment:
-            OMP_NUM_THREADS: 1
-
-      - run: &examples-pytorch-lightning
-          name: examples-pytorch-lightning
-          command: |
-            . venv/bin/activate
-            python examples/pytorch_lightning_simple.py
           environment:
             OMP_NUM_THREADS: 1
 
@@ -284,29 +292,56 @@ jobs:
           environment:
             OMP_NUM_THREADS: 1
 
-      - run: &examples-dask-ml
-          name: examples-dask-ml
-          command: |
-            . venv/bin/activate
-            for file in `find examples -name 'dask_ml*.py'`
-            do
-               python $file
-            done
-
   examples-python36:
     docker:
       - image: circleci/python:3.6
     steps:
-      [checkout, run: *install, run: *install-examples, run: *examples, run: *examples-pytorch-lightning, run: *examples-mn, run: *examples-dask-ml]
+      [checkout, run: *install, run: *install-examples, run: *examples, run: *examples-mn]
 
   examples-python35:
     docker:
       - image: circleci/python:3.5
     steps:
-      [checkout, run: *install, run: *install-examples, run: *examples, run: *examples-mn, run: *examples-dask-ml]
+      - checkout
+
+      - run: *install
+
+      - run: *install-examples
+
+      - run:
+          <<: *examples
+          command: |
+            . venv/bin/activate
+            for file in `find examples -name '*.py' -not -name 'chainermn_*.py' -not -name 'pytorch_lightning_simple.py'`
+            do
+               python $file
+               if grep -e '\-\-pruning' $file > /dev/null; then
+                  python $file --pruning
+               fi
+            done
+
+      - run: *examples-mn
 
   examples-python27:
     docker:
       - image: circleci/python:2.7
     steps:
-      [checkout, run: *install, run: *install-examples, run: *examples, run: *examples-mn]
+      - checkout
+
+      - run: *install
+
+      - run: *install-examples
+
+      - run:
+          <<: *examples
+          command: |
+            . venv/bin/activate
+            for file in `find examples -name '*.py' -not -name 'chainermn_*.py' -not -name 'pytorch_lightning_*.py' -not -name 'xgboost_*.py'`
+            do
+               python $file
+               if grep -e '\-\-pruning' $file > /dev/null; then
+                  python $file --pruning
+               fi
+            done
+
+      - run: *examples-mn

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -331,6 +331,6 @@ jobs:
           <<: *examples
           environment:
             OMP_NUM_THREADS: 1
-            IGNORES: chainermn_.*|pytorch_lightning.*|xgboost_.*
+            IGNORES: chainermn_.*|pytorch_lightning.*|xgboost_.*|dask_ml_.*
 
       - run: *examples-mn


### PR DESCRIPTION
Skip XGBoost tests and examples with Python 2.7 in CircleCI. 

Also includes some overhauling refactoring in the CI config to follow the DRY principle but I'd be more than happy for suggestions how to better organize yaml content.