### PR TITLE
Expose `RDBStorage` constructor.

### DIFF
--- a/docs/source/reference/index.rst
+++ b/docs/source/reference/index.rst
@@ -11,6 +11,7 @@ API Reference
     logging
     pruners
     samplers
+    storages
     structs
     study
     trial

--- a/docs/source/reference/storages.rst
+++ b/docs/source/reference/storages.rst
@@ -1,0 +1,6 @@
+.. module:: optuna.storages
+
+Storages
+========
+
+.. autoclass:: RDBStorage

--- a/optuna/storages/rdb/storage.py
+++ b/optuna/storages/rdb/storage.py
@@ -42,7 +42,7 @@ class RDBStorage(BaseStorage):
 
     Example:
 
-        We create a :class:`~optuna.storages.RDBStorage` instance with
+        We create an :class:`~optuna.storages.RDBStorage` instance with
         customized ``pool_size`` and ``max_overflow`` settings.
 
         .. code::

--- a/optuna/storages/rdb/storage.py
+++ b/optuna/storages/rdb/storage.py
@@ -37,7 +37,7 @@ if type_checking.TYPE_CHECKING:
 class RDBStorage(BaseStorage):
     """Storage class for RDB backend.
 
-    Note that library users can instantiate this class, but the fields and methods
+    Note that library users can instantiate this class, but the attributes
     provided by this class are not supposed to be directly accessed by them.
 
     Args:

--- a/optuna/storages/rdb/storage.py
+++ b/optuna/storages/rdb/storage.py
@@ -40,6 +40,29 @@ class RDBStorage(BaseStorage):
     Note that library users can instantiate this class, but the attributes
     provided by this class are not supposed to be directly accessed by them.
 
+    Example:
+
+        We create a :class:`~optuna.storages.RDBStorage` instance with
+        customized ``pool_size`` and ``max_overflow`` settings.
+
+        .. code::
+
+            >>> import optuna
+            >>>
+            >>> def objective(trial):
+            >>>     ...
+            >>>
+            >>> storage = optuna.storages.RDBStorage(
+            >>>     url='postgresql://foo@localhost/db',
+            >>>     engine_kwargs={
+            >>>         'pool_size': 20,
+            >>>         'max_overflow': 0
+            >>>     }
+            >>> )
+            >>>
+            >>> study = optuna.create_study(storage=storage)
+            >>> study.optimize(objective)
+
     Args:
         url: URL of the storage.
         engine_kwargs:

--- a/optuna/storages/rdb/storage.py
+++ b/optuna/storages/rdb/storage.py
@@ -37,18 +37,21 @@ if type_checking.TYPE_CHECKING:
 class RDBStorage(BaseStorage):
     """Storage class for RDB backend.
 
-    This class is not supposed to be directly accessed by library users.
+    Note that library users can instantiate this class, but the fields and methods
+    provided by this class are not supposed to be directly accessed by them.
 
     Args:
         url: URL of the storage.
         engine_kwargs:
             A dictionary of keyword arguments that is passed to
-            :func:`sqlalchemy.engine.create_engine`.
+            `sqlalchemy.engine.create_engine`_ function.
         enable_cache:
             Flag to control whether to enable storage layer caching.
             If this flag is set to :obj:`True` (the default), the finished trials are
             cached on memory and never re-fetched from the storage.
             Otherwise, the trials are fetched from the storage whenever they are needed.
+
+    .. _sqlalchemy.engine.create_engine: https://docs.sqlalchemy.org/en/latest/core/engines.html#sqlalchemy.create_engine
 
     """
 

--- a/optuna/storages/rdb/storage.py
+++ b/optuna/storages/rdb/storage.py
@@ -51,7 +51,8 @@ class RDBStorage(BaseStorage):
             cached on memory and never re-fetched from the storage.
             Otherwise, the trials are fetched from the storage whenever they are needed.
 
-    .. _sqlalchemy.engine.create_engine: https://docs.sqlalchemy.org/en/latest/core/engines.html#sqlalchemy.create_engine
+    .. _sqlalchemy.engine.create_engine:
+        https://docs.sqlalchemy.org/en/latest/core/engines.html#sqlalchemy.create_engine
 
     """
 

