### PR TITLE
Change subsample's low value from 0 to 0.1 in the catboost example.

### DIFF
--- a/examples/catboost_simple.py
+++ b/examples/catboost_simple.py
@@ -44,7 +44,7 @@ def objective(trial):
     if param['bootstrap_type'] == 'Bayesian':
         param['bagging_temperature'] = trial.suggest_uniform('bagging_temperature', 0, 10)
     elif param['bootstrap_type'] == 'Bernoulli':
-        param['subsample'] = trial.suggest_uniform('subsample', 0, 1)
+        param['subsample'] = trial.suggest_uniform('subsample', 0.1, 1)
 
     gbm = cb.CatBoostClassifier(**param)
 


### PR DESCRIPTION
The catboost example sometimes fails due to the lack of training samples when it uses subsampling (see https://circleci.com/gh/pfnet/optuna/21659). The actual error message is as follows:

```console
_catboost.CatBoostError: catboost/private/libs/algo/tensor_search_helpers.cpp:441: Too few sampling units (subsample=0.00524573, bootstrap_type=Bernoulli): please increase sampling rate or disable sampling
Exited with code 1
```

Currently, the minimum size of subsamples is `0` since the `low` value is `0`. This PR updates it to `0.1`.  I think it is reasonable because the range of the search space in [catboost official benchmark](https://github.com/catboost/catboost/blob/9b28fb0aa046563040157eca23041992f7fcf16a/catboost/benchmarks/training_speed/example_params_grid.json#L4) is `[0.25, 1]`. It is a bit lower but the same order of magnitude.