### PR TITLE
Validate arguments to `PercentilePruner`

### DIFF
--- a/optuna/pruners/percentile.py
+++ b/optuna/pruners/percentile.py
@@ -86,11 +86,24 @@ class PercentilePruner(BasePruner):
         interval_steps:
             Interval in number of steps between the pruning checks, offset by the warmup steps.
             If no value has been reported at the time of a pruning check, that particular check
-            will be postponed until a value is reported.
+            will be postponed until a value is reported. Value must be at least 1.
     """
 
     def __init__(self, percentile, n_startup_trials=5, n_warmup_steps=0, interval_steps=1):
         # type: (float, int, int, int) -> None
+
+        if not 0.0 <= percentile <= 100:
+            raise ValueError(
+                'Percentile must be between 0 and 100 inclusive but got {}.'.format(percentile))
+        if n_startup_trials < 0:
+            raise ValueError(
+                'Number of startup trials cannot be negative but got {}.'.format(n_startup_trials))
+        if n_warmup_steps < 0:
+            raise ValueError(
+                'Number of warmup steps cannot be negative but got {}.'.format(n_warmup_steps))
+        if interval_steps < 1:
+            raise ValueError(
+                'Pruning interval steps must be at least 1 but got {}.'.format(n_warmup_steps))
 
         self.percentile = percentile
         self.n_startup_trials = n_startup_trials

--- a/optuna/pruners/percentile.py
+++ b/optuna/pruners/percentile.py
@@ -103,7 +103,7 @@ class PercentilePruner(BasePruner):
                 'Number of warmup steps cannot be negative but got {}.'.format(n_warmup_steps))
         if interval_steps < 1:
             raise ValueError(
-                'Pruning interval steps must be at least 1 but got {}.'.format(n_warmup_steps))
+                'Pruning interval steps must be at least 1 but got {}.'.format(interval_steps))
 
         self.percentile = percentile
         self.n_startup_trials = n_startup_trials

--- a/tests/pruners_tests/test_percentile.py
+++ b/tests/pruners_tests/test_percentile.py
@@ -14,6 +14,53 @@ if type_checking.TYPE_CHECKING:
     from optuna.study import Study  # NOQA
 
 
+def test_percentile_pruner_percentile():
+    # type: () -> None
+
+    optuna.pruners.PercentilePruner(0.0)
+    optuna.pruners.PercentilePruner(25.0)
+    optuna.pruners.PercentilePruner(100.0)
+
+    with pytest.raises(ValueError):
+        optuna.pruners.PercentilePruner(-0.1)
+
+    with pytest.raises(ValueError):
+        optuna.pruners.PercentilePruner(100.1)
+
+
+def test_percentile_pruner_n_startup_trials():
+    # type: () -> None
+
+    optuna.pruners.PercentilePruner(25.0, n_startup_trials=0)
+    optuna.pruners.PercentilePruner(25.0, n_startup_trials=5)
+
+    with pytest.raises(ValueError):
+        optuna.pruners.PercentilePruner(25.0, n_startup_trials=-1)
+
+
+def test_percentile_pruner_n_warmup_steps():
+    # type: () -> None
+
+    optuna.pruners.PercentilePruner(25.0, n_warmup_steps=0)
+    optuna.pruners.PercentilePruner(25.0, n_warmup_steps=5)
+
+    with pytest.raises(ValueError):
+        optuna.pruners.PercentilePruner(25.0, n_warmup_steps=-1)
+
+
+def test_percentile_pruner_interval_steps():
+    # type: () -> None
+
+    optuna.pruners.PercentilePruner(25.0, interval_steps=1)
+    optuna.pruners.PercentilePruner(25.0, interval_steps=5)
+
+    with pytest.raises(ValueError):
+        optuna.pruners.PercentilePruner(25.0, interval_steps=-1)
+
+    with pytest.raises(ValueError):
+        optuna.pruners.PercentilePruner(25.0, interval_steps=0)
+
+
 def test_percentile_pruner_with_one_trial():
     # type: () -> None
 


### PR DESCRIPTION
Catches and raises early errors (e.g. preventing division by 0 with `interval_steps`) in case user provides erroneous arguments to the `PercentilePruner`. 

I did not document the rather trivial arguments as it looked quite verbose.