### PR TITLE
Improve handling of reported values.

### DIFF
--- a/optuna/trial.py
+++ b/optuna/trial.py
@@ -376,8 +376,7 @@ class Trial(BaseTrial):
         """
 
         try:
-            # We allow users to pass values which have float-like types (e.g., numpy.float32)
-            # for convenience.
+            # For convenience, we allow users to report a value that can be cast to `float`.
             value = float(value)
         except (TypeError, ValueError):
             message = 'The `value` argument is of type \'{}\' but supposed to be a float.'.format(

--- a/optuna/trial.py
+++ b/optuna/trial.py
@@ -379,7 +379,7 @@ class Trial(BaseTrial):
             # We allow users to pass values which have float-like types (e.g., numpy.float32)
             # for convenience.
             value = float(value)
-        except TypeError:
+        except (TypeError, ValueError):
             message = 'The `value` argument is of type \'{}\' but supposed to be a float.'.format(
                 type(value).__name__)
             raise TypeError(message)

--- a/optuna/trial.py
+++ b/optuna/trial.py
@@ -375,6 +375,15 @@ class Trial(BaseTrial):
                 Step of the trial (e.g., Epoch of neural network training).
         """
 
+        try:
+            # We allow users to pass values which have float-like types (e.g., numpy.float32)
+            # for convenience.
+            value = float(value)
+        except TypeError:
+            message = 'The `value` argument is of type \'{}\' but supposed to be a float.'.format(
+                type(value).__name__)
+            raise TypeError(message)
+
         self.storage.set_trial_value(self._trial_id, value)
         if step is not None:
             self.storage.set_trial_intermediate_value(self._trial_id, step, value)

--- a/tests/test_trial.py
+++ b/tests/test_trial.py
@@ -1,6 +1,7 @@
 import math
 from mock import Mock
 from mock import patch
+import numpy as np
 import pytest
 
 from optuna import distributions
@@ -399,3 +400,28 @@ def test_datetime_start(storage_init_func):
     study.optimize(objective, n_trials=1)
 
     assert study.trials[0].datetime_start == trial_datetime_start[0]
+
+
+def test_trial_report():
+    # type: () -> None
+
+    study = create_study()
+    trial = Trial(study, study._storage.create_new_trial(study.study_id))
+
+    # Report values that can be casted to `float` (OK).
+    trial.report(1.23)
+    trial.report(float('nan'))
+    trial.report('1.23')
+    trial.report('inf')
+    trial.report(1)
+    trial.report(np.array([1], dtype=np.float32)[0])
+
+    # Report values that cannot be casted to `float` (Error).
+    with pytest.raises(TypeError):
+        trial.report(None)
+
+    with pytest.raises(TypeError):
+        trial.report('foo')
+
+    with pytest.raises(TypeError):
+        trial.report([1, 2, 3])

--- a/tests/test_trial.py
+++ b/tests/test_trial.py
@@ -411,17 +411,17 @@ def test_trial_report():
     # Report values that can be cast to `float` (OK).
     trial.report(1.23)
     trial.report(float('nan'))
-    trial.report('1.23')
-    trial.report('inf')
+    trial.report('1.23')  # type: ignore
+    trial.report('inf')  # type: ignore
     trial.report(1)
     trial.report(np.array([1], dtype=np.float32)[0])
 
     # Report values that cannot be cast to `float` (Error).
     with pytest.raises(TypeError):
-        trial.report(None)
+        trial.report(None)  # type: ignore
 
     with pytest.raises(TypeError):
-        trial.report('foo')
+        trial.report('foo')  # type: ignore
 
     with pytest.raises(TypeError):
-        trial.report([1, 2, 3])
+        trial.report([1, 2, 3])  # type: ignore

--- a/tests/test_trial.py
+++ b/tests/test_trial.py
@@ -408,7 +408,7 @@ def test_trial_report():
     study = create_study()
     trial = Trial(study, study._storage.create_new_trial(study.study_id))
 
-    # Report values that can be casted to `float` (OK).
+    # Report values that can be cast to `float` (OK).
     trial.report(1.23)
     trial.report(float('nan'))
     trial.report('1.23')
@@ -416,7 +416,7 @@ def test_trial_report():
     trial.report(1)
     trial.report(np.array([1], dtype=np.float32)[0])
 
-    # Report values that cannot be casted to `float` (Error).
+    # Report values that cannot be cast to `float` (Error).
     with pytest.raises(TypeError):
         trial.report(None)
 


### PR DESCRIPTION
This PR includes the following changes for `Trial.report` method:
- Convert reported values to `float` type by using `float` function:
  - Although the type hint of `value` argument is just `float`, this conversion is probably desirable for some users (#642, #655), and
   - This behavior is consistent with the handling of objective values in `Study` ([study.py#L549](https://github.com/pfnet/optuna/blob/master/optuna/study.py#L549))
- Raise an error if the above conversion cannot be applied:
  - This change will make it easier for users to identify the cause of problems with malformed reporting values (#471, #481)