--- a/optuna/study.py
+++ b/optuna/study.py
@@ -596,6 +596,18 @@ def create_study(
         storage:
             Database URL. If this argument is set to None, in-memory storage is used, and the
             :class:`~optuna.study.Study` will not be persistent.
+
+            .. note::
+                When database URL is passed, Optuna internally uses `SQLAlchemy`_ to handle
+                databases. Please refer to `SQLAlchemy's document`_ for further details.
+                If you want to customize the options of `SQLAlchemy Engine`_, you can instantiate
+                :class:`~optuna.storages.RDBStorage` with your favorite options and pass it to
+                ``storage`` argument instead of URL.
+
+             .. _SQLAlchemy: https://www.sqlalchemy.org/
+             .. SQLAlchemy's document: https://docs.sqlalchemy.org/en/latest/core/engines.html#database-urls
+             .. _SQLAlchemy Engine: https://docs.sqlalchemy.org/en/latest/core/engines.html
+
         sampler:
             A sampler object that implements background algorithm for value suggestion.
             If :obj:`None` is specified, :class:`~optuna.samplers.TPESampler` is used
@@ -667,10 +679,8 @@ def load_study(
         study_name:
             Study's name. Each study has a unique name as an identifier.
         storage:
-            Database URL such as ``sqlite:///example.db``. Optuna internally uses `SQLAlchemy
-            <https://www.sqlalchemy.org/>`_ to handle databases. Please refer to `SQLAlchemy's
-            document <https://docs.sqlalchemy.org/en/latest/core/engines.html#database-urls>`_ for
-            further details.
+            Database URL such as ``sqlite:///example.db``. Please see also the documentation of
+            :func:`~optuna.study.create_study` for futhre details.
         sampler:
             A sampler object that implements background algorithm for value suggestion.
             If :obj:`None` is specified, :class:`~optuna.samplers.TPESampler` is used
@@ -696,10 +706,8 @@ def delete_study(
         study_name:
             Study's name.
         storage:
-            Database URL such as ``sqlite:///example.db``. Optuna internally uses `SQLAlchemy
-            <https://www.sqlalchemy.org/>`_ to handle databases. Please refer to `SQLAlchemy's
-            document <https://docs.sqlalchemy.org/en/latest/core/engines.html#database-urls>`_ for
-            further details.
+            Database URL such as ``sqlite:///example.db``. Please see also the documentation of
+            :func:`~optuna.study.create_study` for futhre details.
 
     """
 
@@ -714,7 +722,8 @@ def get_all_study_summaries(storage):
 
     Args:
         storage:
-            Database URL.
+            Database URL such as ``sqlite:///example.db``. Please see also the documentation of
+            :func:`~optuna.study.create_study` for futhre details.
 
     Returns:
         List of study history summarized as :class:`~optuna.structs.StudySummary` objects.

--- a/optuna/study.py
+++ b/optuna/study.py
@@ -605,7 +605,8 @@ def create_study(
                 ``storage`` argument instead of URL.
 
              .. _SQLAlchemy: https://www.sqlalchemy.org/
-             .. SQLAlchemy's document: https://docs.sqlalchemy.org/en/latest/core/engines.html#database-urls
+             .. SQLAlchemy's document:
+                 https://docs.sqlalchemy.org/en/latest/core/engines.html#database-urls
              .. _SQLAlchemy Engine: https://docs.sqlalchemy.org/en/latest/core/engines.html
 
         sampler:

--- a/optuna/study.py
+++ b/optuna/study.py
@@ -605,7 +605,7 @@ def create_study(
                 ``storage`` argument instead of URL.
 
              .. _SQLAlchemy: https://www.sqlalchemy.org/
-             .. SQLAlchemy's document:
+             .. _SQLAlchemy's document:
                  https://docs.sqlalchemy.org/en/latest/core/engines.html#database-urls
              .. _SQLAlchemy Engine: https://docs.sqlalchemy.org/en/latest/core/engines.html
 

--- a/optuna/study.py
+++ b/optuna/study.py
@@ -708,7 +708,7 @@ def delete_study(
             Study's name.
         storage:
             Database URL such as ``sqlite:///example.db``. Please see also the documentation of
-            :func:`~optuna.study.create_study` for futhre details.
+            :func:`~optuna.study.create_study` for further details.
 
     """
 

--- a/optuna/study.py
+++ b/optuna/study.py
@@ -600,9 +600,9 @@ def create_study(
             .. note::
                 When a database URL is passed, Optuna internally uses `SQLAlchemy`_ to handle
                 the database. Please refer to `SQLAlchemy's document`_ for further details.
-                If you want to customize the options of `SQLAlchemy Engine`_, you can instantiate
-                :class:`~optuna.storages.RDBStorage` with your favorite options and pass it to
-                ``storage`` argument instead of URL.
+                If you want to specify non-default options to `SQLAlchemy Engine`_, you can
+                instantiate :class:`~optuna.storages.RDBStorage` with your desired options and
+                pass it to ``storage`` argument instead of URL.
 
              .. _SQLAlchemy: https://www.sqlalchemy.org/
              .. _SQLAlchemy's document:

--- a/optuna/study.py
+++ b/optuna/study.py
@@ -598,8 +598,8 @@ def create_study(
             :class:`~optuna.study.Study` will not be persistent.
 
             .. note::
-                When database URL is passed, Optuna internally uses `SQLAlchemy`_ to handle
-                databases. Please refer to `SQLAlchemy's document`_ for further details.
+                When a database URL is passed, Optuna internally uses `SQLAlchemy`_ to handle
+                the database. Please refer to `SQLAlchemy's document`_ for further details.
                 If you want to customize the options of `SQLAlchemy Engine`_, you can instantiate
                 :class:`~optuna.storages.RDBStorage` with your favorite options and pass it to
                 ``storage`` argument instead of URL.

--- a/optuna/study.py
+++ b/optuna/study.py
@@ -681,7 +681,7 @@ def load_study(
             Study's name. Each study has a unique name as an identifier.
         storage:
             Database URL such as ``sqlite:///example.db``. Please see also the documentation of
-            :func:`~optuna.study.create_study` for futhre details.
+            :func:`~optuna.study.create_study` for further details.
         sampler:
             A sampler object that implements background algorithm for value suggestion.
             If :obj:`None` is specified, :class:`~optuna.samplers.TPESampler` is used

--- a/optuna/study.py
+++ b/optuna/study.py
@@ -724,7 +724,7 @@ def get_all_study_summaries(storage):
     Args:
         storage:
             Database URL such as ``sqlite:///example.db``. Please see also the documentation of
-            :func:`~optuna.study.create_study` for futhre details.
+            :func:`~optuna.study.create_study` for further details.
 
     Returns:
         List of study history summarized as :class:`~optuna.structs.StudySummary` objects.

--- a/optuna/study.py
+++ b/optuna/study.py
@@ -602,7 +602,7 @@ def create_study(
                 the database. Please refer to `SQLAlchemy's document`_ for further details.
                 If you want to specify non-default options to `SQLAlchemy Engine`_, you can
                 instantiate :class:`~optuna.storages.RDBStorage` with your desired options and
-                pass it to ``storage`` argument instead of URL.
+                pass it to the ``storage`` argument instead of a URL.
 
              .. _SQLAlchemy: https://www.sqlalchemy.org/
              .. _SQLAlchemy's document:


### PR DESCRIPTION
This PR exposes the documentation of `RDBStorage` constructor to allow users to directly instantiate it (c.f. #423).
Besides, this PR updates the documentation of `create_study`, `load_study`, `delete_study` and `get_all_study_summaries` as follows:
- `create_study`:
  - The detailed description (note) about `SQLAlchemy` and `RDBStorage` is added.
-  `load_study`, `delete_study`, `get_all_study_summaries`:
   - The descriptions of `storage` arguments are unified.
   - The detailed explanation is delegated to `create_study`.

## Generated doc

`RDBStorage`:

![image](https://user-images.githubusercontent.com/181413/68657264-b938ab00-0576-11ea-88e7-57ba28ffdf70.png)

`create_study`:

![image](https://user-images.githubusercontent.com/181413/68657789-ad99b400-0577-11ea-8456-83931131665c.png)

`load_study`:

![image](https://user-images.githubusercontent.com/181413/68657407-ff8e0a00-0576-11ea-87fe-af354b6bd585.png)
