### PR TITLE
Add a note about type casting of reported values to `trial.report()` doc.

### DIFF
--- a/optuna/trial.py
+++ b/optuna/trial.py
@@ -353,7 +353,7 @@ class Trial(BaseTrial):
 
         Note that the reported value is converted to ``float`` type by applying ``float()``
         function internally. Thus, it accepts all float-like types (e.g., ``numpy.float32``).
-        If the conversion is failed, a ``TypeError`` is raised.
+        If the conversion fails, a ``TypeError`` is raised.
 
         Example:
 

--- a/optuna/trial.py
+++ b/optuna/trial.py
@@ -353,7 +353,7 @@ class Trial(BaseTrial):
 
         Note that the reported value is converted to ``float`` type by applying ``float()``
         function internally. Thus, it accepts all float-like types (e.g., ``numpy.float32``).
-        If the conversion is failed, a ``TypeError`` exception is raised.
+        If the conversion is failed, a ``TypeError`` is raised.
 
         Example:
 

--- a/optuna/trial.py
+++ b/optuna/trial.py
@@ -351,6 +351,10 @@ class Trial(BaseTrial):
         If step is set to :obj:`None`, the value is stored as a final value of the trial.
         Otherwise, it is saved as an intermediate value.
 
+        Note that the reported value is converted to ``float`` type by applying ``float()``
+        function internally. Thus, it accepts all float-like types (e.g., ``numpy.float32``).
+        If the conversion is failed, a ``TypeError`` exception is raised.
+
         Example:
 
             Report intermediate scores of `SGDClassifier <https://scikit-learn.org/stable/modules/


### PR DESCRIPTION
This PRs update the doc of `trial.report()` method to clarify it's behavior.
