### PR TITLE
Use a log-scale axis in slice plots if a parameter type is LogUniformDistribution.

### DIFF
--- a/optuna/visualization.py
+++ b/optuna/visualization.py
@@ -1,5 +1,6 @@
 from collections import defaultdict
 
+from optuna.distributions import LogUniformDistribution
 from optuna.logging import get_logger
 from optuna.structs import StudyDirection
 from optuna.structs import TrialState
@@ -514,6 +515,8 @@ def _get_slice_plot(study, params=None):
         )
         figure.update_xaxes(title_text=sorted_params[0])
         figure.update_yaxes(title_text='Objective Value')
+        if _is_log_scale(trials, sorted_params[0]):
+            figure.update_xaxes(type='log')
     else:
         figure = make_subplots(rows=1, cols=len(sorted_params), shared_yaxes=True)
         figure.update_layout(layout)
@@ -527,8 +530,17 @@ def _get_slice_plot(study, params=None):
             figure.update_xaxes(title_text=param, row=1, col=i + 1)
             if i == 0:
                 figure.update_yaxes(title_text='Objective Value', row=1, col=1)
+            if _is_log_scale(trials, param):
+                figure.update_xaxes(type='log', row=1, col=i + 1)
 
     return figure
+
+
+def _is_log_scale(trials, param):
+    # type: (List[FrozenTrial], str) -> bool
+
+    return any(isinstance(t.distributions[param], LogUniformDistribution)
+               for t in trials if param in t.params)
 
 
 def _generate_slice_subplot(study, trials, param):

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -1,5 +1,6 @@
 import pytest
 
+from optuna.distributions import LogUniformDistribution
 from optuna.distributions import UniformDistribution
 from optuna.study import create_study
 from optuna.trial import Trial  # NOQA
@@ -309,6 +310,62 @@ def test_get_slice_plot():
     study.optimize(fail_objective, n_trials=1, catch=(ValueError,))
     figure = _get_slice_plot(study)
     assert len(figure.data) == 0
+
+
+def test_get_slice_plot_log_scale():
+    # type: () -> None
+
+    study = create_study()
+    study._append_trial(
+        value=0.0,
+        params={
+            'x_linear': 1.0,
+            'y_log': 1e-3,
+        },
+        distributions={
+            'x_linear': UniformDistribution(0.0, 3.0),
+            'y_log': LogUniformDistribution(1e-5, 1.),
+        }
+    )
+
+    # Plot a parameter.
+    figure = _get_slice_plot(study, params=['y_log'])
+    assert figure.layout['xaxis_type'] == 'log'
+    figure = _get_slice_plot(study, params=['x_linear'])
+    assert figure.layout['xaxis_type'] is None
+
+    # Plot multiple parameters.
+    figure = _get_slice_plot(study)
+    assert figure.layout['xaxis_type'] is None
+    assert figure.layout['xaxis2_type'] == 'log'
+
+
+def test_is_log_scale():
+    # type: () -> None
+
+    study = create_study()
+    study._append_trial(
+        value=0.0,
+        params={
+            'param_linear': 1.0,
+        },
+        distributions={
+            'param_linear': UniformDistribution(0.0, 3.0),
+        }
+    )
+    study._append_trial(
+        value=2.0,
+        params={
+            'param_linear': 2.0,
+            'param_log': 1e-3,
+        },
+        distributions={
+            'param_linear': UniformDistribution(0.0, 3.0),
+            'param_log': LogUniformDistribution(1e-5, 1.),
+        }
+    )
+    assert visualization._is_log_scale(study.trials, 'param_log')
+    assert not visualization._is_log_scale(study.trials, 'param_linear')
 
 
 def _is_plotly_available():


### PR DESCRIPTION
This PR changes the x-axis of a slice plot to log scale if a given parameter type is of `LogUniformDistribution`.

Slice plots generated by current master branch:
![before_slice_plot](https://user-images.githubusercontent.com/3255979/68003137-77bf1a80-fcaf-11e9-9ced-a7b8bedeb86d.png)

Slice plots generated by this branch:
![after_slice_plot](https://user-images.githubusercontent.com/3255979/68003232-d1274980-fcaf-11e9-9bd5-50bea106abbf.png)

Code:

```python
import optuna


def objective(trial):
    x = trial.suggest_loguniform('log_x', 1e-5, 1e-1)
    y = trial.suggest_uniform('linear_y', 0, 1)
    return x + y


study = optuna.create_study()
study.optimize(objective, n_trials=100, gc_after_trial=False)

optuna.visualization.plot_slice(study)
```