### PR TITLE
Fix colorbar of contour plots.

### DIFF
--- a/optuna/visualization.py
+++ b/optuna/visualization.py
@@ -19,6 +19,7 @@ if type_checking.TYPE_CHECKING:
     from optuna.structs import FrozenTrial  # NOQA
 
 try:
+    import plotly
     import plotly.graph_objs as go
     from plotly.graph_objs._figure import Figure  # NOQA
     from plotly.subplots import make_subplots
@@ -322,15 +323,22 @@ def _generate_contour_subplot(trials, x_param, y_param, direction):
                 'Trial{} has COMPLETE state, but its value is non-numeric.'.format(trial.number))
         z[y_i][x_i] = value
 
+    # TODO(Yanase): Use reversescale argument to reverse colorscale if Plotly's bug is fixed.
+    # If contours_coloring='heatmap' is specified, reversesecale argument of go.Contour does not
+    # work correctly. See https://github.com/pfnet/optuna/issues/606.
+    colorscale = plotly.colors.PLOTLY_SCALES['Blues']
+    if direction == StudyDirection.MINIMIZE:
+        colorscale = [[1 - t[0], t[1]] for t in colorscale]
+        colorscale.reverse()
+
     contour = go.Contour(
         x=x_indices, y=y_indices, z=z,
         colorbar={'title': 'Objective Value'},
-        colorscale='blues',
+        colorscale=colorscale,
         connectgaps=True,
         contours_coloring='heatmap',
         hoverinfo='none',
         line_smoothing=1.3,
-        reversescale=True if direction == StudyDirection.MINIMIZE else False
     )
 
     scatter = go.Scatter(


### PR DESCRIPTION
This PR fixes https://github.com/pfnet/optuna/issues/606.
The cause of the issue seems to be a bug of `go.Contour` because it only happens if both `contours_coloring='heatmap'` and `reversescale=True` are specified simultaneously.

In this PR, I stopped using `reversesecale` and sorted the color scale manually as a tentative fix.

A plot of a minimization task (the brighter the better):
![minimize-fix-colorbar2](https://user-images.githubusercontent.com/3255979/68018023-6f7cd480-fcdb-11e9-8f34-fd8e1d183664.png)

Code of the minimization task:
```python
import optuna

def objective(trial):
    x = trial.suggest_uniform('x', -10, 10)
    y = trial.suggest_uniform('y', -10, 10)
    return (x - 2) ** 2 + (y + 5) ** 2

study = optuna.create_study(direction='minimize', sampler=optuna.samplers.RandomSampler())
study.optimize(objective, n_trials=100, gc_after_trial=False)
optuna.visualization.plot_contour(study)
```

A plot of a maximization task (the brighter the better):
![maximize-fix-colorbar2](https://user-images.githubusercontent.com/3255979/68018100-a18e3680-fcdb-11e9-901f-7697a31a6c5c.png)

Code of the maximization task:
```python
import optuna

def objective(trial):
    x = trial.suggest_uniform('x', -10, 10)
    y = trial.suggest_uniform('y', -10, 10)
    return - ((x - 2) ** 2 + (y + 5) ** 2)

study = optuna.create_study(direction='maximize', sampler=optuna.samplers.RandomSampler())
study.optimize(objective, n_trials=100, gc_after_trial=False)

optuna.visualization.plot_contour(study)
```
 