### PR TITLE
Remove the version constraint for `pytorch_lightning`.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,23 +58,13 @@ def get_extras_require():
         'bokeh', 'chainer>=5.0.0', 'cma', 'keras', 'lightgbm', 'mock',
         'mpi4py', 'mxnet', 'pandas', 'plotly>=4.0.0', 'pytest', 'scikit-optimize',
         'tensorflow', 'tensorflow-datasets', 'xgboost', 'scikit-learn>=0.19.0',
-        'torch', 'torchvision', 'pytorch-ignite',
-
-        # TODO(ohta):
-        # Remove this version constraint once
-        # https://github.com/williamFalcon/pytorch-lightning/issues/469 is resolved.
-        'pytorch_lightning<0.5.3',
+        'torch', 'torchvision', 'pytorch-ignite', 'pytorch_lightning',
     ]
 
     example_requirements = [
         'chainer', 'keras', 'catboost', 'lightgbm', 'scikit-learn',
         'mxnet', 'xgboost', 'torch', 'torchvision', 'pytorch-ignite',
-        'dask-ml', 'dask[dataframe]',
-
-        # TODO(ohta):
-        # Remove this version constraint once
-        # https://github.com/williamFalcon/pytorch-lightning/issues/469 is resolved.
-        'pytorch-lightning<0.5.3',
+        'dask-ml', 'dask[dataframe]', 'pytorch-lightning',
 
         # TODO(Yanase): Update examples to support TensorFlow 2.0.
         # See https://github.com/pfnet/optuna/issues/565 for further details.

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ def get_extras_require():
         'bokeh', 'chainer>=5.0.0', 'cma', 'keras', 'lightgbm', 'mock',
         'mpi4py', 'mxnet', 'pandas', 'plotly>=4.0.0', 'pytest', 'scikit-optimize',
         'tensorflow', 'tensorflow-datasets', 'xgboost', 'scikit-learn>=0.19.0',
-        'torch', 'torchvision', 'pytorch-ignite', 'pytorch_lightning',
+        'torch', 'torchvision', 'pytorch-ignite', 'pytorch-lightning',
     ]
 
     example_requirements = [


### PR DESCRIPTION
The latest pytorch_lightning ([v0.5.3.2](https://github.com/williamFalcon/pytorch-lightning/releases/tag/0.5.3.2)) has fixed [the import problem](https://github.com/williamFalcon/pytorch-lightning/issues/469), so we can remove the temporary patch introduced by #672.
