### PR TITLE
Fix `import optuna` failure on Python2.7 environment without LightGBM installed.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,8 +108,12 @@ jobs:
             pip install -U pip
             pip install --progress-bar off -U setuptools
             python setup.py sdist
+
+            # Install minimal dependencies and confirm that `import optuna` is successful.
             pip install --progress-bar off $(ls dist/*.tar.gz)
             python -c 'import optuna'
+
+            # Install all dependencies needed for testing.
             pip install --progress-bar off $(ls dist/*.tar.gz)[testing]
 
       - run: &tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,6 +108,8 @@ jobs:
             pip install -U pip
             pip install --progress-bar off -U setuptools
             python setup.py sdist
+            pip install --progress-bar off $(ls dist/*.tar.gz)
+            python -c 'import optuna'
             pip install --progress-bar off $(ls dist/*.tar.gz)[testing]
 
       - run: &tests

--- a/optuna/integration/lightgbm.py
+++ b/optuna/integration/lightgbm.py
@@ -31,6 +31,8 @@ if _available:
 
     for api_name in names_from_tuners:
         setattr(sys.modules[__name__], api_name, tuner.__dict__[api_name])
+else:
+    LightGBMTuner = object  # type: ignore
 
 
 class LightGBMPruningCallback(object):


### PR DESCRIPTION
This PR fixes a failure of `import optuna` on Python2.7 environment without LightGBM installed (see below for the details of the failure).

```console
$ docker run --rm -it python:2.7 /bin/bash

// Install optuna.
root@16d5c79b9009:/# pip install optuna
root@16d5c79b9009:/# optuna --version
optuna 0.18.0

// Import optuna (failed).
root@16d5c79b9009:/# python -c 'import optuna'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/usr/local/lib/python2.7/site-packages/optuna/__init__.py", line 3, in <module>
    from optuna import integration  # NOQA
  File "/usr/local/lib/python2.7/site-packages/optuna/integration/__init__.py", line 37, in <module>
    from optuna.integration.lightgbm import LightGBMTuner  # NOQA
ImportError: cannot import name LightGBMTuner

// Install lightgbm then import optuna (succeeded).
root@16d5c79b9009:/# pip install lightgbm
root@16d5c79b9009:/# python -c 'import optuna'
```

In addition, this PR adds an import check to CI so that similar problems can be detected early in the future.

