### PR TITLE
Implement version property of DictLogger.

### DIFF
--- a/examples/pytorch_lightning_simple.py
+++ b/examples/pytorch_lightning_simple.py
@@ -144,7 +144,7 @@ def objective(trial):
     # PyTorch Lightning will try to restore model parameters from previous trials if checkpoint
     # filenames match. Therefore, the filenames for each trial must be made unique.
     checkpoint_callback = pl.callbacks.ModelCheckpoint(
-        os.path.join(MODEL_DIR, 'trial_{}'.format(trial.number)))
+        os.path.join(MODEL_DIR, 'trial_{}'.format(trial.number)), save_best_only=False)
 
     # The default logger in PyTorch Lightning writes to event files to be consumed by
     # TensorBoard. We create a simple logger instead that holds the log in memory so that the

--- a/examples/pytorch_lightning_simple.py
+++ b/examples/pytorch_lightning_simple.py
@@ -47,12 +47,17 @@ MODEL_DIR = os.path.join(DIR, 'result')
 class DictLogger(pl.logging.LightningLoggerBase):
     """PyTorch Lightning `dict` logger."""
 
-    def __init__(self):
+    def __init__(self, version):
         super(DictLogger, self).__init__()
         self.metrics = []
+        self._version = version
 
     def log_metrics(self, metric, step_num=None):
         self.metrics.append(metric)
+
+    @property
+    def version(self):
+        return self._version
 
 
 class Net(nn.Module):
@@ -145,7 +150,7 @@ def objective(trial):
     # TensorBoard. We create a simple logger instead that holds the log in memory so that the
     # final accuracy can be obtained after optimization. When using the default logger, the
     # final accuracy could be stored in an attribute of the `Trainer` instead.
-    logger = DictLogger()
+    logger = DictLogger(trial.number)
 
     trainer = pl.Trainer(
         logger=logger,


### PR DESCRIPTION
This PR fixes `examples/pytorch_lightning_simple.py` for `pytorch-lightning==0.5.3.x`.
The implementation of [the logger base class](https://github.com/williamFalcon/pytorch-lightning/blob/master/pytorch_lightning/logging/base.py#L73-L76) was changed from `0.5.3`, and the loggers are required to have `version` property.

This PR adds `version` property to `DictLogger`. The version value is set to `Trial.number`, and the log messages are shown as follows:

![image](https://user-images.githubusercontent.com/3255979/68818636-f4e38a00-06c8-11ea-9e95-65533b14760d.png)

Please note that the updated example works with `pytorch==0.5.2`.