### PR TITLE
[WIP] Add `test-tube` package to test and example requirements.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,23 +58,13 @@ def get_extras_require():
         'bokeh', 'chainer>=5.0.0', 'cma', 'keras', 'lightgbm', 'mock',
         'mpi4py', 'mxnet', 'pandas', 'plotly>=4.0.0', 'pytest', 'scikit-optimize',
         'tensorflow', 'tensorflow-datasets', 'xgboost', 'scikit-learn>=0.19.0',
-        'torch', 'torchvision', 'pytorch-ignite',
-
-        # TODO(ohta):
-        # Remove this version constraint once
-        # https://github.com/williamFalcon/pytorch-lightning/issues/469 is resolved.
-        'pytorch_lightning<0.5.3',
+        'torch', 'torchvision', 'pytorch-ignite', 'pytorch_lightning', 'test-tube',
     ]
 
     example_requirements = [
         'chainer', 'keras', 'catboost', 'lightgbm', 'scikit-learn',
         'mxnet', 'xgboost', 'torch', 'torchvision', 'pytorch-ignite',
-        'dask-ml', 'dask[dataframe]',
-
-        # TODO(ohta):
-        # Remove this version constraint once
-        # https://github.com/williamFalcon/pytorch-lightning/issues/469 is resolved.
-        'pytorch-lightning<0.5.3',
+        'dask-ml', 'dask[dataframe]', 'pytorch_lightning', 'test-tube',
 
         # TODO(Yanase): Update examples to support TensorFlow 2.0.
         # See https://github.com/pfnet/optuna/issues/565 for further details.


### PR DESCRIPTION
Since v0.5.3, `pytorch_lightning` requires `test-tube` to import the package (see also https://github.com/pfnet/optuna/pull/672).