### PR TITLE
Use a log-scale axis in contour plots if a parameter type is LogUniformDistribution.

### DIFF
--- a/optuna/visualization.py
+++ b/optuna/visualization.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+import math
 
 from optuna.distributions import LogUniformDistribution
 from optuna.logging import get_logger
@@ -263,6 +264,12 @@ def _get_contour_plot(study, params=None):
         figure = go.Figure(data=sub_plots)
         figure.update_xaxes(title_text=x_param, range=param_values_range[x_param])
         figure.update_yaxes(title_text=y_param, range=param_values_range[y_param])
+        if _is_log_scale(trials, x_param):
+            log_range = [math.log10(p) for p in param_values_range[x_param]]
+            figure.update_xaxes(range=log_range, type='log')
+        if _is_log_scale(trials, y_param):
+            log_range = [math.log10(p) for p in param_values_range[y_param]]
+            figure.update_yaxes(range=log_range, type='log')
     else:
         figure = make_subplots(rows=len(sorted_params),
                                cols=len(sorted_params), shared_xaxes=True, shared_yaxes=True)
@@ -285,6 +292,12 @@ def _get_contour_plot(study, params=None):
                                     row=y_i + 1, col=x_i + 1)
                 figure.update_yaxes(range=param_values_range[y_param],
                                     row=y_i + 1, col=x_i + 1)
+                if _is_log_scale(trials, x_param):
+                    log_range = [math.log10(p) for p in param_values_range[x_param]]
+                    figure.update_xaxes(range=log_range, type='log', row=y_i + 1, col=x_i + 1)
+                if _is_log_scale(trials, y_param):
+                    log_range = [math.log10(p) for p in param_values_range[y_param]]
+                    figure.update_yaxes(range=log_range, type='log', row=y_i + 1, col=x_i + 1)
                 if x_i == 0:
                     figure.update_yaxes(title_text=y_param, row=y_i + 1, col=x_i + 1)
                 if y_i == len(sorted_params) - 1:

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -171,6 +171,99 @@ def test_get_contour_plot():
     assert len(figure.data) == 0
 
 
+def test_get_contour_plot_log_scale():
+    # type: () -> None
+
+    # If the search space has two parameters, _get_contour_plot generates a single plot.
+    study = create_study()
+    study._append_trial(
+        value=0.0,
+        params={
+            'param_a': 1e-6,
+            'param_b': 1e-4,
+        },
+        distributions={
+            'param_a': LogUniformDistribution(1e-7, 1e-2),
+            'param_b': LogUniformDistribution(1e-5, 1e-1),
+        }
+    )
+    study._append_trial(
+        value=1.0,
+        params={
+            'param_a': 1e-5,
+            'param_b': 1e-3,
+        },
+        distributions={
+            'param_a': LogUniformDistribution(1e-7, 1e-2),
+            'param_b': LogUniformDistribution(1e-5, 1e-1),
+        }
+    )
+
+    figure = _get_contour_plot(study)
+    assert figure.layout['xaxis']['range'] == (-6, -5)
+    assert figure.layout['yaxis']['range'] == (-4, -3)
+    assert figure.layout['xaxis_type'] == 'log'
+    assert figure.layout['yaxis_type'] == 'log'
+
+    # If the search space has three parameters, _get_contour_plot generates nine plots.
+    study = create_study()
+    study._append_trial(
+        value=0.0,
+        params={
+            'param_a': 1e-6,
+            'param_b': 1e-4,
+            'param_c': 1e-2,
+        },
+        distributions={
+            'param_a': LogUniformDistribution(1e-7, 1e-2),
+            'param_b': LogUniformDistribution(1e-5, 1e-1),
+            'param_c': LogUniformDistribution(1e-3, 10),
+        }
+    )
+    study._append_trial(
+        value=1.0,
+        params={
+            'param_a': 1e-5,
+            'param_b': 1e-3,
+            'param_c': 1e-1,
+        },
+        distributions={
+            'param_a': LogUniformDistribution(1e-7, 1e-2),
+            'param_b': LogUniformDistribution(1e-5, 1e-1),
+            'param_c': LogUniformDistribution(1e-3, 10),
+        }
+    )
+
+    figure = _get_contour_plot(study)
+    param_a_range = (-6, -5)
+    param_b_range = (-4, -3)
+    param_c_range = (-2, -1)
+    axis_to_range = {
+        'xaxis': param_a_range,
+        'xaxis2': param_b_range,
+        'xaxis3': param_c_range,
+        'xaxis4': param_a_range,
+        'xaxis5': param_b_range,
+        'xaxis6': param_c_range,
+        'xaxis7': param_a_range,
+        'xaxis8': param_b_range,
+        'xaxis9': param_c_range,
+        'yaxis': param_a_range,
+        'yaxis2': param_a_range,
+        'yaxis3': param_a_range,
+        'yaxis4': param_b_range,
+        'yaxis5': param_b_range,
+        'yaxis6': param_b_range,
+        'yaxis7': param_c_range,
+        'yaxis8': param_c_range,
+        'yaxis9': param_c_range,
+    }
+
+    for axis, param_range in axis_to_range.items():
+        assert figure.layout[axis]['range'] == param_range
+        assert figure.layout[axis]['type'] == 'log'
+
+
 def test_get_parallel_coordinate_plot():
     # type: () -> None
 


### PR DESCRIPTION
This PR changes the axes of a contour plot if the types of parameters are `LogUniformDistribution`.

An example:
- `x`: `UniformDistribution`
- `y`: `LogUniformDistribution`
- `z`: `LogUniformDistribution`

Plots generated by the current master branch:
![newplot (42)](https://user-images.githubusercontent.com/3255979/68284610-29e84f00-00c1-11ea-8dd4-1546b8533138.png)


Plots generated by this branch:
![newplot (41)](https://user-images.githubusercontent.com/3255979/68284423-d8d85b00-00c0-11ea-8904-900d9bf65ed5.png)

Code:
```python
import optuna

def objective(trial):
    x = trial.suggest_uniform('x', -10, 10)
    y = trial.suggest_loguniform('y', 1e-7, 1e-2)
    z = trial.suggest_loguniform('z', 1e-5, 1)
    return x**2 + 10**y + 10**z

study = optuna.create_study(direction='maximize', sampler=optuna.samplers.RandomSampler())
study.optimize(objective, n_trials=100, gc_after_trial=False)

optuna.visualization.plot_contour(study)
```