### PR TITLE
Add punctuation to copyright in docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -25,8 +25,8 @@ on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 # -- Project information -----------------------------------------------------
 
 project = 'Optuna'
-copyright = '2018, Optuna Contributors'
-author = 'Optuna Contributors'
+copyright = '2018, Optuna Contributors.'
+author = 'Optuna Contributors.'
 
 # The short X.Y version
 version = __version__
@@ -135,7 +135,7 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, 'Optuna.tex', 'Optuna Documentation', 'Optuna Contributors', 'manual'),
+    (master_doc, 'Optuna.tex', 'Optuna Documentation', 'Optuna Contributors.', 'manual'),
 ]
 
 # -- Options for manual page output ------------------------------------------


### PR DESCRIPTION
Minor followup of https://github.com/pfnet/optuna/pull/676.

It seems like sphinx uses some sort of template/format for printing the copyright but I couldn't figure out how it should be configured. The update timestamp (`html_last_updated_fmt`) however when tried locally automatically appended a punctuation.