### PR TITLE
Improve documentation of `Trial.should_prune`

### DIFF
--- a/optuna/trial.py
+++ b/optuna/trial.py
@@ -394,19 +394,28 @@ class Trial(BaseTrial):
 
     def should_prune(self, step=None):
         # type: (Optional[int]) -> bool
-        """Judge whether the trial should be pruned.
+        """Suggest whether the trial should be pruned or not.
 
-        This method calls prune method of the pruner, which judges whether the trial should
-        be pruned at the given step. Please refer to the example code of
-        :func:`optuna.trial.Trial.report`.
+        The suggestion is made by a pruning algorithm associated with the trial and is based on
+        previously reported values. The algorithm can be specified when constructing a
+        :class:`~optuna.study.Study`.
+
+        .. note::
+            If no values have been reported, the algorithm cannot make meaningful suggestions.
+            Similarly, if this method is called multiple times with the exact same set of reported
+            values, the suggestions will be the same.
+
+        .. seealso::
+            Please refer to the example code in :func:`optuna.trial.Trial.report`.
 
         Args:
             step:
-                Deprecated: Step of the trial (e.g., epoch of neural network training).
+                Deprecated since 0.12.0: Step of the trial (e.g., epoch of neural network
+                training). Deprecated in favor of always considering the most recent step.
 
         Returns:
-            A boolean value. If :obj:`True`, the trial should be pruned. Otherwise, the trial will
-            be continued.
+            A boolean value. If :obj:`True`, the trial should be pruned according to the
+            configured pruning algorithm. Otherwise, the trial should continued.
         """
         if step is not None:
             warnings.warn(

--- a/optuna/trial.py
+++ b/optuna/trial.py
@@ -415,7 +415,7 @@ class Trial(BaseTrial):
 
         Returns:
             A boolean value. If :obj:`True`, the trial should be pruned according to the
-            configured pruning algorithm. Otherwise, the trial should continued.
+            configured pruning algorithm. Otherwise, the trial should continue.
         """
         if step is not None:
             warnings.warn(


### PR DESCRIPTION
The documentation of `Trial.should_prune` was not precisely consistent after the deprecation of the `step` argument and could use some clarifications as well regarding how the pruning suggestion is made, i.e. that it depends on previously reported values. This PR addresses these points.

It was brought to discussion in this PR/comment https://github.com/pfnet/optuna/pull/660#discussion_r345104564.