### PR TITLE
Add a border to each data point in a slice plot.

### DIFF
--- a/optuna/visualization.py
+++ b/optuna/visualization.py
@@ -539,6 +539,10 @@ def _generate_slice_subplot(study, trials, param):
         y=[t.value for t in trials if param in t.params],
         mode='markers',
         marker={
+            'line': {
+                'width': 0.5,
+                'color': 'Grey',
+            },
             'color': [t.number for t in trials if param in t.params],
             'colorscale': 'Blues',
             'colorbar': {'title': '#Trials'}


### PR DESCRIPTION
This PR solves https://github.com/pfnet/optuna/issues/609.
Currently, some points are hard to distinguish from the background due to the low contrast.

![without-line](https://user-images.githubusercontent.com/3255979/68008725-36386a80-fcc3-11e9-8ee4-be3ea20a8176.png)

This PR adds a thin gray line to each data point to improve the visibility.

![with-line](https://user-images.githubusercontent.com/3255979/68008736-3e90a580-fcc3-11e9-8f86-1400298380db.png)

@suecharo 
I appreciate your cool design of slice plots, but I'd like to modify it to make it easier to see.
Please let me know if you have any ideas or concerns about this change.